### PR TITLE
Make leaves persistent to stop hedges from decaying

### DIFF
--- a/src/block_definitions.rs
+++ b/src/block_definitions.rs
@@ -150,6 +150,11 @@ impl Block {
 
     pub fn properties(&self) -> Option<Value> {
         match self.id {
+            49 => Some(Value::Compound({
+                let mut map: HashMap<String, Value> = HashMap::new();
+                map.insert("persistent".to_string(), Value::String("true".to_string()));
+                map
+            })),
             105 => Some(Value::Compound({
                 let mut map: HashMap<String, Value> = HashMap::new();
                 map.insert("age".to_string(), Value::String("7".to_string()));


### PR DESCRIPTION
This PR makes the "OAK_LEAVES" Block always have `persistent` set to `true`, so that they don't decay.
Fixes #329 