### PR TITLE
Disable transparent flag

### DIFF
--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -16,7 +16,7 @@
         "minWidth": 1000,
         "minHeight": 650,
         "resizable": true,
-        "transparent": true,
+        "transparent": false,
         "center": true,
         "theme": "Dark",
         "additionalBrowserArgs": "--disable-features=VizDisplayCompositor"


### PR DESCRIPTION
Likely fixes
`assertion failed: !bitmap.is_null() @ C:\Users\louis\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\softbuffer-0.4.6\src\backends\win32.rs:99:9`