### PR TITLE
Some overflow fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [profile.release]
 lto = "thin"
+overflow-checks = true
 
 [features]
 default = ["gui"]

--- a/src/element_processing/amenities.rs
+++ b/src/element_processing/amenities.rs
@@ -184,7 +184,10 @@ pub fn generate_amenities(editor: &mut WorldEditor, element: &ProcessedElement, 
                         );
 
                         // Add parking spot markings
-                        if amenity_type == "parking" && (x + z) % 8 == 0 && (x * z) % 32 != 0 {
+                        if amenity_type == "parking"
+                            && (x + z) % 8 == 0
+                            && x.wrapping_mul(z) % 32 != 0
+                        {
                             editor.set_block(
                                 LIGHT_GRAY_CONCRETE,
                                 x,

--- a/src/element_processing/water_areas.rs
+++ b/src/element_processing/water_areas.rs
@@ -207,13 +207,15 @@ fn inverse_floodfill_recursive(
         println!("Water area generation exceeded 25 seconds, continuing anyway");
     }
 
-    const ITERATIVE_THRES: i32 = 10_000;
+    const ITERATIVE_THRES: i64 = 10_000;
 
     if min.0 > max.0 || min.1 > max.1 {
         return;
     }
 
-    if (max.0 - min.0) * (max.1 - min.1) < ITERATIVE_THRES {
+    // Multiply as i64 to avoid overflow; in release builds where unchecked math is
+    // enabled, this could cause the rest of this code to end up in an infinite loop.
+    if ((max.0 - min.0) as i64) * ((max.1 - min.1) as i64) < ITERATIVE_THRES {
         inverse_floodfill_iterative(min, max, 0, outers, inners, editor);
         return;
     }


### PR DESCRIPTION
I tried Arnis with a large area that was painfully slow on `--debug`, and would just hang on `--release`.

I mustered enough patience to wait for `--debug` to do its thing, only to see it panic on a overflow.

This PR fixes two of the overflow panics I found, and also turns on `overflow-checks` in release builds so they won't hang in similar situations.