### PR TITLE
Add fallback api urls specifically for Russia

### DIFF
--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -95,9 +95,10 @@ pub fn fetch_data(
         "https://z.overpass-api.de/api/interpreter",
         //"https://overpass.kumi.systems/api/interpreter", // This server is not reliable anymore
         //"https://overpass.private.coffee/api/interpreter", // This server is not reliable anymore
-        "https://overpass.osm.ch/api/interpreter",
     ];
-    let url: &&str = api_servers.choose(&mut rand::thread_rng()).unwrap();
+    let fallback_api_servers: Vec<&str> =
+        vec!["https://maps.mail.ru/osm/tools/overpass/api/interpreter"];
+    let mut url: &&str = api_servers.choose(&mut rand::thread_rng()).unwrap();
 
     // Generate Overpass API query for bounding box
     let query: String = format!(
@@ -140,11 +141,30 @@ pub fn fetch_data(
         Ok(data)
     } else {
         // Fetch data from Overpass API
-        let response: String = match download_method {
-            "requests" => download_with_reqwest(url, &query)?,
-            "curl" => download_with_curl(url, &query)?,
-            "wget" => download_with_wget(url, &query)?,
-            _ => download_with_reqwest(url, &query)?, // Default to requests
+        let mut attempt = 0;
+        let max_attempts = 1;
+        let response: String = loop {
+            let result = match download_method {
+                "requests" => download_with_reqwest(url, &query),
+                "curl" => download_with_curl(url, &query).map_err(|e| e.into()),
+                "wget" => download_with_wget(url, &query).map_err(|e| e.into()),
+                _ => download_with_reqwest(url, &query), // Default to requests
+            };
+
+            match result {
+                Ok(response) => break response,
+                Err(error) => {
+                    if attempt >= max_attempts {
+                        return Err(error);
+                    }
+
+                    println!("Request failed. Switching to fallback url...");
+                    url = fallback_api_servers
+                        .choose(&mut rand::thread_rng())
+                        .unwrap();
+                    attempt += 1;
+                }
+            }
         };
 
         let data: Value = serde_json::from_str(&response)?;


### PR DESCRIPTION
As mentioned in #246, Overpass is blocked in Russia. I've added fallback url to local Overpass instance. At the moment, only the most reliable one from Mail.ru. It's only called when the previous attempt fails.

Also removed https://overpass.osm.ch/api/interpreter as it only covers Switzerland, which sometimes resulted in 'API returned no data' error.

Not sure if this PR fixes #246. There may be some other reason, as it should eventually result in a timeout error anyway, and this issue is about infinite loading, and the author says VPN doesn't help. Maybe something preventing request even from being started in the first place.