### PR TITLE
fix: resolve breaking changes from geo 0.32 and rusty-leveldb 4 bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
  "rayon",
  "reqwest",
  "rfd",
- "rusty-leveldb 4.0.1",
+ "rusty-leveldb",
  "semver",
  "serde",
  "serde_json",
@@ -539,7 +539,7 @@ dependencies = [
  "len-trait",
  "miniz_oxide 0.9.0",
  "nbtx",
- "rusty-leveldb 3.0.3",
+ "rusty-leveldb",
  "serde",
  "thiserror 1.0.69",
  "uuid",
@@ -1123,15 +1123,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "crc32c"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
-dependencies = [
- "rustc_version",
-]
 
 [[package]]
 name = "crc32fast"
@@ -4833,21 +4824,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c48d2f060dd1286adc9c3d179cb5af1292a9d2fcf291abcfe056023fc1977b44"
 dependencies = [
  "crc",
- "errno 0.2.8",
- "fs2",
- "integer-encoding",
- "rand 0.8.5",
- "snap",
-]
-
-[[package]]
-name = "rusty-leveldb"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ddda8f34100fca4bf1b0bbf743d12d27b5d84c35c74a52f392aac26f54e82d"
-dependencies = [
- "bytes",
- "crc32c",
  "errno 0.2.8",
  "fs2",
  "integer-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ bedrockrs_shared = { git = "https://github.com/bedrock-crustaceans/bedrock-rs", 
 nbtx = { git = "https://github.com/bedrock-crustaceans/nbtx", optional = true }
 vek = { version = "0.17", optional = true }
 zip = { version = "0.6", default-features = false, features = ["deflate"], optional = true }
-rusty-leveldb = { version = "4", optional = true }
+rusty-leveldb = { version = "3", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.0", features = ["Win32_System_Console"] }

--- a/src/urban_ground.rs
+++ b/src/urban_ground.rs
@@ -19,7 +19,7 @@
 
 use crate::coordinate_system::cartesian::XZBBox;
 use crate::floodfill::flood_fill_area;
-use geo::{ConcaveHull, ConvexHull, MultiPoint, Point, Polygon, Simplify};
+use geo::{concave_hull::ConcaveHullOptions, ConcaveHull, ConvexHull, MultiPoint, Point, Polygon, Simplify};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Duration;
 
@@ -546,7 +546,10 @@ impl UrbanGroundComputer {
             multi_point.convex_hull()
         } else {
             // Use concave hull for better fit
-            multi_point.concave_hull(self.config.concavity)
+            multi_point.concave_hull_with_options(ConcaveHullOptions {
+                concavity: self.config.concavity,
+                ..Default::default()
+            })
         };
 
         // Simplify the hull to reduce vertex count (improves flood fill performance)


### PR DESCRIPTION
- geo 0.32.0 removed the concavity argument from concave_hull(); migrate to concave_hull_with_options(ConcaveHullOptions { concavity, ..Default::default() })
- rusty-leveldb 4.x is incompatible with bedrockrs_level which requires 3.x; revert direct dependency back to version 3