### PR TITLE
Change rfd features to enable manual builds on Linux.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ nalgebra = "0.33.0"
 once_cell = "1.19.0"
 rand = "0.8.5"
 reqwest = { version = "0.12.7", features = ["blocking", "json"] }
-rfd = "0.15.0"
+rfd = { version = "0.15.1", default-features = false, features = ["tokio"] }
 semver = "1.0.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
rfd wasn't building on Linux, since its default features appear to be for Windows. This commit changes them to work on Linux. 

- [ ] TODO test on Windows to make sure it doesn't break that build (CI should tell us).