### PR TITLE
Fix clippy

### DIFF
--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -59,7 +59,7 @@ fn download_with_curl(url: &str, query: &str) -> io::Result<String> {
         .output()?;
 
     if !output.status.success() {
-        Err(io::Error::new(io::ErrorKind::Other, "Curl command failed"))
+        Err(io::Error::other("Curl command failed"))
     } else {
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
     }
@@ -73,7 +73,7 @@ fn download_with_wget(url: &str, query: &str) -> io::Result<String> {
         .output()?;
 
     if !output.status.success() {
-        Err(io::Error::new(io::ErrorKind::Other, "Wget command failed"))
+        Err(io::Error::other("Wget command failed"))
     } else {
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
     }


### PR DESCRIPTION
error: this can be `std::io::Error::other(_)`
  --> src/retrieve_data.rs:62:13
   |
62 |         Err(io::Error::new(io::ErrorKind::Other, "Curl command failed"))
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
   = note: `-D clippy::io-other-error` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::io_other_error)]`
help: use `std::io::Error::other`
   |
62 -         Err(io::Error::new(io::ErrorKind::Other, "Curl command failed"))
62 +         Err(io::Error::other("Curl command failed"))
   |

error: this can be `std::io::Error::other(_)`
  --> src/retrieve_data.rs:76:13
   |
76 |         Err(io::Error::new(io::ErrorKind::Other, "Wget command failed"))
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error
help: use `std::io::Error::other`
   |
76 -         Err(io::Error::new(io::ErrorKind::Other, "Wget command failed"))
76 +         Err(io::Error::other("Wget command failed"))
   |