### PR TITLE
Small data retrieval improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-log",
  "tauri-plugin-shell",
+ "tempfile",
  "tokio",
  "windows 0.61.1",
 ]
@@ -288,7 +289,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.42",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -331,7 +332,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 0.38.42",
  "tracing",
 ]
 
@@ -358,7 +359,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.42",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -1833,6 +1834,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "gif"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,6 +2787,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3661,7 +3680,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.42",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3821,6 +3840,12 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "radium"
@@ -4175,7 +4200,20 @@ dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -5110,15 +5148,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.2.15",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -5699,6 +5736,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5786,7 +5832,7 @@ checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 0.38.42",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -5799,7 +5845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
 dependencies = [
  "bitflags 2.6.0",
- "rustix",
+ "rustix 0.38.42",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -6423,6 +6469,15 @@ checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,6 @@ tokio = { version = "1.44.2", features = ["full"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61.1", features = ["Win32_System_Console"] }
+
+[dev-dependencies]
+tempfile = "3.20.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,8 +1,6 @@
 use crate::bbox::BBox;
 use clap::Parser;
-use colored::Colorize;
 use std::path::Path;
-use std::process::exit;
 use std::time::Duration;
 
 /// Command-line arguments parser
@@ -18,7 +16,7 @@ pub struct Args {
     pub file: Option<String>,
 
     /// Path to the Minecraft world (required)
-    #[arg(long)]
+    #[arg(long, value_parser = validate_minecraft_world_path)]
     pub path: String,
 
     /// Downloader method (requests/curl/wget) (optional)
@@ -48,20 +46,19 @@ pub struct Args {
     pub timeout: Option<Duration>,
 }
 
-impl Args {
-    pub fn run(&self) {
-        // Validating the world path
-        let mc_world_path: &Path = Path::new(&self.path);
-        if !mc_world_path.join("region").exists() {
-            eprintln!(
-                "{}",
-                "Error! No Minecraft world found at the given path"
-                    .red()
-                    .bold()
-            );
-            exit(1);
-        }
+fn validate_minecraft_world_path(path: &str) -> Result<String, String> {
+    let mc_world_path = Path::new(path);
+    if !mc_world_path.exists() {
+        return Err(format!("Path does not exist: {}", path));
     }
+    if !mc_world_path.is_dir() {
+        return Err(format!("Path is not a directory: {}", path));
+    }
+    let region = mc_world_path.join("region");
+    if !region.is_dir() {
+        return Err(format!("No Minecraft world found at {:?}", region));
+    }
+    Ok(path.to_string())
 }
 
 fn parse_duration(arg: &str) -> Result<std::time::Duration, std::num::ParseIntError> {
@@ -73,13 +70,23 @@ fn parse_duration(arg: &str) -> Result<std::time::Duration, std::num::ParseIntEr
 mod tests {
     use super::*;
 
+    fn minecraft_tmpdir() -> tempfile::TempDir {
+        let tmpdir = tempfile::tempdir().unwrap();
+        // create a `region` directory in the tempdir
+        let region_path = tmpdir.path().join("region");
+        std::fs::create_dir(&region_path).unwrap();
+        tmpdir
+    }
     #[test]
     fn test_flags() {
+        let tmpdir = minecraft_tmpdir();
+        let tmp_path = tmpdir.path().to_str().unwrap();
+
         // Test that terrain/debug are SetTrue
         let cmd = [
             "arnis",
             "--path",
-            "",
+            tmp_path,
             "--bbox",
             "1,2,3,4",
             "--terrain",
@@ -89,7 +96,7 @@ mod tests {
         assert!(args.debug);
         assert!(args.terrain);
 
-        let cmd = ["arnis", "--path", "", "--bbox", "1,2,3,4"];
+        let cmd = ["arnis", "--path", tmp_path, "--bbox", "1,2,3,4"];
         let args = Args::parse_from(cmd.iter());
         assert!(!args.debug);
         assert!(!args.terrain);
@@ -97,13 +104,16 @@ mod tests {
 
     #[test]
     fn test_required_options() {
+        let tmpdir = minecraft_tmpdir();
+        let tmp_path = tmpdir.path().to_str().unwrap();
+
         let cmd = ["arnis"];
         assert!(Args::try_parse_from(cmd.iter()).is_err());
 
-        let cmd = ["arnis", "--path", "", "--bbox", "1,2,3,4"];
+        let cmd = ["arnis", "--path", tmp_path, "--bbox", "1,2,3,4"];
         assert!(Args::try_parse_from(cmd.iter()).is_ok());
 
-        let cmd = ["arnis", "--path", "", "--file", ""];
+        let cmd = ["arnis", "--path", tmp_path, "--file", ""];
         assert!(Args::try_parse_from(cmd.iter()).is_err());
 
         // The --gui flag isn't used here, ugh. TODO clean up main.rs and its argparse usage.

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,6 +15,10 @@ pub struct Args {
     #[arg(long, group = "location")]
     pub file: Option<String>,
 
+    /// JSON file to save OSM data to (optional)
+    #[arg(long, group = "location")]
+    pub save_json_file: Option<String>,
+
     /// Path to the Minecraft world (required)
     #[arg(long, value_parser = validate_minecraft_world_path)]
     pub path: String,

--- a/src/bbox.rs
+++ b/src/bbox.rs
@@ -12,10 +12,17 @@ pub struct BBox {
 
 impl BBox {
     pub fn new(min_lat: f64, min_lng: f64, max_lat: f64, max_lng: f64) -> Result<Self, String> {
-        let vals_in_order = min_lng < max_lng && min_lat < max_lat;
-
-        if !vals_in_order {
-            return Err("Invalid BBox".to_string());
+        if min_lng >= max_lng {
+            return Err(format!(
+                "Invalid BBox: min_lng {} >= max_lng {} ",
+                min_lng, max_lng
+            ));
+        }
+        if min_lat >= max_lat {
+            return Err(format!(
+                "Invalid BBox: min_lat {} >= max_lat {}",
+                min_lat, max_lat
+            ));
         }
 
         let min = GeoCoord::new(min_lat, min_lng)?;

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -424,6 +424,7 @@ fn gui_start_generation(
             let args: Args = Args {
                 bbox,
                 file: None,
+                save_json_file: None,
                 path: updated_world_path,
                 downloader: "requests".to_string(),
                 scale: world_scale,
@@ -435,7 +436,7 @@ fn gui_start_generation(
             };
 
             // Run data fetch and world generation
-            match retrieve_data::fetch_data(args.bbox, None, args.debug, "requests") {
+            match retrieve_data::fetch_data_from_overpass(args.bbox, args.debug, "requests", None) {
                 Ok(raw_data) => {
                     let (mut parsed_elements, scale_factor_x, scale_factor_z) =
                         osm_parser::parse_osm_data(&raw_data, args.bbox, args.scale, args.debug);

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,6 @@ fn run_cli() {
 
     // Parse input arguments
     let args: Args = Args::parse();
-    args.run();
 
     // Fetch data
     let raw_data: serde_json::Value =

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,9 +77,16 @@ fn run_cli() {
     let args: Args = Args::parse();
 
     // Fetch data
-    let raw_data: serde_json::Value =
-        retrieve_data::fetch_data(args.bbox, args.file.as_deref(), args.debug, "requests")
-            .expect("Failed to fetch data");
+    let raw_data = match &args.file {
+        Some(file) => retrieve_data::fetch_data_from_file(file),
+        None => retrieve_data::fetch_data_from_overpass(
+            args.bbox,
+            args.debug,
+            args.downloader.as_str(),
+            args.save_json_file.as_deref(),
+        ),
+    }
+    .expect("Failed to fetch data");
 
     let mut ground = ground::generate_ground_data(&args);
 

--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -227,12 +227,6 @@ pub fn fetch_data_from_overpass(
             }
         }
 
-        // If debug is enabled, write data to file
-        if debug {
-            let mut file: File = File::create("export.json")?;
-            file.write_all(response.as_bytes())?;
-        }
-
         emit_gui_progress_update(5.0, "");
 
         Ok(data)

--- a/src/test_utilities.rs
+++ b/src/test_utilities.rs
@@ -8,7 +8,8 @@ use crate::retrieve_data;
 pub fn generate_example(llbbox: BBox) -> (XZBBox, Vec<ProcessedElement>) {
     // Fetch data
     let raw_data: serde_json::Value =
-        retrieve_data::fetch_data(llbbox, None, false, "requests").expect("Failed to fetch data");
+        retrieve_data::fetch_data_from_overpass(llbbox, false, "requests", None)
+            .expect("Failed to fetch data");
 
     // Parse raw data
     let (mut parsed_elements, scale_factor_x, scale_factor_z) =


### PR DESCRIPTION
Just some papercuts I noticed while trying out the CLI:

* `args.run()` is an unfortunate place to do argument validation; can just as well do it while parsing.
* I messed up my bbox the first time around and got an unhelpful error. No more!
* It's useful to be able to always choose to save the Overpass data to a file, instead of only when happening to use `--debug`, so that's now a thing (`--save-json-file`).