### PR TITLE
Add CLI build test to CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -48,5 +48,8 @@ jobs:
     - name: Install Rust dependencies
       run: cargo fetch
 
-    - name: Build
+    - name: Build gui
       run: cargo build --release
+
+    - name: Build cli
+      run: cargo build --no-default-features --release


### PR DESCRIPTION
Since the gui is now an optional feature, we should also test that the CLI builds on its own.