### PR TITLE
CI: Add cache action to preserve build artifacts.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -43,6 +43,17 @@ jobs:
         sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
         echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
 
+    - name: Set up cache for Cargo
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
     - name: Check formatting
       run: cargo fmt -- --check
 


### PR DESCRIPTION
Right now CI rebuilds from scratch for each step. It takes way longer than it needs to. This action supposedly will cache the build artifacts so they can be re-used each step. 

> [!NOTE]
> Github Copilot made this... so who knows if it actually works.


# To Do
- [ ] Consider running `cargo build --all-features` or something first, then run everything else afterwards? What's the most optimal way? 