### PR TITLE
CI: fix benchmark time to not include build

### DIFF
--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -22,7 +22,6 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          components: clippy
 
       - name: Create dummy Minecraft world directory
         run: |

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           toolchain: stable
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Create dummy Minecraft world directory
         run: |
           mkdir -p "./world/region"

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -28,6 +28,9 @@ jobs:
         run: |
           mkdir -p "./world/region"
 
+      - name: Build for release
+        run: cargo build --release --no-default-features
+
       - name: Start timer
         id: start_time
         run: echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
@@ -35,7 +38,7 @@ jobs:
       - name: Run benchmark command with memory tracking
         id: benchmark
         run: |
-          /usr/bin/time -v cargo run --release --no-default-features -- --path="./world" --terrain --bbox="48.117861,11.541996,48.154520,11.604824" 2> benchmark_log.txt
+          /usr/bin/time -v ./target/release/arnis --path="./world" --terrain --bbox="48.117861,11.541996,48.154520,11.604824" 2> benchmark_log.txt
           grep "Maximum resident set size" benchmark_log.txt | awk '{print $6}' > peak_mem_kb.txt
           peak_kb=$(cat peak_mem_kb.txt)
           peak_mb=$((peak_kb / 1024))

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -61,7 +61,7 @@ jobs:
           seconds=$((duration % 60))
           peak_mem=${{ steps.benchmark.outputs.peak_memory }}
 
-          baseline_time=124
+          baseline_time=42
           diff=$((duration - baseline_time))
           abs_diff=${diff#-}
 


### PR DESCRIPTION
Timing `cargo run` means also timing the build if one doesn't exist.

This splits the benchmark CI to build first, then just time the compiled binary.

A follow-up could be to use https://github.com/sharkdp/hyperfine so the benchmark is run a couple of times, but then you'd need to take into account how many times Hyperfine decides to run the benchmark, which is not something I want to implement in Bash math.

I adjusted the baseline duration accordingly in this PR.