### PR TITLE
Optimize ground generation + new natural elements

### DIFF
--- a/src/block_definitions.rs
+++ b/src/block_definitions.rs
@@ -56,7 +56,7 @@ impl Block {
             26 => "glowstone",
             27 => "granite",
             28 => "grass_block",
-            29 => "tall_grass",
+            29 => "short_grass",
             30 => "gravel",
             31 => "gray_concrete",
             32 => "gray_terracotta",
@@ -154,6 +154,8 @@ impl Block {
             133 => "ice",
             134 => "packed_ice",
             135 => "mud",
+            136 => "dead_bush",
+            137..=138 => "tall_grass",
             _ => panic!("Invalid id"),
         }
     }
@@ -277,6 +279,16 @@ impl Block {
             125 => Some(Value::Compound({
                 let mut map = HashMap::new();
                 map.insert("shape".to_string(), Value::String("south_west".to_string()));
+                map
+            })),
+            137 => Some(Value::Compound({
+                let mut map = HashMap::new();
+                map.insert("half".to_string(), Value::String("lower".to_string()));
+                map
+            })),
+            138 => Some(Value::Compound({
+                let mut map = HashMap::new();
+                map.insert("half".to_string(), Value::String("upper".to_string()));
                 map
             })),
             _ => None,
@@ -425,6 +437,9 @@ pub const DIRT_PATH: Block = Block::new(132);
 pub const ICE: Block = Block::new(133);
 pub const PACKED_ICE: Block = Block::new(134);
 pub const MUD: Block = Block::new(135);
+pub const DEAD_BUSH: Block = Block::new(136);
+pub const TALL_GRASS_BOTTOM: Block = Block::new(137);
+pub const TALL_GRASS_TOP: Block = Block::new(138);
 
 // Variations for building corners
 pub static BUILDING_CORNER_VARIATIONS: [Block; 20] = [

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -143,77 +143,35 @@ pub fn generate_world(
 
     let groundlayer_block = if args.winter { SNOW_BLOCK } else { GRASS_BLOCK };
 
-    // Differentiate between terrain and non-terrain generation
-    if ground.elevation_enabled {
-        // Pre-calculate ground levels for all points
-        let mut ground_levels: Vec<Vec<i32>> = Vec::with_capacity(scale_factor_x as usize + 1);
-        for x in 0..=(scale_factor_x as i32) {
-            let mut row = Vec::with_capacity(scale_factor_z as usize + 1);
-            for z in 0..=(scale_factor_z as i32) {
-                row.push(ground.level(XZPoint::new(x, z)));
+    for x in 0..=(scale_factor_x as i32) {
+        for z in 0..=(scale_factor_z as i32) {
+            let ground_level = ground.level(XZPoint::new(x, z));
+            // Find the highest block in this column
+            let max_y = (MIN_Y..ground_level)
+                .find(|y: &i32| editor.block_at(x, *y, z))
+                .unwrap_or(ground_level)
+                .min(ground_level);
+            // Add default dirt and grass layer if there isn't a stone layer already
+            if !editor.check_for_block(x, max_y, z, Some(&[STONE]), None) {
+                editor.set_block(groundlayer_block, x, max_y, z, None, None);
+                editor.set_block(DIRT, x, max_y - 1, z, None, None);
+                editor.set_block(DIRT, x, max_y - 2, z, None, None);
             }
-            ground_levels.push(row);
-        }
-
-        // Process blocks in larger batches
-        for x in 0..=(scale_factor_x as i32) {
-            for z in 0..=(scale_factor_z as i32) {
-                let ground_level = ground_levels[x as usize][z as usize];
-
-                // Find the highest block in this column
-                let max_y = (MIN_Y..ground_level)
-                    .find(|y: &i32| editor.block_at(x, *y, z))
-                    .unwrap_or(ground_level)
-                    .min(ground_level);
-
-                // Add default dirt and grass layer if there isn't a stone layer already
-                if !editor.check_for_block(x, max_y, z, Some(&[STONE]), None) {
-                    editor.set_block(groundlayer_block, x, max_y, z, None, None);
-                    editor.set_block(DIRT, x, max_y - 1, z, None, None);
-                    editor.set_block(DIRT, x, max_y - 2, z, None, None);
-                }
-                // Fill underground with stone
-                if args.fillground {
-                    editor.fill_blocks(STONE, x, MIN_Y + 1, z, x, max_y - 1, z, None, None);
-                    editor.set_block(BEDROCK, x, MIN_Y, z, None, Some(&[BEDROCK]));
-                }
-
-                block_counter += 1;
-                if block_counter % batch_size == 0 {
-                    ground_pb.inc(batch_size);
-                }
-
-                gui_progress_grnd += progress_increment_grnd;
-                if (gui_progress_grnd - last_emitted_progress).abs() > 0.25 {
-                    emit_gui_progress_update(gui_progress_grnd, "");
-                    last_emitted_progress = gui_progress_grnd;
-                }
+            // Fill underground with stone
+            if args.fillground {
+                editor.fill_blocks(STONE, x, MIN_Y + 1, z, x, max_y - 1, z, None, None);
             }
-        }
+            editor.set_block(BEDROCK, x, MIN_Y, z, None, Some(&[BEDROCK]));
 
-        // Set blocks at spawn location
-        for x in 0..=20 {
-            for z in 0..=20 {
-                editor.set_block(groundlayer_block, x, -62, z, None, None);
+            block_counter += 1;
+            if block_counter % batch_size == 0 {
+                ground_pb.inc(batch_size);
             }
-        }
-    } else {
-        for x in 0..=(scale_factor_x as i32) {
-            for z in 0..=(scale_factor_z as i32) {
-                let ground_level = ground.level(XZPoint::new(x, z));
-                editor.set_block(groundlayer_block, x, ground_level, z, None, None);
-                editor.set_block(DIRT, x, ground_level - 1, z, None, None);
 
-                block_counter += 1;
-                if block_counter % batch_size == 0 {
-                    ground_pb.inc(batch_size);
-                }
-
-                gui_progress_grnd += progress_increment_grnd;
-                if (gui_progress_grnd - last_emitted_progress).abs() > 0.25 {
-                    emit_gui_progress_update(gui_progress_grnd, "");
-                    last_emitted_progress = gui_progress_grnd;
-                }
+            gui_progress_grnd += progress_increment_grnd;
+            if (gui_progress_grnd - last_emitted_progress).abs() > 0.25 {
+                emit_gui_progress_update(gui_progress_grnd, "");
+                last_emitted_progress = gui_progress_grnd;
             }
         }
     }

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -152,7 +152,7 @@ pub fn generate_world(
                 .unwrap_or(ground_level)
                 .min(ground_level);
             // Add default dirt and grass layer if there isn't a stone layer already
-            if !editor.check_for_block(x, max_y, z, Some(&[STONE]), None) {
+            if !editor.check_for_block(x, max_y, z, Some(&[STONE])) {
                 editor.set_block(groundlayer_block, x, max_y, z, None, None);
                 editor.set_block(DIRT, x, max_y - 1, z, None, None);
                 editor.set_block(DIRT, x, max_y - 2, z, None, None);

--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -302,7 +302,6 @@ pub fn generate_siding(editor: &mut WorldEditor, element: &ProcessedWay, ground:
                     bx,
                     ground_level - 1,
                     bz,
-                    None,
                     Some(&[BLACK_CONCRETE, WHITE_CONCRETE]),
                 ) {
                     editor.set_block(siding_block, bx, ground_level, bz, None, None);

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -154,7 +154,7 @@ pub fn generate_landuse(
             }
             "forest" => {
                 if !editor.check_for_block(x, ground_level, z, Some(&[WATER])) {
-                    let random_choice: i32 = rng.gen_range(0..21);
+                    let random_choice: i32 = rng.gen_range(0..30);
                     if random_choice == 20 {
                         Tree::create(editor, (x, ground_level + 1, z));
                     } else if random_choice == 2 {
@@ -165,7 +165,7 @@ pub fn generate_landuse(
                             _ => WHITE_FLOWER,
                         };
                         editor.set_block(flower_block, x, ground_level + 1, z, None, None);
-                    } else if random_choice <= 1 {
+                    } else if random_choice <= 12 {
                         editor.set_block(GRASS, x, ground_level + 1, z, None, None);
                     }
                 }

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -19,9 +19,8 @@ pub fn generate_landuse(
     let landuse_tag: &String = element.tags.get("landuse").unwrap_or(&binding);
 
     let block_type = match landuse_tag.as_str() {
-        "greenfield" | "meadow" | "grass" => GRASS_BLOCK,
+        "greenfield" | "meadow" | "grass" | "orchard" | "forest" => GRASS_BLOCK,
         "farmland" => FARMLAND,
-        "forest" => GRASS_BLOCK,
         "cemetery" => PODZOL,
         "construction" => COARSE_DIRT,
         "traffic_island" => STONE_BLOCK_SLAB,
@@ -279,6 +278,13 @@ pub fn generate_landuse(
                     } else if random_choice < 800 {
                         editor.set_block(GRASS, x, ground_level + 1, z, None, None);
                     }
+                }
+            }
+            "orchard" => {
+                println!("Generating orchard...");
+                if x % 18 == 0 && z % 10 == 0 {
+                    println!("Placing tree...");
+                    Tree::create(editor, (x, ground_level + 1, z));
                 }
             }
             "quarry" => {

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -266,7 +266,7 @@ pub fn generate_landuse(
                 }
             }
             "grass" => {
-                if rng.gen_range(1..=7) != 1
+                if rng.gen_range(1..8) != 1
                     && editor.check_for_block(x, ground_level, z, Some(&[GRASS_BLOCK]))
                 {
                     editor.set_block(GRASS, x, ground_level + 1, z, None, None);

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -23,7 +23,6 @@ pub fn generate_landuse(
         "farmland" => FARMLAND,
         "forest" => GRASS_BLOCK,
         "cemetery" => PODZOL,
-        "beach" => SAND,
         "construction" => COARSE_DIRT,
         "traffic_island" => STONE_BLOCK_SLAB,
         "residential" => {

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -75,7 +75,7 @@ pub fn generate_landuse(
                     let random_choice: i32 = rng.gen_range(0..100);
                     if random_choice < 15 {
                         // Place graves
-                        if editor.check_for_block(x, ground_level, z, Some(&[PODZOL]), None) {
+                        if editor.check_for_block(x, ground_level, z, Some(&[PODZOL])) {
                             if rng.gen_bool(0.5) {
                                 editor.set_block(
                                     COBBLESTONE,
@@ -145,7 +145,7 @@ pub fn generate_landuse(
                             }
                         }
                     } else if random_choice < 30 {
-                        if editor.check_for_block(x, ground_level, z, Some(&[PODZOL]), None) {
+                        if editor.check_for_block(x, ground_level, z, Some(&[PODZOL])) {
                             editor.set_block(RED_FLOWER, x, ground_level + 1, z, None, None);
                         }
                     } else if random_choice < 33 {
@@ -154,7 +154,7 @@ pub fn generate_landuse(
                 }
             }
             "forest" => {
-                if !editor.check_for_block(x, ground_level, z, None, Some(&[WATER])) {
+                if !editor.check_for_block(x, ground_level, z, Some(&[WATER])) {
                     let random_choice: i32 = rng.gen_range(0..21);
                     if random_choice == 20 {
                         Tree::create(editor, (x, ground_level + 1, z));
@@ -173,7 +173,7 @@ pub fn generate_landuse(
             }
             "farmland" => {
                 // Check if the current block is not water or another undesired block
-                if !editor.check_for_block(x, ground_level, z, None, Some(&[WATER, ICE])) {
+                if !editor.check_for_block(x, ground_level, z, Some(&[WATER])) {
                     if x % 9 == 0 && z % 9 == 0 {
                         // Place water in dot pattern
                         editor.set_block(WATER, x, ground_level, z, Some(&[FARMLAND]), None);
@@ -200,7 +200,7 @@ pub fn generate_landuse(
                         }
                     } else {
                         // Set crops only if the block below is farmland
-                        if editor.check_for_block(x, ground_level, z, Some(&[FARMLAND]), None) {
+                        if editor.check_for_block(x, ground_level, z, Some(&[FARMLAND])) {
                             let crop_choice = [WHEAT, CARROTS, POTATOES][rng.gen_range(0..3)];
                             editor.set_block(crop_choice, x, ground_level + 1, z, None, None);
                         }
@@ -267,13 +267,13 @@ pub fn generate_landuse(
             }
             "grass" => {
                 if rng.gen_range(1..=7) != 1
-                    && editor.check_for_block(x, ground_level, z, Some(&[GRASS_BLOCK]), None)
+                    && editor.check_for_block(x, ground_level, z, Some(&[GRASS_BLOCK]))
                 {
                     editor.set_block(GRASS, x, ground_level + 1, z, None, None);
                 }
             }
             "meadow" => {
-                if editor.check_for_block(x, ground_level, z, Some(&[GRASS_BLOCK]), None) {
+                if editor.check_for_block(x, ground_level, z, Some(&[GRASS_BLOCK])) {
                     let random_choice: i32 = rng.gen_range(0..1001);
                     if random_choice < 5 {
                         Tree::create(editor, (x, ground_level + 1, z));

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -122,7 +122,7 @@ pub fn generate_leisure(
                     let random_choice: i32 = rng.gen_range(0..5000);
 
                     match random_choice {
-                        0..=10 => {
+                        0..10 => {
                             // Swing set
                             for y in 1..=4 {
                                 editor.set_block(OAK_FENCE, x - 1, ground_level + y, z, None, None);
@@ -131,7 +131,7 @@ pub fn generate_leisure(
                             editor.set_block(OAK_FENCE, x, ground_level + 4, z, None, None);
                             editor.set_block(STONE_BLOCK_SLAB, x, ground_level + 2, z, None, None);
                         }
-                        11..=20 => {
+                        10..20 => {
                             // Slide
                             editor.set_block(OAK_SLAB, x, ground_level + 1, z, None, None);
                             editor.set_block(OAK_SLAB, x + 1, ground_level + 2, z, None, None);
@@ -143,7 +143,7 @@ pub fn generate_leisure(
                             editor.set_block(LADDER, x + 2, ground_level + 2, z - 1, None, None);
                             editor.set_block(LADDER, x + 2, ground_level + 1, z - 1, None, None);
                         }
-                        21..=30 => {
+                        20..30 => {
                             // Sandpit
                             editor.fill_blocks(
                                 SAND,

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -88,7 +88,7 @@ pub fn generate_leisure(
 
                 // Add decorative elements for parks and gardens
                 if matches!(leisure_type.as_str(), "park" | "garden")
-                    && editor.check_for_block(x, ground_level, z, Some(&[GRASS_BLOCK]), None)
+                    && editor.check_for_block(x, ground_level, z, Some(&[GRASS_BLOCK]))
                 {
                     let mut rng: rand::prelude::ThreadRng = rand::thread_rng();
                     let random_choice: i32 = rng.gen_range(0..1000);

--- a/src/element_processing/natural.rs
+++ b/src/element_processing/natural.rs
@@ -129,9 +129,9 @@ pub fn generate_natural(
                             if !editor.check_for_block(x, y, z, Some(&[GRASS_BLOCK])) {
                                 continue;
                             }
-                            let random_choice = rng.gen_range(0..100);
-                            if random_choice < 15 {
-                                if random_choice <= 3 {
+                            let random_choice = rng.gen_range(0..500);
+                            if random_choice < 30 {
+                                if random_choice < 3 {
                                     editor.set_block(OAK_LEAVES, x, y + 1, z, None, None);
                                 } else {
                                     editor.set_block(GRASS, x, y + 1, z, None, None);

--- a/src/element_processing/natural.rs
+++ b/src/element_processing/natural.rs
@@ -105,7 +105,7 @@ pub fn generate_natural(
 
                     // Generate elements for "wood" and "tree_row"
                     if natural_type == "wood" || natural_type == "tree_row" {
-                        if editor.check_for_block(x, y, z, None, Some(&[WATER])) {
+                        if editor.check_for_block(x, y, z, Some(&[WATER])) {
                             continue;
                         }
 

--- a/src/element_processing/natural.rs
+++ b/src/element_processing/natural.rs
@@ -125,6 +125,19 @@ pub fn generate_natural(
                                 }
                             }
                         }
+                        "heath" => {
+                            if !editor.check_for_block(x, y, z, Some(&[GRASS_BLOCK])) {
+                                continue;
+                            }
+                            let random_choice = rng.gen_range(0..100);
+                            if random_choice < 15 {
+                                if random_choice <= 3 {
+                                    editor.set_block(OAK_LEAVES, x, y + 1, z, None, None);
+                                } else {
+                                    editor.set_block(GRASS, x, y + 1, z, None, None);
+                                }
+                            }
+                        }
                         "scrub" => {
                             if !editor.check_for_block(x, y, z, Some(&[GRASS_BLOCK])) {
                                 continue;
@@ -141,11 +154,10 @@ pub fn generate_natural(
                                 if random_choice < 250 {
                                     editor.set_block(TALL_GRASS_BOTTOM, x, y + 1, z, None, None);
                                     editor.set_block(TALL_GRASS_TOP, x, y + 2, z, None, None);
-                                }
-                                else {
+                                } else {
                                     editor.set_block(GRASS, x, y + 1, z, None, None);
                                 }
-                            } 
+                            }
                         }
                         "tree_row" | "wood" => {
                             if editor.check_for_block(x, y, z, Some(&[WATER])) {

--- a/src/element_processing/natural.rs
+++ b/src/element_processing/natural.rs
@@ -23,14 +23,6 @@ pub fn generate_natural(
 
                 Tree::create(editor, (x, ground.level(node.xz()) + 1, z));
             }
-        } else if natural_type == "shrub" {
-            if let ProcessedElement::Node(node) = element {
-                let x: i32 = node.x;
-                let z: i32 = node.z;
-                let y: i32 = ground.level(node.xz());
-                editor.set_block(OAK_LEAVES, x, y, z, None, None);
-                editor.set_block(OAK_LEAVES, x, y + 1, z, None, None);
-            }
         } else {
             let mut previous_node: Option<(i32, i32)> = None;
             let mut corner_addup: (i32, i32, i32) = (0, 0, 0);
@@ -123,7 +115,7 @@ pub fn generate_natural(
                             if !editor.check_for_block(x, y, z, Some(&[GRASS_BLOCK])) {
                                 continue;
                             }
-                            let random_choice = rng.gen_range(0..50);
+                            let random_choice = rng.gen_range(0..100);
                             if random_choice < 40 {
                                 if random_choice < 5 {
                                     editor.set_block(TALL_GRASS_BOTTOM, x, y + 1, z, None, None);
@@ -137,16 +129,16 @@ pub fn generate_natural(
                             if !editor.check_for_block(x, y, z, Some(&[GRASS_BLOCK])) {
                                 continue;
                             }
-                            let random_choice = rng.gen_range(0..100);
+                            let random_choice = rng.gen_range(0..500);
                             if random_choice == 0 {
                                 Tree::create(editor, (x, y + 1, z));
-                            } else if random_choice < 30 {
+                            } else if random_choice < 40 {
                                 editor.set_block(OAK_LEAVES, x, y + 1, z, None, None);
-                                if random_choice < 10 {
+                                if random_choice < 15 {
                                     editor.set_block(OAK_LEAVES, x, y + 2, z, None, None);
                                 }
-                            } else if random_choice < 80 {
-                                if random_choice < 60 {
+                            } else if random_choice < 300 {
+                                if random_choice < 250 {
                                     editor.set_block(TALL_GRASS_BOTTOM, x, y + 1, z, None, None);
                                     editor.set_block(TALL_GRASS_TOP, x, y + 2, z, None, None);
                                 }
@@ -159,10 +151,10 @@ pub fn generate_natural(
                             if editor.check_for_block(x, y, z, Some(&[WATER])) {
                                 continue;
                             }
-                            let random_choice: i32 = rng.gen_range(0..40);
-                            if random_choice == 1 {
+                            let random_choice: i32 = rng.gen_range(0..30);
+                            if random_choice == 0 {
                                 Tree::create(editor, (x, y + 1, z));
-                            } else if random_choice == 2 {
+                            } else if random_choice == 1 {
                                 let flower_block = match rng.gen_range(1..=4) {
                                     1 => RED_FLOWER,
                                     2 => BLUE_FLOWER,
@@ -170,7 +162,7 @@ pub fn generate_natural(
                                     _ => WHITE_FLOWER,
                                 };
                                 editor.set_block(flower_block, x, y + 1, z, None, None);
-                            } else if random_choice <= 15 {
+                            } else if random_choice <= 12 {
                                 editor.set_block(GRASS, x, y + 1, z, None, None);
                             }
                         }

--- a/src/world_editor.rs
+++ b/src/world_editor.rs
@@ -398,35 +398,18 @@ impl WorldEditor {
     }
 
     /// Checks for a block at the given coordinates.
-    pub fn check_for_block(
-        &self,
-        x: i32,
-        y: i32,
-        z: i32,
-        whitelist: Option<&[Block]>,
-        blacklist: Option<&[Block]>,
-    ) -> bool {
-        // Retrieve the chunk modification map
+    pub fn check_for_block(&self, x: i32, y: i32, z: i32, whitelist: Option<&[Block]>) -> bool {
+        // Check if a block exists on given coordinates
         if let Some(existing_block) = self.world.get_block(x, y, z) {
-            // Check against whitelist and blacklist
             if let Some(whitelist) = whitelist {
                 if whitelist
                     .iter()
                     .any(|whitelisted_block: &Block| whitelisted_block.id() == existing_block.id())
                 {
-                    return true; // Block is in whitelist
-                }
-            }
-            if let Some(blacklist) = blacklist {
-                if blacklist
-                    .iter()
-                    .any(|blacklisted_block: &Block| blacklisted_block.id() == existing_block.id())
-                {
-                    return true; // Block is in blacklist
+                    return true; // Block is in the list
                 }
             }
         }
-
         false
     }
 


### PR DESCRIPTION
Some technical changes:
- Removed precalculation of ground levels for terrain mode, taking it directly from the ground object, because it didn't really improve performance and it took extra memory.
- Unified code for both terrain and flat modes by removing `if ground.elevation_enabled {...} else {...}` so the code is simpler, both modes share the same code now and ground is generated the same way in both modes, also fillground works for the flat mode, which can be useful in the future.
- Removed the spawn platform, it isn't really needed, the player always spawns on solid surface
- Always generate bedrock at MIN_Y
- Refactored the check_for_block() function, because the whitelist and blacklist worked basically the same, both returned true, and it would be hard to process whitelist for true and blacklist for false at the same time, so leaving just whitelist for simplicity

Suggestion: I think default ground_level should be changed from -62 to -61 and the region.template should be changed to generate a normal superflat world, with 1 grass, 2 dirt, 1 bedrock to match the new generation. There was a discussion in #384 about that file, but I still don't know how to change it, so @louis-e please do this if you agree with my idea

Improvements to generation:
- Added dead bush to sand regions
- Added surface types for beaches
- Implement generation of plants in grassland, scrub, heath and orchard

Todo:
- Implement tree types
- Implement better generation of wetlands