### PR TITLE
Create workflows for generating windows and linux binaries

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,45 @@
+name: Build and Release for Linux
+
+on:
+  release:
+    types: [created] # Triggers only when a release is created
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Create Executable
+        uses: Martin005/pyinstaller-action@v1.2.0
+        with:
+          python_ver: '3.10'
+          spec: 'pyinst-compile.spec'
+          requirements: 'requirements.txt'
+          upload_exe_with_name: 'arnis'
+          options: '--onefile --name arnis'
+
+      - name: Build
+        run: make build
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./dist/arnis
+          asset_name: arnis
+          asset_content_type: application/octet-stream

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,45 @@
+name: Build and Release for Windows
+
+on:
+  release:
+    types: [created] # Triggers only when a release is created
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Create Executable
+        uses: Martin005/pyinstaller-action@v1.2.0
+        with:
+          python_ver: '3.10'
+          spec: 'pyinst-compile.spec'
+          requirements: 'requirements.txt'
+          upload_exe_with_name: 'arnis.exe'
+          options: '--onefile --name arnis'
+
+      - name: Build
+        run: make build
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./dist/arnis.exe
+          asset_name: arnis.exe
+          asset_content_type: application/octet-stream

--- a/pyinst-compile.spec
+++ b/pyinst-compile.spec
@@ -1,0 +1,34 @@
+# -*- mode: python ; coding: utf-8 -*-
+import os
+import site
+
+# Locate the site-packages directory
+site_packages_path = next(p for p in site.getsitepackages() if 'site-packages' in p)
+
+# Path to the legacy_blocks.json file
+legacy_blocks_path = os.path.join(site_packages_path, 'anvil', 'legacy_blocks.json')
+
+block_cipher = None
+
+a = Analysis(['arnis.py'],
+             pathex=['.'],
+             binaries=[],
+             datas=[(legacy_blocks_path, 'anvil')],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          name='arnis',
+          debug=False,
+          strip=False,
+          upx=True,
+          runtime_tmpdir=None,
+          console=True )


### PR DESCRIPTION
Made a workflow for generating windows and linux binaries with pyinstaller. to use them simply create a release and artifacts would be automatically be added. example here https://github.com/amir16yp/arnis/releases/tag/1.0

i would say either delay merging this until @daniil2327 GUI is done, or merge it now and make a quick release of the current state of the program. your choice.

Btw i tried various ways to optimize the prorgam, but somehow, according to the benchmarks i made with the same 3 squared km, it somehow got slower, so i scrapped those additions for now. the only optimization that kind of worked was a minor one for floodfill, but i will make a separate PR for that