### PR TITLE
Change functions returning vecs to global arrays.

### DIFF
--- a/src/block_definitions.rs
+++ b/src/block_definitions.rs
@@ -427,95 +427,89 @@ pub const PACKED_ICE: Block = Block::new(134);
 pub const MUD: Block = Block::new(135);
 
 // Variations for building corners
-pub fn building_corner_variations() -> Vec<Block> {
-    vec![
-        STONE_BRICKS,
-        COBBLESTONE,
-        BRICK,
-        MOSSY_COBBLESTONE,
-        SANDSTONE,
-        RED_NETHER_BRICKS,
-        BLACKSTONE,
-        SMOOTH_QUARTZ,
-        CHISELED_STONE_BRICKS,
-        POLISHED_BASALT,
-        CUT_SANDSTONE,
-        POLISHED_BLACKSTONE_BRICKS,
-        ANDESITE,
-        GRANITE,
-        DIORITE,
-        CRACKED_STONE_BRICKS,
-        PRISMARINE,
-        BLUE_TERRACOTTA,
-        NETHER_BRICK,
-        QUARTZ_BRICKS,
-    ]
-}
+pub static BUILDING_CORNER_VARIATIONS: [Block; 20] = [
+    STONE_BRICKS,
+    COBBLESTONE,
+    BRICK,
+    MOSSY_COBBLESTONE,
+    SANDSTONE,
+    RED_NETHER_BRICKS,
+    BLACKSTONE,
+    SMOOTH_QUARTZ,
+    CHISELED_STONE_BRICKS,
+    POLISHED_BASALT,
+    CUT_SANDSTONE,
+    POLISHED_BLACKSTONE_BRICKS,
+    ANDESITE,
+    GRANITE,
+    DIORITE,
+    CRACKED_STONE_BRICKS,
+    PRISMARINE,
+    BLUE_TERRACOTTA,
+    NETHER_BRICK,
+    QUARTZ_BRICKS,
+];
 
 // Variations for building walls
 pub fn building_wall_variations() -> Vec<Block> {
-    building_wall_color_map()
+    BUILDING_WALL_COLOR_MAP
         .into_iter()
         .map(|(_, block)| block)
         .collect()
 }
 
 // https://wiki.openstreetmap.org/wiki/Key:building:colour
-pub fn building_wall_color_map() -> Vec<(RGBTuple, Block)> {
-    vec![
-        ((233, 107, 57), BRICK),
-        ((18, 12, 13), CRACKED_POLISHED_BLACKSTONE_BRICKS),
-        ((76, 127, 153), CYAN_CONCRETE),
-        ((0, 0, 0), DEEPSLATE_BRICKS),
-        ((186, 195, 142), END_STONE_BRICKS),
-        ((57, 41, 35), GRAY_TERRACOTTA),
-        ((112, 108, 138), LIGHT_BLUE_TERRACOTTA),
-        ((122, 92, 66), MUD_BRICKS),
-        ((24, 13, 14), NETHER_BRICKS),
-        ((159, 82, 36), ORANGE_TERRACOTTA),
-        ((128, 128, 128), POLISHED_ANDESITE),
-        ((174, 173, 174), POLISHED_DIORITE),
-        ((141, 101, 142), PURPUR_PILLAR),
-        ((142, 60, 46), RED_TERRACOTTA),
-        ((153, 83, 28), SMOOTH_RED_SANDSTONE),
-        ((224, 216, 175), SMOOTH_SANDSTONE),
-        ((188, 182, 179), SMOOTH_STONE),
-        ((35, 86, 85), WARPED_PLANKS),
-        ((255, 255, 255), WHITE_CONCRETE),
-        ((209, 177, 161), WHITE_TERRACOTTA),
-        ((191, 147, 42), YELLOW_TERRACOTTA),
-    ]
-}
+pub static BUILDING_WALL_COLOR_MAP: [(RGBTuple, Block); 21] = [
+    ((233, 107, 57), BRICK),
+    ((18, 12, 13), CRACKED_POLISHED_BLACKSTONE_BRICKS),
+    ((76, 127, 153), CYAN_CONCRETE),
+    ((0, 0, 0), DEEPSLATE_BRICKS),
+    ((186, 195, 142), END_STONE_BRICKS),
+    ((57, 41, 35), GRAY_TERRACOTTA),
+    ((112, 108, 138), LIGHT_BLUE_TERRACOTTA),
+    ((122, 92, 66), MUD_BRICKS),
+    ((24, 13, 14), NETHER_BRICKS),
+    ((159, 82, 36), ORANGE_TERRACOTTA),
+    ((128, 128, 128), POLISHED_ANDESITE),
+    ((174, 173, 174), POLISHED_DIORITE),
+    ((141, 101, 142), PURPUR_PILLAR),
+    ((142, 60, 46), RED_TERRACOTTA),
+    ((153, 83, 28), SMOOTH_RED_SANDSTONE),
+    ((224, 216, 175), SMOOTH_SANDSTONE),
+    ((188, 182, 179), SMOOTH_STONE),
+    ((35, 86, 85), WARPED_PLANKS),
+    ((255, 255, 255), WHITE_CONCRETE),
+    ((209, 177, 161), WHITE_TERRACOTTA),
+    ((191, 147, 42), YELLOW_TERRACOTTA),
+];
 
 // Variations for building floors
 pub fn building_floor_variations() -> Vec<Block> {
-    building_wall_color_map()
+    BUILDING_WALL_COLOR_MAP
         .into_iter()
         .map(|(_, block)| block)
         .collect()
 }
 
-pub fn building_floor_color_map() -> Vec<(RGBTuple, Block)> {
-    vec![
-        ((181, 101, 59), ACACIA_PLANKS),
-        ((22, 15, 16), BLACKSTONE),
-        ((104, 51, 74), CRIMSON_PLANKS),
-        ((82, 55, 26), DARK_OAK_PLANKS),
-        ((182, 133, 99), JUNGLE_PLANKS),
-        ((33, 128, 185), LIGHT_BLUE_CONCRETE),
-        ((78, 103, 43), MOSS_BLOCK),
-        ((171, 138, 88), OAK_PLANKS),
-        ((0, 128, 0), OXIDIZED_COPPER),
-        ((18, 12, 13), POLISHED_BLACKSTONE),
-        ((64, 64, 64), POLISHED_DEEPSLATE),
-        ((255, 255, 255), POLISHED_DIORITE),
-        ((143, 96, 79), POLISHED_GRANITE),
-        ((141, 101, 142), PURPUR_BLOCK),
-        ((128, 0, 0), RED_NETHER_BRICKS),
-        ((153, 83, 28), SMOOTH_RED_SANDSTONE),
-        ((128, 96, 57), SPRUCE_PLANKS),
-        ((128, 128, 128), STONE_BRICKS),
-        ((150, 93, 68), TERRACOTTA),
-        ((35, 86, 85), WARPED_PLANKS),
-    ]
-}
+pub static BUILDING_FLOOR_COLOR_MAP: [(RGBTuple, Block); 20] = [
+    ((181, 101, 59), ACACIA_PLANKS),
+    ((22, 15, 16), BLACKSTONE),
+    ((104, 51, 74), CRIMSON_PLANKS),
+    ((82, 55, 26), DARK_OAK_PLANKS),
+    ((182, 133, 99), JUNGLE_PLANKS),
+    ((33, 128, 185), LIGHT_BLUE_CONCRETE),
+    ((78, 103, 43), MOSS_BLOCK),
+    ((171, 138, 88), OAK_PLANKS),
+    ((0, 128, 0), OXIDIZED_COPPER),
+    ((18, 12, 13), POLISHED_BLACKSTONE),
+    ((64, 64, 64), POLISHED_DEEPSLATE),
+    ((255, 255, 255), POLISHED_DIORITE),
+    ((143, 96, 79), POLISHED_GRANITE),
+    ((141, 101, 142), PURPUR_BLOCK),
+    ((128, 0, 0), RED_NETHER_BRICKS),
+    ((153, 83, 28), SMOOTH_RED_SANDSTONE),
+    ((128, 96, 57), SPRUCE_PLANKS),
+    ((128, 128, 128), STONE_BRICKS),
+    ((150, 93, 68), TERRACOTTA),
+    ((35, 86, 85), WARPED_PLANKS),
+];

--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -38,17 +38,17 @@ pub fn generate_buildings(
 
     // Randomly select block variations for corners, walls, and floors
     let mut rng: rand::prelude::ThreadRng = rand::thread_rng();
-    let variation_index_corner: usize = rng.gen_range(0..building_corner_variations().len());
+    let variation_index_corner: usize = rng.gen_range(0..BUILDING_CORNER_VARIATIONS.len());
     let variation_index_wall: usize = rng.gen_range(0..building_wall_variations().len());
     let variation_index_floor: usize = rng.gen_range(0..building_floor_variations().len());
 
-    let corner_block: Block = building_corner_variations()[variation_index_corner];
+    let corner_block: Block = BUILDING_CORNER_VARIATIONS[variation_index_corner];
     let wall_block: Block = element
         .tags
         .get("building:colour")
         .and_then(|building_colour: &String| {
             color_text_to_rgb_tuple(building_colour).map(|rgb: (u8, u8, u8)| {
-                find_nearest_block_in_color_map(&rgb, building_wall_color_map())
+                find_nearest_block_in_color_map(&rgb, &BUILDING_WALL_COLOR_MAP)
             })
         })
         .flatten()
@@ -58,7 +58,7 @@ pub fn generate_buildings(
         .get("roof:colour")
         .and_then(|roof_colour: &String| {
             color_text_to_rgb_tuple(roof_colour).map(|rgb: (u8, u8, u8)| {
-                find_nearest_block_in_color_map(&rgb, building_floor_color_map())
+                find_nearest_block_in_color_map(&rgb, &BUILDING_FLOOR_COLOR_MAP)
             })
         })
         .flatten()
@@ -505,12 +505,13 @@ pub fn generate_building_from_relation(
 
 fn find_nearest_block_in_color_map(
     rgb: &RGBTuple,
-    color_map: Vec<(RGBTuple, Block)>,
+    color_map: &[(RGBTuple, Block)],
 ) -> Option<Block> {
     color_map
-        .into_iter()
+        .iter()
         .min_by_key(|(entry_rgb, _)| rgb_distance(entry_rgb, rgb))
         .map(|(_, block)| block)
+        .copied()
 }
 
 /// Generates a bridge structure, paying attention to the "level" tag.

--- a/src/element_processing/tree.rs
+++ b/src/element_processing/tree.rs
@@ -139,7 +139,7 @@ pub struct Tree<'a> {
 impl Tree<'_> {
     pub fn create(editor: &mut WorldEditor, (x, y, z): Coord, snow: bool) {
         let mut blacklist: Vec<Block> = Vec::new();
-        blacklist.extend(building_corner_variations());
+        blacklist.extend(BUILDING_CORNER_VARIATIONS);
         blacklist.extend(building_wall_variations());
         blacklist.extend(building_floor_variations());
         blacklist.push(WATER);


### PR DESCRIPTION
I'm not sure why these were initally functions. I think they are better off as global arrays, since the function would initialize a new vec every time its called, whereas this only initializes it once.

TODO
- [x] Test: I tested it with one small section of a city and it appears to work. I wouldn't by any means call this thoroughly-tested.