### PR TITLE
Initialize the Tauri shell plugin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,7 @@ fn main() {
                     ])
                     .build(),
             )
+            .plugin(tauri_plugin_shell::init())
             .invoke_handler(tauri::generate_handler![
                 gui_select_world,
                 gui_start_generation,


### PR DESCRIPTION
This fixes the GitHub link in the main window