### PR TITLE
revert a small world change

### DIFF
--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -72,43 +72,37 @@ impl SectionToModify {
         palette.sort();
         palette.dedup();
 
-        let data = if palette.len() == 1 {
-            vec![]
-        } else {
-            let palette_lookup: FnvHashMap<_, _> = palette
-                .iter()
-                .enumerate()
-                .map(|(k, v)| (v, i64::try_from(k).unwrap()))
-                .collect();
+        let palette_lookup: FnvHashMap<_, _> = palette
+            .iter()
+            .enumerate()
+            .map(|(k, v)| (v, i64::try_from(k).unwrap()))
+            .collect();
 
-            let mut bits_per_block = 4; // minimum allowed
-            while (1 << bits_per_block) < palette.len() {
-                bits_per_block += 1;
-            }
+        let mut bits_per_block = 4; // minimum allowed
+        while (1 << bits_per_block) < palette.len() {
+            bits_per_block += 1;
+        }
 
-            let mut data = vec![];
+        let mut data = vec![];
 
-            let mut cur = 0;
-            let mut cur_idx = 0;
-            for block in &self.blocks {
-                let p = palette_lookup[block];
+        let mut cur = 0;
+        let mut cur_idx = 0;
+        for block in &self.blocks {
+            let p = palette_lookup[block];
 
-                if cur_idx + bits_per_block > 64 {
-                    data.push(cur);
-                    cur = 0;
-                    cur_idx = 0;
-                }
-
-                cur |= p << cur_idx;
-                cur_idx += bits_per_block;
-            }
-
-            if cur_idx > 0 {
+            if cur_idx + bits_per_block > 64 {
                 data.push(cur);
+                cur = 0;
+                cur_idx = 0;
             }
 
-            data
-        };
+            cur |= p << cur_idx;
+            cur_idx += bits_per_block;
+        }
+
+        if cur_idx > 0 {
+            data.push(cur);
+        }
 
         let palette = palette
             .iter()


### PR DESCRIPTION
Made a small world change that the MC wiki said was okay (if a section only contains one block we don't need to save `data`). Although MC can handle this fine, it seems that some plugins and utilities can't handle it. Ironically, fastanvil itself can't handle it!

It technically makes worlds a bit smaller but it doesn't seem like a big enough benefit to lose compatibility.