### PR TITLE
Add generic linux binary to releases workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Release Rust Project
+name: Build and Release Arnis
 
 on:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Release Rust Project
+name: Build and Release Arnis
 
 on:
   release:
@@ -13,11 +13,11 @@ jobs:
             target: x86_64-pc-windows-msvc
             binary_name: arnis.exe
             artifact_name: arnis-windows-x86_64.exe
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             binary_name: arnis
             artifact_name: arnis-linux-x86_64
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             target: aarch64-unknown-linux-gnu
             binary_name: arnis
             artifact_name: arnis-linux-aarch64
@@ -43,18 +43,17 @@ jobs:
         targets: ${{ matrix.target }}
 
     - name: Install Linux x86_64 dependencies
-      if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
+      if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
       run: |
         sudo apt update
         sudo apt install -y software-properties-common
         sudo add-apt-repository universe
-        echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
         sudo apt update
         sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
         echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
 
     - name: Install Linux ARM64 dependencies and setup cross-compilation
-      if: matrix.os == 'ubuntu-latest' && matrix.target == 'aarch64-unknown-linux-gnu'
+      if: matrix.os == 'ubuntu-24.04' && matrix.target == 'aarch64-unknown-linux-gnu'
       run: |
         sudo apt update
         sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
@@ -68,7 +67,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         brew install gtk+3
-        brew install webkit2gtk-4.1
+        brew install webkitgtk
         brew install pkg-config
 
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,17 +6,40 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary_name: arnis.exe
+            asset_name: arnis-windows-x64.exe
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary_name: arnis
+            asset_name: arnis-linux-x64
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up Rust for Windows
+    - name: Set up Rust
       uses: dtolnay/rust-toolchain@v1
       with:
         toolchain: stable
-        targets: x86_64-pc-windows-msvc
+        targets: ${{ matrix.target }}
+
+    - name: Install Linux dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt update
+        sudo apt install -y software-properties-common
+        sudo add-apt-repository universe
+        echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+        sudo apt update
+        sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
+        echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: cargo fetch --locked
@@ -24,15 +47,15 @@ jobs:
     - name: Build
       run: cargo build --frozen --release
 
-    - name: Upload artifact (Windows)
+    - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
-        name: windows-latest-build
-        path: target/release/arnis.exe
+        name: ${{ matrix.os }}-build
+        path: target/release/${{ matrix.binary_name }}
 
   release:
-    runs-on: windows-latest
     needs: build
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -43,10 +66,20 @@ jobs:
         name: windows-latest-build
         path: ./builds/windows
 
+    - name: Download Linux build artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ubuntu-latest-build
+        path: ./builds/linux
+
+    - name: Make Linux binary executable
+      run: chmod +x ./builds/linux/arnis
+
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
       with:
         files: |
           builds/windows/arnis.exe
+          builds/linux/arnis
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Release Arnis
+name: Build and Release Rust Project
 
 on:
   release:
@@ -12,19 +12,19 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary_name: arnis.exe
-            artifact_name: arnis-windows-x86_64.exe
+            artifact_name: arnis-windows-x64.exe
+          - os: windows-latest
+            target: i686-pc-windows-msvc
+            binary_name: arnis.exe
+            artifact_name: arnis-windows-x86.exe
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             binary_name: arnis
-            artifact_name: arnis-linux-x86_64
-          - os: macos-latest
-            target: x86_64-apple-darwin
+            artifact_name: arnis-linux-x64
+          - os: ubuntu-24.04
+            target: i686-unknown-linux-gnu
             binary_name: arnis
-            artifact_name: arnis-macos-x86_64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            binary_name: arnis
-            artifact_name: arnis-macos-aarch64
+            artifact_name: arnis-linux-x86
 
     runs-on: ${{ matrix.os }}
 
@@ -38,8 +38,8 @@ jobs:
         toolchain: stable
         targets: ${{ matrix.target }}
 
-    - name: Install Linux dependencies
-      if: matrix.os == 'ubuntu-24.04'
+    - name: Install Linux x64 dependencies
+      if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
       run: |
         sudo apt update
         sudo apt install -y software-properties-common
@@ -48,12 +48,15 @@ jobs:
         sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
         echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
 
-    - name: Install macOS dependencies
-      if: matrix.os == 'macos-latest'
+    - name: Install Linux x86 dependencies
+      if: matrix.os == 'ubuntu-24.04' && matrix.target == 'i686-unknown-linux-gnu'
       run: |
-        brew install gtk+3
-        brew install webkitgtk
-        brew install pkg-config
+        sudo dpkg --add-architecture i386
+        sudo apt update
+        sudo apt install -y gcc-multilib g++-multilib
+        sudo apt install -y libgtk-3-dev:i386 libglib2.0-dev:i386 libsoup-3.0-dev:i386 libwebkit2gtk-4.1-dev:i386
+        echo "PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig" >> $GITHUB_ENV
+        echo "CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=gcc" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: cargo fetch --locked
@@ -99,9 +102,9 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          artifacts/arnis-windows-x86_64.exe
-          artifacts/arnis-linux-x86_64
-          artifacts/arnis-macos-x86_64
-          artifacts/arnis-macos-aarch64
+          artifacts/arnis-windows-x64.exe
+          artifacts/arnis-windows-x86.exe
+          artifacts/arnis-linux-x64
+          artifacts/arnis-linux-x86
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
             binary_name: arnis
             artifact_name: arnis-linux-x86_64
-          - os: ubuntu-24.04
-            target: aarch64-unknown-linux-gnu
-            binary_name: arnis
-            artifact_name: arnis-linux-aarch64
           - os: macos-latest
             target: x86_64-apple-darwin
             binary_name: arnis
@@ -42,8 +38,8 @@ jobs:
         toolchain: stable
         targets: ${{ matrix.target }}
 
-    - name: Install Linux x86_64 dependencies
-      if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
+    - name: Install Linux dependencies
+      if: matrix.os == 'ubuntu-24.04'
       run: |
         sudo apt update
         sudo apt install -y software-properties-common
@@ -51,17 +47,6 @@ jobs:
         sudo apt update
         sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
         echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
-
-    - name: Install Linux ARM64 dependencies and setup cross-compilation
-      if: matrix.os == 'ubuntu-24.04' && matrix.target == 'aarch64-unknown-linux-gnu'
-      run: |
-        sudo apt update
-        sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-        echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
-        # Install ARM64 versions of required libraries
-        sudo dpkg --add-architecture arm64
-        sudo apt update
-        sudo apt install -y libgtk-3-dev:arm64 libglib2.0-dev:arm64 libsoup-3.0-dev:arm64 libwebkit2gtk-4.1-dev:arm64
 
     - name: Install macOS dependencies
       if: matrix.os == 'macos-latest'
@@ -116,7 +101,6 @@ jobs:
         files: |
           artifacts/arnis-windows-x86_64.exe
           artifacts/arnis-linux-x86_64
-          artifacts/arnis-linux-aarch64
           artifacts/arnis-macos-x86_64
           artifacts/arnis-macos-aarch64
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary_name: arnis.exe
-            artifact_name: arnis-windows-x64.exe
-          - os: ubuntu-24.04
+            asset_name: arnis-windows-x64.exe
+          - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary_name: arnis
-            artifact_name: arnis-linux-x64
+            asset_name: arnis-linux-x64
 
     runs-on: ${{ matrix.os }}
 
@@ -31,11 +31,12 @@ jobs:
         targets: ${{ matrix.target }}
 
     - name: Install Linux dependencies
-      if: matrix.os == 'ubuntu-24.04'
+      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt update
         sudo apt install -y software-properties-common
         sudo add-apt-repository universe
+        echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
         sudo apt update
         sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
         echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
@@ -44,47 +45,41 @@ jobs:
       run: cargo fetch --locked
 
     - name: Build
-      run: cargo build --frozen --release --target ${{ matrix.target }}
-
-    - name: Prepare binary
-      run: |
-        mkdir -p artifacts
-        if [ "${{ matrix.os }}" = "windows-latest" ]; then
-          cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} artifacts/${{ matrix.artifact_name }}
-        else
-          cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} artifacts/${{ matrix.artifact_name }}
-        fi
+      run: cargo build --frozen --release
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ matrix.artifact_name }}
-        path: artifacts/${{ matrix.artifact_name }}
+        name: ${{ matrix.os }}-build
+        path: target/release/${{ matrix.binary_name }}
 
   release:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - name: Create artifact directory
-      run: mkdir -p artifacts
+    - name: Checkout code
+      uses: actions/checkout@v3
 
-    - name: Download all artifacts
+    - name: Download Windows build artifact
       uses: actions/download-artifact@v3
       with:
-        path: artifacts
+        name: windows-latest-build
+        path: ./builds/windows
 
-    - name: Prepare artifacts for release
-      run: |
-        cd artifacts
-        find . -type f -not -name "*.exe" -exec chmod +x {} \;
-        # Move all files to current directory
-        find . -mindepth 2 -type f -exec mv {} . \;
+    - name: Download Linux build artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ubuntu-latest-build
+        path: ./builds/linux
+
+    - name: Make Linux binary executable
+      run: chmod +x ./builds/linux/arnis
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          artifacts/arnis-windows-x64.exe
-          artifacts/arnis-linux-x64
+          builds/windows/arnis.exe
+          builds/linux/arnis
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,18 +13,10 @@ jobs:
             target: x86_64-pc-windows-msvc
             binary_name: arnis.exe
             artifact_name: arnis-windows-x64.exe
-          - os: windows-latest
-            target: i686-pc-windows-msvc
-            binary_name: arnis.exe
-            artifact_name: arnis-windows-x86.exe
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             binary_name: arnis
             artifact_name: arnis-linux-x64
-          - os: ubuntu-24.04
-            target: i686-unknown-linux-gnu
-            binary_name: arnis
-            artifact_name: arnis-linux-x86
 
     runs-on: ${{ matrix.os }}
 
@@ -38,8 +30,8 @@ jobs:
         toolchain: stable
         targets: ${{ matrix.target }}
 
-    - name: Install Linux x64 dependencies
-      if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
+    - name: Install Linux dependencies
+      if: matrix.os == 'ubuntu-24.04'
       run: |
         sudo apt update
         sudo apt install -y software-properties-common
@@ -47,16 +39,6 @@ jobs:
         sudo apt update
         sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
         echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
-
-    - name: Install Linux x86 dependencies
-      if: matrix.os == 'ubuntu-24.04' && matrix.target == 'i686-unknown-linux-gnu'
-      run: |
-        sudo dpkg --add-architecture i386
-        sudo apt update
-        sudo apt install -y gcc-multilib g++-multilib
-        sudo apt install -y libgtk-3-dev:i386 libglib2.0-dev:i386 libsoup-3.0-dev:i386 libwebkit2gtk-4.1-dev:i386
-        echo "PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig" >> $GITHUB_ENV
-        echo "CARGO_TARGET_I686_UNKNOWN_LINUX_GNU_LINKER=gcc" >> $GITHUB_ENV
 
     - name: Install dependencies
       run: cargo fetch --locked
@@ -103,8 +85,6 @@ jobs:
       with:
         files: |
           artifacts/arnis-windows-x64.exe
-          artifacts/arnis-windows-x86.exe
           artifacts/arnis-linux-x64
-          artifacts/arnis-linux-x86
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,23 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             binary_name: arnis.exe
-            asset_name: arnis-windows-x64.exe
+            artifact_name: arnis-windows-x86_64.exe
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             binary_name: arnis
-            asset_name: arnis-linux-x64
+            artifact_name: arnis-linux-x86_64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            binary_name: arnis
+            artifact_name: arnis-linux-aarch64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary_name: arnis
+            artifact_name: arnis-macos-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            binary_name: arnis
+            artifact_name: arnis-macos-aarch64
 
     runs-on: ${{ matrix.os }}
 
@@ -30,8 +42,8 @@ jobs:
         toolchain: stable
         targets: ${{ matrix.target }}
 
-    - name: Install Linux dependencies
-      if: matrix.os == 'ubuntu-latest'
+    - name: Install Linux x86_64 dependencies
+      if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
       run: |
         sudo apt update
         sudo apt install -y software-properties-common
@@ -41,45 +53,72 @@ jobs:
         sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
         echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
 
+    - name: Install Linux ARM64 dependencies and setup cross-compilation
+      if: matrix.os == 'ubuntu-latest' && matrix.target == 'aarch64-unknown-linux-gnu'
+      run: |
+        sudo apt update
+        sudo apt install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+        # Install ARM64 versions of required libraries
+        sudo dpkg --add-architecture arm64
+        sudo apt update
+        sudo apt install -y libgtk-3-dev:arm64 libglib2.0-dev:arm64 libsoup-3.0-dev:arm64 libwebkit2gtk-4.1-dev:arm64
+
+    - name: Install macOS dependencies
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install gtk+3
+        brew install webkit2gtk-4.1
+        brew install pkg-config
+
     - name: Install dependencies
       run: cargo fetch --locked
 
     - name: Build
-      run: cargo build --frozen --release
+      run: cargo build --frozen --release --target ${{ matrix.target }}
+
+    - name: Prepare binary
+      run: |
+        mkdir -p artifacts
+        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} artifacts/${{ matrix.artifact_name }}
+        else
+          cp target/${{ matrix.target }}/release/${{ matrix.binary_name }} artifacts/${{ matrix.artifact_name }}
+        fi
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ matrix.os }}-build
-        path: target/release/${{ matrix.binary_name }}
+        name: ${{ matrix.artifact_name }}
+        path: artifacts/${{ matrix.artifact_name }}
 
   release:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+    - name: Create artifact directory
+      run: mkdir -p artifacts
 
-    - name: Download Windows build artifact
+    - name: Download all artifacts
       uses: actions/download-artifact@v3
       with:
-        name: windows-latest-build
-        path: ./builds/windows
+        path: artifacts
 
-    - name: Download Linux build artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: ubuntu-latest-build
-        path: ./builds/linux
-
-    - name: Make Linux binary executable
-      run: chmod +x ./builds/linux/arnis
+    - name: Prepare artifacts for release
+      run: |
+        cd artifacts
+        find . -type f -not -name "*.exe" -exec chmod +x {} \;
+        # Move all files to current directory
+        find . -mindepth 2 -type f -exec mv {} . \;
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          builds/windows/arnis.exe
-          builds/linux/arnis
+          artifacts/arnis-windows-x86_64.exe
+          artifacts/arnis-linux-x86_64
+          artifacts/arnis-linux-aarch64
+          artifacts/arnis-macos-x86_64
+          artifacts/arnis-macos-aarch64
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will allow easier packaging in of the binary version in various linux distros (it compiles it using an ubuntu runner, but i have found that the binary works on arch and probably any glibc distro with xorg)