### PR TITLE
Remove gui-only deps when building cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,15 @@ lto = "thin"
 
 [features]
 default = ["gui"]
-gui = ["dep:tauri", "dep:tauri-plugin-log", "dep:tauri-plugin-shell"]
+gui = ["tauri", "tauri-plugin-log", "tauri-plugin-shell", "tokio", "rfd", "dirs", "tauri-build"]
 
 [build-dependencies]
-tauri-build = "2"
+tauri-build = {version = "2", optional = true}
 
 [dependencies]
 clap = { version = "4.1", features = ["derive"] }
 colored = "2.1.0"
-dirs = "5.0.1"
+dirs = {version = "5.0.1", optional = true }
 fastanvil = "0.31.0"
 fastnbt = "2.5.0"
 flate2 = "1.0"
@@ -36,14 +36,14 @@ once_cell = "1.19.0"
 rand = "0.8.5"
 rayon = "1.10.0"
 reqwest = { version = "0.12.7", features = ["blocking", "json"] }
-rfd = "0.15.1"
+rfd = { version = "0.15.1", optional = true }
 semver = "1.0.23"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tauri = { version = "2", optional = true }
 tauri-plugin-log = { version = "2.2.0", optional = true }
 tauri-plugin-shell = { version = "2", optional = true }
-tokio = { version = "1.42.0", features = ["full"] }
+tokio = { version = "1.42.0", features = ["full"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.59.0", features = ["Win32_System_Console"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,17 +28,19 @@ mod world_editor;
 use args::Args;
 use clap::Parser;
 use colored::*;
+#[cfg(feature = "gui")]
 use fastnbt::Value;
+#[cfg(feature = "gui")]
 use flate2::read::GzDecoder;
+#[cfg(feature = "gui")]
 use log::{error, LevelFilter};
+#[cfg(feature = "gui")]
 use rfd::FileDialog;
-use std::{
-    env,
-    fs::{self, File},
-    io::{Read, Write},
-    panic,
-    path::{Path, PathBuf},
-};
+#[cfg(feature = "gui")]
+use std::io::Read;
+#[cfg(feature = "gui")]
+use std::path::{Path, PathBuf};
+use std::{env, fs, io::Write, panic};
 #[cfg(feature = "gui")]
 use tauri_plugin_log::{Builder as LogBuilder, Target, TargetKind};
 #[cfg(target_os = "windows")]
@@ -125,8 +127,8 @@ fn main() {
 
         // Write the parsed OSM data to a file for inspection
         if args.debug {
-            let mut output_file: File =
-                File::create("parsed_osm_data.txt").expect("Failed to create output file");
+            let mut output_file: fs::File =
+                fs::File::create("parsed_osm_data.txt").expect("Failed to create output file");
             for element in &parsed_elements {
                 writeln!(
                     output_file,
@@ -254,7 +256,7 @@ fn gui_select_world(generate_new: bool) -> Result<String, i32> {
                 let session_lock_path = path.join("session.lock");
                 if session_lock_path.exists() {
                     // Try to acquire a lock on the session.lock file
-                    if let Ok(file) = File::open(&session_lock_path) {
+                    if let Ok(file) = fs::File::open(&session_lock_path) {
                         if fs2::FileExt::try_lock_shared(&file).is_err() {
                             return Err(2); // Error code 2: The selected world is currently in use
                         } else {
@@ -276,6 +278,7 @@ fn gui_select_world(generate_new: bool) -> Result<String, i32> {
     }
 }
 
+#[cfg(feature = "gui")]
 fn create_new_world(base_path: &Path) -> Result<String, String> {
     // Generate a unique world name
     let mut counter: i32 = 1;


### PR DESCRIPTION
It looks like these are only GUI dependencies. I still need to test that it compiles, but these give unused warnings when compiling with the gui disabled.