### PR TITLE
Update leisure and highway element processing

### DIFF
--- a/src/block_definitions.rs
+++ b/src/block_definitions.rs
@@ -22,7 +22,7 @@ impl Block {
     }
 
     pub fn namespace(&self) -> &str {
-        "mincraft"
+        "minecraft"
     }
 
     pub fn name(&self) -> &str {

--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -131,6 +131,22 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                     block_type = GRAY_CONCRETE;
                     block_range = 2;
                 }
+                "secondary_link" | "tertiary_link" => {
+                    block_type = BLACK_CONCRETE;
+                    block_range = 1;
+                }
+                "escape" => {
+                    block_type = SAND;
+                    block_range = 1;
+                }
+                "steps" => {
+                    block_type = OAK_SLAB;
+                    block_range = 1;
+                }
+                "ladder" => {
+                    block_type = LADDER;
+                    block_range = 1;
+                }
                 _ => {
                     if let Some(lanes) = element.tags().get("lanes") {
                         if lanes == "2" {

--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -143,10 +143,7 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                     block_type = OAK_SLAB;
                     block_range = 1;
                 }
-                "ladder" => {
-                    block_type = LADDER;
-                    block_range = 1;
-                }
+
                 _ => {
                     if let Some(lanes) = element.tags().get("lanes") {
                         if lanes == "2" {

--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -132,14 +132,17 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                     block_range = 2;
                 }
                 "secondary_link" | "tertiary_link" => {
+                    //Exit ramps, sliproads
                     block_type = BLACK_CONCRETE;
                     block_range = 1;
                 }
                 "escape" => {
+                    // Sand trap for vehicles on mountainous roads
                     block_type = SAND;
                     block_range = 1;
                 }
                 "steps" => {
+                    //TODO: Add correct stairs respecting height, step_count, etc.
                     block_type = GRAY_CONCRETE;
                     block_range = 1;
                 }

--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -140,7 +140,7 @@ pub fn generate_highways(editor: &mut WorldEditor, element: &ProcessedElement, a
                     block_range = 1;
                 }
                 "steps" => {
-                    block_type = OAK_SLAB;
+                    block_type = GRAY_CONCRETE;
                     block_range = 1;
                 }
 

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -15,8 +15,9 @@ pub fn generate_leisure(editor: &mut WorldEditor, element: &ProcessedWay, args: 
 
         // Determine block type based on leisure type
         let block_type: Block = match leisure_type.as_str() {
-            "park" | "nature_reserve" | "garden" | "disc_golf_course" | "golf_course"
-            | "soccer_golf" => GRASS_BLOCK,
+            "park" | "nature_reserve" | "garden" | "disc_golf_course" | "golf_course" => {
+                GRASS_BLOCK
+            }
             "playground" | "recreation_ground" | "pitch" | "beach_resort" | "dog_park" => {
                 if let Some(surface) = element.tags.get("surface") {
                     match surface.as_str() {

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -23,7 +23,7 @@ pub fn generate_leisure(
         // Determine block type based on leisure type
         let block_type: Block = match leisure_type.as_str() {
             "park" | "nature_preserve" | "garden" => GRASS_BLOCK,
-            "playground" | "recreation_ground" | "pitch" | "beach_resort"=> {
+            "playground" | "recreation_ground" | "pitch" | "beach_resort" => {
                 if let Some(surface) = element.tags.get("surface") {
                     match surface.as_str() {
                         "clay" => TERRACOTTA,
@@ -35,12 +35,11 @@ pub fn generate_leisure(
                     GREEN_STAINED_HARDENED_CLAY
                 }
             }
-            "swimming_pool" | "swimming_area" | "marina" => WATER,  //Add swimming area and marina
-            "bathing_place" => SMOOTH_SANDSTONE,                    // Could be sand or concrete
-            "water_park" | "slipway" => LIGHT_GRAY_CONCRETE,        // Water park area, not the pool. Usually is concrete
-            "ice_rink" => PACKED_ICE,                               // Ice for Ice Rink, may need edge defined
-            _ => GRASS_BLOCK
-               
+            "swimming_pool" | "swimming_area" | "marina" => WATER, //Add swimming area and marina
+            "bathing_place" => SMOOTH_SANDSTONE,                   // Could be sand or concrete
+            "water_park" | "slipway" => LIGHT_GRAY_CONCRETE, // Water park area, not the pool. Usually is concrete
+            "ice_rink" => PACKED_ICE, // Ice for Ice Rink, may need edge defined
+            _ => GRASS_BLOCK,
         };
 
         // Process leisure area nodes

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -15,13 +15,16 @@ pub fn generate_leisure(editor: &mut WorldEditor, element: &ProcessedWay, args: 
 
         // Determine block type based on leisure type
         let block_type: Block = match leisure_type.as_str() {
-            "park" | "nature_preserve" | "garden" => GRASS_BLOCK,
-            "playground" | "recreation_ground" | "pitch" | "beach_resort" => {
+            "park" | "nature_reserve" | "garden" | "disc_golf_course" | "golf_course"
+            | "soccer_golf" => GRASS_BLOCK,
+            "playground" | "recreation_ground" | "pitch" | "beach_resort" | "dog_park" => {
                 if let Some(surface) = element.tags.get("surface") {
                     match surface.as_str() {
                         "clay" => TERRACOTTA,
                         "sand" => SAND,
                         "tartan" => RED_TERRACOTTA,
+                        "grass" => GRASS,
+                        "pebblestone" | "cobblestone" | "unhewn_cobblestone" => COBBLESTONE,
                         _ => GREEN_STAINED_HARDENED_CLAY,
                     }
                 } else {
@@ -30,6 +33,7 @@ pub fn generate_leisure(editor: &mut WorldEditor, element: &ProcessedWay, args: 
             }
             "swimming_pool" | "swimming_area" => WATER, //Add swimming area and marina
             "bathing_place" => SMOOTH_SANDSTONE,        // Could be sand or concrete
+            "outdoor_seating" => SMOOTH_STONE,
             "water_park" | "slipway" => LIGHT_GRAY_CONCRETE, // Water park area, not the pool. Usually is concrete
             "ice_rink" => PACKED_ICE, // Ice for Ice Rink, may need edge defined
             _ => GRASS_BLOCK,
@@ -81,7 +85,7 @@ pub fn generate_leisure(editor: &mut WorldEditor, element: &ProcessedWay, args: 
                 editor.set_block(block_type, x, 0, z, Some(&[GRASS_BLOCK]), None);
 
                 // Add decorative elements for parks and gardens
-                if matches!(leisure_type.as_str(), "park" | "garden")
+                if matches!(leisure_type.as_str(), "park" | "garden" | "nature_reserve")
                     && editor.check_for_block(x, 0, z, Some(&[GRASS_BLOCK]))
                 {
                     let mut rng: rand::prelude::ThreadRng = rand::thread_rng();

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -23,7 +23,7 @@ pub fn generate_leisure(editor: &mut WorldEditor, element: &ProcessedWay, args: 
                         "clay" => TERRACOTTA,
                         "sand" => SAND,
                         "tartan" => RED_TERRACOTTA,
-                        "grass" => GRASS,
+                        "grass" => GRASS_BLOCK,
                         "pebblestone" | "cobblestone" | "unhewn_cobblestone" => COBBLESTONE,
                         _ => GREEN_STAINED_HARDENED_CLAY,
                     }

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -25,6 +25,7 @@ pub fn generate_leisure(editor: &mut WorldEditor, element: &ProcessedWay, args: 
                         "sand" => SAND,
                         "tartan" => RED_TERRACOTTA,
                         "grass" => GRASS_BLOCK,
+                        "dirt" => DIRT,
                         "pebblestone" | "cobblestone" | "unhewn_cobblestone" => COBBLESTONE,
                         _ => GREEN_STAINED_HARDENED_CLAY,
                     }
@@ -32,11 +33,11 @@ pub fn generate_leisure(editor: &mut WorldEditor, element: &ProcessedWay, args: 
                     GREEN_STAINED_HARDENED_CLAY
                 }
             }
-            "swimming_pool" | "swimming_area" => WATER, //Add swimming area and marina
+            "swimming_pool" | "swimming_area" => WATER, //Swimming area: Area in a larger body of water for swimming
             "bathing_place" => SMOOTH_SANDSTONE,        // Could be sand or concrete
-            "outdoor_seating" => SMOOTH_STONE,
+            "outdoor_seating" => SMOOTH_STONE,          //Usually stone or stone bricks
             "water_park" | "slipway" => LIGHT_GRAY_CONCRETE, // Water park area, not the pool. Usually is concrete
-            "ice_rink" => PACKED_ICE, // Ice for Ice Rink, may need edge defined
+            "ice_rink" => PACKED_ICE, // TODO: Ice for Ice Rink, needs building defined
             _ => GRASS_BLOCK,
         };
 

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -22,8 +22,8 @@ pub fn generate_leisure(
 
         // Determine block type based on leisure type
         let block_type: Block = match leisure_type.as_str() {
-            "park" => GRASS_BLOCK,
-            "playground" | "recreation_ground" | "pitch" => {
+            "park" | "nature_preserve" | "garden" => GRASS_BLOCK,
+            "playground" | "recreation_ground" | "pitch" | "beach_resort"=> {
                 if let Some(surface) = element.tags.get("surface") {
                     match surface.as_str() {
                         "clay" => TERRACOTTA,
@@ -35,9 +35,12 @@ pub fn generate_leisure(
                     GREEN_STAINED_HARDENED_CLAY
                 }
             }
-            "garden" => GRASS_BLOCK,
-            "swimming_pool" => WATER,
-            _ => GRASS_BLOCK,
+            "swimming_pool" | "swimming_area" | "marina" => WATER,  //Add swimming area and marina
+            "bathing_place" => SMOOTH_SANDSTONE,                    // Could be sand or concrete
+            "water_park" | "slipway" => LIGHT_GRAY_CONCRETE,        // Water park area, not the pool. Usually is concrete
+            "ice_rink" => PACKED_ICE,                               // Ice for Ice Rink, may need edge defined
+            _ => GRASS_BLOCK
+               
         };
 
         // Process leisure area nodes

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -28,8 +28,8 @@ pub fn generate_leisure(editor: &mut WorldEditor, element: &ProcessedWay, args: 
                     GREEN_STAINED_HARDENED_CLAY
                 }
             }
-            "swimming_pool" | "swimming_area" | "marina" => WATER, //Add swimming area and marina
-            "bathing_place" => SMOOTH_SANDSTONE,                   // Could be sand or concrete
+            "swimming_pool" | "swimming_area" => WATER, //Add swimming area and marina
+            "bathing_place" => SMOOTH_SANDSTONE,        // Could be sand or concrete
             "water_park" | "slipway" => LIGHT_GRAY_CONCRETE, // Water park area, not the pool. Usually is concrete
             "ice_rink" => PACKED_ICE, // Ice for Ice Rink, may need edge defined
             _ => GRASS_BLOCK,


### PR DESCRIPTION
Hi Louis,
This is my first time contributing to a Rust project. 
I noticed a few things I could add while still learning the Rust syntax.

- Fix 'Mincraft' typo (Code still works the same so not sure what that prefix does) 
- Add additional types for leisure
    -  I tested this on an ice rink, but it still generated the normal building over it. Ice-rink generation may need to be moved to buildings.rs   
    - Will test slipway and nature reserve
- Add additional types for highway
