### PR TITLE
fix: allow CLI to create new world in non-existent directory

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -239,10 +239,12 @@ mod tests {
     #[test]
     fn test_java_nonexistent_path_is_ok() {
         // Java: nonexistent paths are OK - create_new_world will create them
+        let tmp = tempfile::tempdir().unwrap();
+        let nonexistent = tmp.path().join("does_not_exist");
         let cmd = [
             "arnis",
             "--output-dir",
-            "/nonexistent/path",
+            nonexistent.to_str().unwrap(),
             "--bbox",
             "1,2,3,4",
         ];


### PR DESCRIPTION
## Summary

Fixes #706

Previously, `validate_args()` required the output directory to exist for Java Edition, but the actual world creation logic (`create_new_world()`) would create the directory anyway. This caused a chicken-and-egg problem where users had to manually create the directory first.

## Changes

- Modified `validate_args()` to allow non-existent paths for Java Edition
- If path exists but is a file (not directory), still fail with clear error
- If path does not exist, that is OK - `create_new_world()` will create it

## Testing

- Added `test_java_nonexistent_path_is_ok` - verifies non-existent paths are allowed
- Added `test_java_path_exists_but_is_file_fails` - verifies files are rejected
- All existing tests pass

## Behavior

| Path State | Before | After |
|------------|--------|-------|
| Exists as directory | ✅ OK | ✅ OK |
| Exists as file | ❌ Error | ❌ Error |
| Does not exist | ❌ Error | ✅ OK (will be created) |

This matches the GUI behavior and the documented FAQ behavior.