### PR TITLE
Change what trees are generated based on tag content

### DIFF
--- a/src/element_processing/tree.rs
+++ b/src/element_processing/tree.rs
@@ -92,6 +92,7 @@ fn round(editor: &mut WorldEditor, material: Block, (x, y, z): Coord, block_patt
     }
 }
 
+#[derive(Clone, Copy)]
 pub enum TreeType {
     Oak,
     Spruce,
@@ -121,6 +122,27 @@ impl Tree<'_> {
         (x, y, z): Coord,
         building_footprints: Option<&BuildingFootprintBitmap>,
     ) {
+        // Use deterministic RNG based on coordinates for consistent tree types across region boundaries
+        // The element_id of 0 is used as a salt for tree-specific randomness
+        let mut rng = coord_rng(x, z, 0);
+
+        let tree_type = match rng.gen_range(1..=3) {
+            1 => TreeType::Oak,
+            2 => TreeType::Spruce,
+            3 => TreeType::Birch,
+            _ => unreachable!(),
+        };
+
+        Self::create_of_type(editor, (x, y, z), tree_type, building_footprints);
+    }
+
+    /// Creates a tree of a specific type at the specified coordinates.
+    pub fn create_of_type(
+        editor: &mut WorldEditor,
+        (x, y, z): Coord,
+        tree_type: TreeType,
+        building_footprints: Option<&BuildingFootprintBitmap>,
+    ) {
         // Skip if this coordinate is inside a building
         if let Some(footprints) = building_footprints {
             if footprints.contains(x, z) {
@@ -135,16 +157,7 @@ impl Tree<'_> {
         blacklist.extend(Self::get_functional_blocks());
         blacklist.push(WATER);
 
-        // Use deterministic RNG based on coordinates for consistent tree types across region boundaries
-        // The element_id of 0 is used as a salt for tree-specific randomness
-        let mut rng = coord_rng(x, z, 0);
-
-        let tree = Self::get_tree(match rng.gen_range(1..=3) {
-            1 => TreeType::Oak,
-            2 => TreeType::Spruce,
-            3 => TreeType::Birch,
-            _ => unreachable!(),
-        });
+        let tree = Self::get_tree(tree_type);
 
         // Build the logs
         editor.fill_blocks(

--- a/src/gui/js/maps/wkt.parser.js
+++ b/src/gui/js/maps/wkt.parser.js
@@ -195,11 +195,7 @@ Wkt.Wkt.prototype.toObject = function (config) {
  * Absorbs the geometry of another Wkt.Wkt instance, merging it with its own,
  * creating a collection (MULTI-geometry) based on their types, which must agree.
  * For example, creates a MULTIPOLYGON from a POLYGON type merged with another
-<<<<<<< HEAD
- * POLYGON type.
-=======
  * POLYGON type, or adds a POLYGON instance to a MULTIPOLYGON instance.
->>>>>>> dev
  * @memberof Wkt.Wkt
  * @method
  */


### PR DESCRIPTION
This PR makes trees (`natural=tree`) and trees in woods (`natural=wood`) and forests (`landuse=forest`) generate depending on infos from tags.

If a `genus` or `genus:wikidata` is given and it is one of the trees we can generate, or if a `species` contains the genus of what we can generate, exactly that one is generated. (`natural=tree` only)
If `leaf_type=broadleafed/needleleafed` is given, only trees/a tree that has leafs or needles respectively is generated.