### PR TITLE
Data parsing fixes

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -439,7 +439,7 @@ fn gui_start_generation(
             match retrieve_data::fetch_data_from_overpass(args.bbox, args.debug, "requests", None) {
                 Ok(raw_data) => {
                     let (mut parsed_elements, scale_factor_x, scale_factor_z) =
-                        osm_parser::parse_osm_data(&raw_data, args.bbox, args.scale, args.debug);
+                        osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug);
                     parsed_elements.sort_by(|el1, el2| {
                         let (el1_priority, el2_priority) =
                             (osm_parser::get_priority(el1), osm_parser::get_priority(el2));

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn run_cli() {
 
     // Parse raw data
     let (mut parsed_elements, scale_factor_x, scale_factor_z) =
-        osm_parser::parse_osm_data(&raw_data, args.bbox, args.scale, args.debug);
+        osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug);
     parsed_elements
         .sort_by_key(|element: &osm_parser::ProcessedElement| osm_parser::get_priority(element));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,11 +98,12 @@ fn run_cli() {
 
     // Write the parsed OSM data to a file for inspection
     if args.debug {
-        let mut output_file: fs::File =
-            fs::File::create("parsed_osm_data.txt").expect("Failed to create output file");
+        let mut buf = std::io::BufWriter::new(
+            fs::File::create("parsed_osm_data.txt").expect("Failed to create output file"),
+        );
         for element in &parsed_elements {
             writeln!(
-                output_file,
+                buf,
                 "Element ID: {}, Type: {}, Tags: {:?}",
                 element.id(),
                 element.kind(),

--- a/src/osm_parser.rs
+++ b/src/osm_parser.rs
@@ -143,7 +143,7 @@ fn lat_lon_to_minecraft_coords(
 }
 
 pub fn parse_osm_data(
-    json_data: &Value,
+    json_data: Value,
     bbox: BBox,
     scale: f64,
     debug: bool,
@@ -153,7 +153,7 @@ pub fn parse_osm_data(
 
     // Deserialize the JSON data into the OSMData structure
     let data: OsmData =
-        serde_json::from_value(json_data.clone()).expect("Failed to parse OSM data");
+        serde_json::from_value(json_data).expect("Failed to parse OSM data");
 
     // Determine which dimension is larger and assign scale factors accordingly
     let (scale_factor_z, scale_factor_x) = geo_distance(bbox.min(), bbox.max());

--- a/src/osm_parser.rs
+++ b/src/osm_parser.rs
@@ -28,9 +28,48 @@ struct OsmElement {
     pub members: Vec<OsmMember>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Deserialize)]
 struct OsmData {
     pub elements: Vec<OsmElement>,
+}
+
+struct SplitOsmData {
+    pub nodes: Vec<OsmElement>,
+    pub ways: Vec<OsmElement>,
+    pub relations: Vec<OsmElement>,
+    #[allow(dead_code)]
+    pub others: Vec<OsmElement>,
+}
+
+impl SplitOsmData {
+    fn total_count(&self) -> usize {
+        self.nodes.len() + self.ways.len() + self.relations.len() + self.others.len()
+    }
+    fn from_raw_osm_data(osm_data: OsmData) -> Self {
+        let mut nodes = Vec::new();
+        let mut ways = Vec::new();
+        let mut relations = Vec::new();
+        let mut others = Vec::new();
+        for element in osm_data.elements {
+            match element.r#type.as_str() {
+                "node" => nodes.push(element),
+                "way" => ways.push(element),
+                "relation" => relations.push(element),
+                _ => others.push(element),
+            }
+        }
+        SplitOsmData {
+            nodes,
+            ways,
+            relations,
+            others,
+        }
+    }
+}
+
+fn parse_raw_osm_data(json_data: Value) -> Result<SplitOsmData, serde_json::Error> {
+    let osm_data: OsmData = serde_json::from_value(json_data)?;
+    Ok(SplitOsmData::from_raw_osm_data(osm_data))
 }
 
 // End raw data
@@ -152,8 +191,7 @@ pub fn parse_osm_data(
     emit_gui_progress_update(10.0, "Parsing data...");
 
     // Deserialize the JSON data into the OSMData structure
-    let data: OsmData =
-        serde_json::from_value(json_data).expect("Failed to parse OSM data");
+    let data = parse_raw_osm_data(json_data).expect("Failed to parse OSM data");
 
     // Determine which dimension is larger and assign scale factors accordingly
     let (scale_factor_z, scale_factor_x) = geo_distance(bbox.min(), bbox.max());
@@ -161,6 +199,7 @@ pub fn parse_osm_data(
     let scale_factor_x: f64 = scale_factor_x.floor() * scale;
 
     if debug {
+        println!("Total elements: {}", data.total_count());
         println!("Scale factor X: {}", scale_factor_x);
         println!("Scale factor Z: {}", scale_factor_z);
     }
@@ -171,37 +210,31 @@ pub fn parse_osm_data(
     let mut processed_elements: Vec<ProcessedElement> = Vec::new();
 
     // First pass: store all nodes with Minecraft coordinates and process nodes with tags
-    for element in &data.elements {
-        if element.r#type == "node" {
-            if let (Some(lat), Some(lon)) = (element.lat, element.lon) {
-                let (x, z) =
-                    lat_lon_to_minecraft_coords(lat, lon, bbox, scale_factor_z, scale_factor_x);
+    for element in data.nodes {
+        if let (Some(lat), Some(lon)) = (element.lat, element.lon) {
+            let (x, z) =
+                lat_lon_to_minecraft_coords(lat, lon, bbox, scale_factor_z, scale_factor_x);
 
-                let processed: ProcessedNode = ProcessedNode {
-                    id: element.id,
-                    tags: element.tags.clone().unwrap_or_default(),
-                    x,
-                    z,
-                };
+            let processed: ProcessedNode = ProcessedNode {
+                id: element.id,
+                tags: element.tags.clone().unwrap_or_default(),
+                x,
+                z,
+            };
 
-                nodes_map.insert(element.id, processed.clone());
+            nodes_map.insert(element.id, processed.clone());
 
-                // Process nodes with tags
-                if let Some(tags) = &element.tags {
-                    if !tags.is_empty() {
-                        processed_elements.push(ProcessedElement::Node(processed));
-                    }
+            // Process nodes with tags
+            if let Some(tags) = &element.tags {
+                if !tags.is_empty() {
+                    processed_elements.push(ProcessedElement::Node(processed));
                 }
             }
         }
     }
 
     // Second pass: process ways
-    for element in &data.elements {
-        if element.r#type != "way" {
-            continue;
-        }
-
+    for element in data.ways {
         let mut nodes: Vec<ProcessedNode> = vec![];
         if let Some(node_ids) = &element.nodes {
             for &node_id in node_ids {
@@ -225,11 +258,7 @@ pub fn parse_osm_data(
     }
 
     // Third pass: process relations
-    for element in &data.elements {
-        if element.r#type != "relation" {
-            continue;
-        }
-
+    for element in data.relations {
         let Some(tags) = &element.tags else {
             continue;
         };
@@ -244,7 +273,7 @@ pub fn parse_osm_data(
             .iter()
             .filter_map(|mem: &OsmMember| {
                 if mem.r#type != "way" {
-                    eprintln!("WARN: Unknown relation type {}", mem.r#type);
+                    eprintln!("WARN: Unknown relation member type \"{}\"", mem.r#type);
                     return None;
                 }
 

--- a/src/test_utilities.rs
+++ b/src/test_utilities.rs
@@ -13,7 +13,7 @@ pub fn generate_example(llbbox: BBox) -> (XZBBox, Vec<ProcessedElement>) {
 
     // Parse raw data
     let (mut parsed_elements, scale_factor_x, scale_factor_z) =
-        osm_parser::parse_osm_data(&raw_data, llbbox, 1.0, false);
+        osm_parser::parse_osm_data(raw_data, llbbox, 1.0, false);
     parsed_elements
         .sort_by_key(|element: &osm_parser::ProcessedElement| osm_parser::get_priority(element));
 


### PR DESCRIPTION
* Makes `parse_osm_data` take ownership of the raw data instead of the caller cloning it. IOW, the parser function transmutes the raw data to the parsed stuff.
* Similarly, `SplitOsmData` now does the work of splitting the elements by type, so the loops that handle them don't need to check for types themselves (and also can work without references, on the data itself.) (Future work could improve things there for less cloning.)
* Makes writing the debug file use a buffered writer, which makes it much, much faster.