### PR TITLE
Fix: Generate multipolygon buildings from OSM relations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ version = "2.1.1"
 dependencies = [
  "clap",
  "colored",
- "dirs 4.0.0",
+ "dirs",
  "fastanvil",
  "fastnbt",
  "flate2",
@@ -152,7 +152,7 @@ dependencies = [
  "fs2",
  "geo",
  "indicatif",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "nalgebra",
  "once_cell",
  "rand 0.8.5",
@@ -724,6 +724,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,31 +865,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1455,14 +1454,15 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.28.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
+checksum = "34f0e6e028c581e82e6822a68869514e94c25e7f8ea669a2d8595bdf7461ccc5"
 dependencies = [
  "earcutr",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
+ "i_overlay",
  "log",
  "num-traits",
  "robust",
@@ -1478,6 +1478,7 @@ checksum = "b6f47c611187777bbca61ea7aba780213f5f3441fd36294ab333e96cfa791b65"
 dependencies = [
  "approx",
  "num-traits",
+ "rayon",
  "rstar",
  "serde",
 ]
@@ -1872,6 +1873,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "i_float"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775f9961a8d2f879725da8aff789bb20a3ddf297473e0c90af75e69313919490"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "347c253b4748a1a28baf94c9ce133b6b166f08573157e05afe718812bc599fcd"
+
+[[package]]
+name = "i_overlay"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06740cd31c1f963823e007d8e6edcd2db634b2856f4f613e3df01737fd852482"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27dbe9e5238d6b9c694c08415bf00fb370b089949bd818ab01f41f8927b8774c"
+dependencies = [
+ "i_float",
+ "serde",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155181bc97d770181cf9477da51218a19ee92a8e5be642e796661aee2b601139"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -3490,6 +3535,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4352,7 +4417,7 @@ checksum = "2e2e3349fbb2be7af9fad1b43d61ac83ba55ab48d47fbe1b2732f0c8211610a9"
 dependencies = [
  "anyhow",
  "bytes",
- "dirs 5.0.1",
+ "dirs",
  "dunce",
  "embed_plist",
  "futures-util",
@@ -4402,7 +4467,7 @@ checksum = "b274ec7239ada504deb615f1c8abd7ba99631e879709e6f10e5d17217058d976"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs 5.0.1",
+ "dirs",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4939,7 +5004,7 @@ checksum = "d48a05076dd272615d03033bf04f480199f7d1b66a8ac64d75c625fc4a70c06b"
 dependencies = [
  "core-graphics",
  "crossbeam-channel",
- "dirs 5.0.1",
+ "dirs",
  "libappindicator",
  "muda",
  "objc2",

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -105,7 +105,14 @@ pub fn generate_world(
                 }
             }
             ProcessedElement::Relation(rel) => {
-                if rel.tags.contains_key("water") {
+                if rel.tags.contains_key("building") || rel.tags.contains_key("building:part") {
+                    buildings::generate_building_from_relation(
+                        &mut editor,
+                        rel,
+                        ground_level,
+                        args,
+                    );
+                } else if rel.tags.contains_key("water") {
                     water_areas::generate_water_areas(&mut editor, rel, ground_level);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,22 +161,8 @@ fn gui_select_world(generate_new: bool) -> Result<String, String> {
         // Handle new world generation
         if let Some(default_path) = &default_dir {
             if default_path.exists() {
-                // Generate a unique world name
-                let mut counter: i32 = 1;
-                let unique_name: String = loop {
-                    let candidate_name: String = format!("Arnis World {}", counter);
-                    let candidate_path: PathBuf = default_path.join(&candidate_name);
-                    if !candidate_path.exists() {
-                        break candidate_name;
-                    }
-                    counter += 1;
-                };
-
-                let new_world_path: PathBuf = default_path.join(&unique_name);
-
-                // Create the new world structure
-                create_new_world(&new_world_path, &unique_name)?;
-                Ok(new_world_path.display().to_string())
+                // Call create_new_world and return the result
+                create_new_world(default_path)
             } else {
                 Err("Minecraft directory not found.".to_string())
             }
@@ -212,24 +198,8 @@ fn gui_select_world(generate_new: bool) -> Result<String, String> {
 
                 return Ok(path.display().to_string());
             } else {
-                // No Minecraft directory found, generating world in custom user selected directory
-
-                // Generate a unique world name
-                let mut counter: i32 = 1;
-                let unique_name: String = loop {
-                    let candidate_name: String = format!("Arnis World {}", counter);
-                    let candidate_path: PathBuf = path.join(&candidate_name);
-                    if !candidate_path.exists() {
-                        break candidate_name;
-                    }
-                    counter += 1;
-                };
-
-                let new_world_path: PathBuf = path.join(&unique_name);
-
-                // Create the new world structure
-                create_new_world(&new_world_path, &unique_name)?;
-                return Ok(new_world_path.display().to_string());
+                // No Minecraft directory found, generating new world in custom user selected directory
+                return create_new_world(&path);
             }
         }
 
@@ -238,76 +208,82 @@ fn gui_select_world(generate_new: bool) -> Result<String, String> {
     }
 }
 
-fn create_new_world(world_path: &Path, world_name: &str) -> Result<(), String> {
+fn create_new_world(base_path: &Path) -> Result<String, String> {
+    // Generate a unique world name
+    let mut counter: i32 = 1;
+    let unique_name: String = loop {
+        let candidate_name: String = format!("Arnis World {}", counter);
+        let candidate_path: PathBuf = base_path.join(&candidate_name);
+        if !candidate_path.exists() {
+            break candidate_name;
+        }
+        counter += 1;
+    };
+
+    let new_world_path: PathBuf = base_path.join(&unique_name);
+
     // Create the new world directory structure
-    fs::create_dir_all(world_path.join("region"))
-        .map_err(|e: std::io::Error| format!("Failed to create world directory: {}", e))?;
+    fs::create_dir_all(new_world_path.join("region"))
+        .map_err(|e| format!("Failed to create world directory: {}", e))?;
 
     // Copy the region template file
     const REGION_TEMPLATE: &[u8] = include_bytes!("../mcassets/region.template");
-    let region_path = world_path.join("region").join("r.0.0.mca");
+    let region_path = new_world_path.join("region").join("r.0.0.mca");
     fs::write(&region_path, REGION_TEMPLATE)
-        .map_err(|e: std::io::Error| format!("Failed to create region file: {}", e))?;
+        .map_err(|e| format!("Failed to create region file: {}", e))?;
 
     // Add the level.dat file
     const LEVEL_TEMPLATE: &[u8] = include_bytes!("../mcassets/level.dat");
 
     // Decompress the gzipped level.template
-    let mut decoder: GzDecoder<&[u8]> = GzDecoder::new(LEVEL_TEMPLATE);
-    let mut decompressed_data: Vec<u8> = Vec::new();
+    let mut decoder = GzDecoder::new(LEVEL_TEMPLATE);
+    let mut decompressed_data = Vec::new();
     decoder
         .read_to_end(&mut decompressed_data)
-        .map_err(|e: std::io::Error| format!("Failed to decompress level.template: {}", e))?;
+        .map_err(|e| format!("Failed to decompress level.template: {}", e))?;
 
     // Parse the decompressed NBT data
     let mut level_data: Value = fastnbt::from_bytes(&decompressed_data)
-        .map_err(|e: fastnbt::error::Error| format!("Failed to parse level.dat template: {}", e))?;
+        .map_err(|e| format!("Failed to parse level.dat template: {}", e))?;
 
     // Modify the LevelName and LastPlayed fields
     if let Value::Compound(ref mut root) = level_data {
         if let Some(Value::Compound(ref mut data)) = root.get_mut("Data") {
             // Update LevelName
-            data.insert(
-                "LevelName".to_string(),
-                Value::String(world_name.to_string()),
-            );
+            data.insert("LevelName".to_string(), Value::String(unique_name.clone()));
 
             // Update LastPlayed to the current Unix time in milliseconds
-            let current_time: std::time::Duration = std::time::SystemTime::now()
+            let current_time = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map_err(|e: std::time::SystemTimeError| {
-                    format!("Failed to get current time: {}", e)
-                })?;
-            let current_time_millis: i64 = current_time.as_millis() as i64;
+                .map_err(|e| format!("Failed to get current time: {}", e))?;
+            let current_time_millis = current_time.as_millis() as i64;
             data.insert("LastPlayed".to_string(), Value::Long(current_time_millis));
         }
     }
 
     // Serialize the updated NBT data back to bytes
-    let serialized_level_data: Vec<u8> =
-        fastnbt::to_bytes(&level_data).map_err(|e: fastnbt::error::Error| {
-            format!("Failed to serialize updated level.dat: {}", e)
-        })?;
+    let serialized_level_data: Vec<u8> = fastnbt::to_bytes(&level_data)
+        .map_err(|e| format!("Failed to serialize updated level.dat: {}", e))?;
 
     // Compress the serialized data back to gzip
-    let mut encoder: flate2::write::GzEncoder<Vec<u8>> =
-        flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
     encoder
         .write_all(&serialized_level_data)
-        .map_err(|e: std::io::Error| format!("Failed to compress updated level.dat: {}", e))?;
-    let compressed_level_data: Vec<u8> = encoder.finish().map_err(|e: std::io::Error| {
-        format!("Failed to finalize compression for level.dat: {}", e)
-    })?;
+        .map_err(|e| format!("Failed to compress updated level.dat: {}", e))?;
+    let compressed_level_data = encoder
+        .finish()
+        .map_err(|e| format!("Failed to finalize compression for level.dat: {}", e))?;
 
-    fs::write(world_path.join("level.dat"), compressed_level_data)
-        .map_err(|e: std::io::Error| format!("Failed to create level.dat file: {}", e))?;
+    // Write the level.dat file
+    fs::write(new_world_path.join("level.dat"), compressed_level_data)
+        .map_err(|e| format!("Failed to create level.dat file: {}", e))?;
 
     // Add the icon.png file
     const ICON_TEMPLATE: &[u8] = include_bytes!("../mcassets/icon.png");
-    fs::write(world_path.join("icon.png"), ICON_TEMPLATE)
-        .map_err(|e: std::io::Error| format!("Failed to create icon.png file: {}", e))?;
+    fs::write(new_world_path.join("icon.png"), ICON_TEMPLATE)
+        .map_err(|e| format!("Failed to create icon.png file: {}", e))?;
 
-    Ok(())
+    Ok(new_world_path.display().to_string())
 }
 
 #[tauri::command]

--- a/src/osm_parser.rs
+++ b/src/osm_parser.rs
@@ -51,7 +51,7 @@ pub struct ProcessedWay {
     pub tags: HashMap<String, String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ProcessedMemberRole {
     Outer,
     Inner,


### PR DESCRIPTION
Added support for processing multipolygon relations as buildings. Updated generate_world to handle ProcessedRelation elements and added generate_building_from_relation function to handle outer ways. Inner ways are not taken into account yet, could be added in the future if needed. Fixes missing buildings in Minecraft generation.

Fixes https://github.com/louis-e/arnis/issues/112