### PR TITLE
Allow hyphen at start of bbox argument

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 ))]
 pub struct Args {
     /// Bounding box of the area (min_lng,min_lat,max_lng,max_lat) (required)
-    #[arg(long)]
+    #[arg(long, allow_hyphen_values = true)]
     pub bbox: Option<String>,
 
     /// JSON file containing OSM data (optional)


### PR DESCRIPTION
I was running into an issue using this on my city because my min longitude started with a negative sign. There was probably a way to escape this, but I couldn't figure it out, and the fix in the code was pretty straightforward. Hopefully this helps someone else!


P.S. Happy thanksgiving from Canada :3