### PR TITLE
Enhance road generation with sidewalks, surface variation, and map labels

### DIFF
--- a/src/bedrock_block_map.rs
+++ b/src/bedrock_block_map.rs
@@ -719,6 +719,9 @@ pub fn to_bedrock_block(block: Block) -> BedrockBlock {
         "potted_dandelion" => BedrockBlock::simple("flower_pot"),
         "potted_blue_orchid" => BedrockBlock::simple("flower_pot"),
 
+        // Banner
+        "white_banner" => BedrockBlock::simple("standing_banner"),
+
         // Bed (Bedrock uses single "bed" block with color state)
         "red_bed" => BedrockBlock::with_states(
             "bed",

--- a/src/block_definitions.rs
+++ b/src/block_definitions.rs
@@ -327,6 +327,7 @@ impl Block {
             246 => "potted_red_tulip",
             247 => "potted_dandelion",
             248 => "potted_blue_orchid",
+            249 => "white_banner",
             _ => panic!("Invalid id"),
         }
     }
@@ -665,6 +666,12 @@ impl Block {
                 map.insert("half".to_string(), Value::String("top".to_string()));
                 map
             })),
+            // White banner (default rotation 0 = south)
+            249 => Some(Value::Compound({
+                let mut map = HashMap::new();
+                map.insert("rotation".to_string(), Value::String("0".to_string()));
+                map
+            })),
             _ => None,
         }
     }
@@ -962,6 +969,7 @@ pub const BRICK_SLAB: Block = Block::new(245);
 pub const POTTED_RED_TULIP: Block = Block::new(246);
 pub const POTTED_DANDELION: Block = Block::new(247);
 pub const POTTED_BLUE_ORCHID: Block = Block::new(248);
+pub const WHITE_BANNER: Block = Block::new(249);
 
 /// Maps a block to its corresponding stair variant
 #[inline]

--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -2502,6 +2502,23 @@ pub fn generate_buildings(
     // Add shutters and window boxes to small residential buildings
     generate_residential_window_decorations(editor, element, &config);
 
+    // Add exterior lighting along building perimeter for buildings taller than 3 blocks
+    if config.building_height > 3 && !config.is_abandoned_building {
+        let lantern_spacing = rng.random_range(8..=12) as usize;
+        for (i, &(wx, wz)) in wall_outline.iter().enumerate() {
+            if i % lantern_spacing == 0 {
+                editor.set_block(
+                    SEA_LANTERN,
+                    wx,
+                    config.start_y_offset + 3,
+                    wz,
+                    None,
+                    None,
+                );
+            }
+        }
+    }
+
     // Create roof area = floor area + wall outline (so roof covers the walls too)
     let roof_area: Vec<(i32, i32)> = {
         let mut area: HashSet<(i32, i32)> = cached_floor_area.iter().copied().collect();

--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -2,9 +2,11 @@ use crate::args::Args;
 use crate::block_definitions::*;
 use crate::bresenham::bresenham_line;
 use crate::coordinate_system::cartesian::XZPoint;
+use crate::deterministic_rng::coord_rng;
 use crate::floodfill_cache::FloodFillCache;
 use crate::osm_parser::{ProcessedElement, ProcessedWay};
 use crate::world_editor::WorldEditor;
+use rand::Rng;
 use std::collections::HashMap;
 
 /// Type alias for highway connectivity map
@@ -161,6 +163,8 @@ fn generate_highways_internal(
             let mut block_range: i32 = 2;
             let mut add_stripe = false;
             let mut add_outline = false;
+            let mut add_sidewalks = false;
+            let mut randomize_surface = false;
             let scale_factor = args.scale;
 
             // Check if this is a bridge - bridges need special elevation handling
@@ -201,6 +205,7 @@ fn generate_highways_internal(
                 "footway" | "pedestrian" => {
                     block_type = GRAY_CONCRETE;
                     block_range = 1;
+                    randomize_surface = true;
                 }
                 "path" => {
                     block_type = DIRT_PATH;
@@ -209,16 +214,21 @@ fn generate_highways_internal(
                 "motorway" | "primary" | "trunk" => {
                     block_range = 5;
                     add_stripe = true;
+                    add_sidewalks = true;
                 }
                 "secondary" => {
                     block_range = 4;
                     add_stripe = true;
+                    add_sidewalks = true;
                 }
                 "tertiary" => {
                     add_stripe = true;
+                    add_sidewalks = true;
                 }
                 "track" => {
+                    block_type = COARSE_DIRT;
                     block_range = 1;
+                    randomize_surface = true;
                 }
                 "service" => {
                     block_type = GRAY_CONCRETE;
@@ -240,6 +250,21 @@ fn generate_highways_internal(
                     block_range = 1;
                 }
 
+                "residential" | "unclassified" => {
+                    add_sidewalks = true;
+                    randomize_surface = true;
+                    if let Some(lanes) = element.tags().get("lanes") {
+                        if lanes == "2" {
+                            block_range = 3;
+                            add_stripe = true;
+                            add_outline = true;
+                        } else if lanes != "1" {
+                            block_range = 4;
+                            add_stripe = true;
+                            add_outline = true;
+                        }
+                    }
+                }
                 _ => {
                     if let Some(lanes) = element.tags().get("lanes") {
                         if lanes == "2" {
@@ -488,24 +513,57 @@ fn generate_highways_internal(
                                             None,
                                         );
                                     }
-                                } else if use_absolute_y {
-                                    editor.set_block_absolute(
-                                        block_type,
-                                        set_x,
-                                        current_y,
-                                        set_z,
-                                        None,
-                                        Some(&[BLACK_CONCRETE, WHITE_CONCRETE]),
-                                    );
                                 } else {
-                                    editor.set_block(
-                                        block_type,
-                                        set_x,
-                                        current_y,
-                                        set_z,
-                                        None,
-                                        Some(&[BLACK_CONCRETE, WHITE_CONCRETE]),
-                                    );
+                                    // Apply surface randomization for certain road types
+                                    let actual_block = if randomize_surface {
+                                        let mut srng = coord_rng(set_x, set_z, 77);
+                                        match highway_type.as_str() {
+                                            "track" => {
+                                                if srng.random_range(0..100) < 40 {
+                                                    DIRT_PATH
+                                                } else {
+                                                    COARSE_DIRT
+                                                }
+                                            }
+                                            "footway" | "pedestrian" => {
+                                                if srng.random_range(0..100) < 10 {
+                                                    STONE
+                                                } else {
+                                                    block_type
+                                                }
+                                            }
+                                            _ => {
+                                                // Residential/unclassified: subtle wear
+                                                if srng.random_range(0..100) < 8 {
+                                                    GRAY_CONCRETE
+                                                } else {
+                                                    block_type
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        block_type
+                                    };
+
+                                    if use_absolute_y {
+                                        editor.set_block_absolute(
+                                            actual_block,
+                                            set_x,
+                                            current_y,
+                                            set_z,
+                                            None,
+                                            Some(&[BLACK_CONCRETE, WHITE_CONCRETE]),
+                                        );
+                                    } else {
+                                        editor.set_block(
+                                            actual_block,
+                                            set_x,
+                                            current_y,
+                                            set_z,
+                                            None,
+                                            Some(&[BLACK_CONCRETE, WHITE_CONCRETE]),
+                                        );
+                                    }
                                 }
 
                                 // Add stone brick foundation underneath elevated highways/bridges for thickness
@@ -643,11 +701,74 @@ fn generate_highways_internal(
                                 stripe_length = 0;
                             }
                         }
+
+                        // Add sidewalks along the edges of the road (ground level only)
+                        if add_sidewalks && current_y == 0 && !use_absolute_y {
+                            let sidewalk_offset = block_range + 1;
+                            for &(sdx, sdz) in &[
+                                (-sidewalk_offset, 0),
+                                (sidewalk_offset, 0),
+                                (0, -sidewalk_offset),
+                                (0, sidewalk_offset),
+                            ] {
+                                let sw_x = x + sdx;
+                                let sw_z = z + sdz;
+                                editor.set_block(
+                                    STONE_BLOCK_SLAB,
+                                    sw_x,
+                                    1,
+                                    sw_z,
+                                    Some(&[GRASS_BLOCK, DIRT, COARSE_DIRT, PODZOL]),
+                                    None,
+                                );
+                            }
+                        }
                     }
 
                     segment_index += 1;
                 }
                 previous_node = Some((node.x, node.z));
+            }
+
+            // Place named banners along roads for map labeling
+            if let Some(road_name) = element.tags().get("name") {
+                if !road_name.is_empty() && way.nodes.len() >= 2 {
+                    let banner_interval = 100; // Place a banner every ~100 blocks
+                    let mut accumulated_distance: usize = 0;
+                    let mut last_banner_distance: usize = 0;
+
+                    // Place first banner near the start
+                    let first = &way.nodes[0];
+                    let second = &way.nodes[1];
+                    let dx = (second.x - first.x) as f64;
+                    let dz = (second.z - first.z) as f64;
+                    let angle = dz.atan2(dx);
+                    // Convert angle to Minecraft rotation (0-15, 0=south, clockwise)
+                    let rotation =
+                        (((-angle.to_degrees() + 180.0) / 22.5).round() as i32).rem_euclid(16);
+
+                    // Place banner offset to the side of the road
+                    let offset = block_range + 2;
+                    let banner_x = first.x + offset;
+                    let banner_z = first.z;
+                    editor.set_banner(road_name, banner_x, 1, banner_z, rotation);
+
+                    // Place additional banners along long roads
+                    for pair in way.nodes.windows(2) {
+                        let seg_dx = (pair[1].x - pair[0].x).abs();
+                        let seg_dz = (pair[1].z - pair[0].z).abs();
+                        let seg_len =
+                            ((seg_dx * seg_dx + seg_dz * seg_dz) as f64).sqrt() as usize;
+                        accumulated_distance += seg_len;
+
+                        if accumulated_distance - last_banner_distance >= banner_interval {
+                            let mid_x = (pair[0].x + pair[1].x) / 2 + offset;
+                            let mid_z = (pair[0].z + pair[1].z) / 2;
+                            editor.set_banner(road_name, mid_x, 1, mid_z, rotation);
+                            last_banner_distance = accumulated_distance;
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -164,6 +164,8 @@ pub fn generate_landuse(
                     } else if random_choice < 41 {
                         editor.set_block(LARGE_FERN_LOWER, x, 1, z, None, None);
                         editor.set_block(LARGE_FERN_UPPER, x, 2, z, None, None);
+                    } else if random_choice < 44 {
+                        editor.set_block(DEAD_BUSH, x, 1, z, None, None);
                     }
                 }
             }
@@ -297,8 +299,21 @@ pub fn generate_landuse(
                 if editor.check_for_block(x, 0, z, Some(&[GRASS_BLOCK])) {
                     match rng.random_range(0..200) {
                         0 => editor.set_block(OAK_LEAVES, x, 1, z, None, None),
-                        1..=8 => editor.set_block(FERN, x, 1, z, None, None),
-                        9..=170 => editor.set_block(GRASS, x, 1, z, None, None),
+                        1..=4 => {
+                            let flower = match rng.random_range(0..4) {
+                                0 => RED_FLOWER,
+                                1 => BLUE_FLOWER,
+                                2 => YELLOW_FLOWER,
+                                _ => WHITE_FLOWER,
+                            };
+                            editor.set_block(flower, x, 1, z, None, None);
+                        }
+                        5..=12 => editor.set_block(FERN, x, 1, z, None, None),
+                        13..=22 => {
+                            editor.set_block(TALL_GRASS_BOTTOM, x, 1, z, None, None);
+                            editor.set_block(TALL_GRASS_TOP, x, 2, z, None, None);
+                        }
+                        23..=170 => editor.set_block(GRASS, x, 1, z, None, None),
                         _ => {}
                     }
                 }
@@ -307,8 +322,20 @@ pub fn generate_landuse(
                 if editor.check_for_block(x, 0, z, Some(&[GRASS_BLOCK])) {
                     match rng.random_range(0..200) {
                         0 => editor.set_block(OAK_LEAVES, x, 1, z, None, None),
-                        1..=2 => editor.set_block(FERN, x, 1, z, None, None),
-                        3..=16 => editor.set_block(GRASS, x, 1, z, None, None),
+                        1..=2 => {
+                            let flower = match rng.random_range(0..4) {
+                                0 => RED_FLOWER,
+                                1 => YELLOW_FLOWER,
+                                _ => WHITE_FLOWER,
+                            };
+                            editor.set_block(flower, x, 1, z, None, None);
+                        }
+                        3..=5 => editor.set_block(FERN, x, 1, z, None, None),
+                        6..=8 => {
+                            editor.set_block(TALL_GRASS_BOTTOM, x, 1, z, None, None);
+                            editor.set_block(TALL_GRASS_TOP, x, 2, z, None, None);
+                        }
+                        9..=20 => editor.set_block(GRASS, x, 1, z, None, None),
                         _ => {}
                     }
                 }
@@ -318,8 +345,15 @@ pub fn generate_landuse(
                     let random_choice: i32 = rng.random_range(0..1001);
                     if random_choice < 5 {
                         Tree::create(editor, (x, 1, z), Some(building_footprints));
-                    } else if random_choice < 6 {
-                        editor.set_block(RED_FLOWER, x, 1, z, None, None);
+                    } else if random_choice < 8 {
+                        let flower = match rng.random_range(0..5) {
+                            0 => RED_FLOWER,
+                            1 => BLUE_FLOWER,
+                            2 => YELLOW_FLOWER,
+                            3 => WHITE_FLOWER,
+                            _ => FERN,
+                        };
+                        editor.set_block(flower, x, 1, z, None, None);
                     } else if random_choice < 9 {
                         editor.set_block(OAK_LEAVES, x, 1, z, None, None);
                     } else if random_choice < 40 {
@@ -327,6 +361,9 @@ pub fn generate_landuse(
                     } else if random_choice < 65 {
                         editor.set_block(LARGE_FERN_LOWER, x, 1, z, None, None);
                         editor.set_block(LARGE_FERN_UPPER, x, 2, z, None, None);
+                    } else if random_choice < 100 {
+                        editor.set_block(TALL_GRASS_BOTTOM, x, 1, z, None, None);
+                        editor.set_block(TALL_GRASS_TOP, x, 2, z, None, None);
                     } else if random_choice < 825 {
                         editor.set_block(GRASS, x, 1, z, None, None);
                     }

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -111,17 +111,32 @@ pub fn generate_leisure(
                             };
                             editor.set_block(plant_choice, x, 1, z, None, None);
                         }
-                        30..90 => {
+                        30..70 => {
                             // Grass
                             editor.set_block(GRASS, x, 1, z, None, None);
                         }
-                        90..105 => {
+                        70..85 => {
+                            // Tall grass
+                            editor.set_block(TALL_GRASS_BOTTOM, x, 1, z, None, None);
+                            editor.set_block(TALL_GRASS_TOP, x, 2, z, None, None);
+                        }
+                        85..95 => {
+                            // Large fern
+                            editor.set_block(LARGE_FERN_LOWER, x, 1, z, None, None);
+                            editor.set_block(LARGE_FERN_UPPER, x, 2, z, None, None);
+                        }
+                        95..110 => {
                             // Oak leaves
                             editor.set_block(OAK_LEAVES, x, 1, z, None, None);
                         }
-                        105..120 => {
+                        110..125 => {
                             // Tree
                             Tree::create(editor, (x, 1, z), Some(building_footprints));
+                        }
+                        125..130 => {
+                            // Park bench
+                            editor.set_block(OAK_STAIRS, x, 1, z, None, None);
+                            editor.set_block(OAK_STAIRS, x + 1, 1, z, None, None);
                         }
                         _ => {}
                     }

--- a/src/element_processing/waterways.rs
+++ b/src/element_processing/waterways.rs
@@ -1,7 +1,9 @@
 use crate::block_definitions::*;
 use crate::bresenham::bresenham_line;
+use crate::deterministic_rng::coord_rng;
 use crate::osm_parser::ProcessedWay;
 use crate::world_editor::WorldEditor;
+use rand::Rng;
 
 pub fn generate_waterways(editor: &mut WorldEditor, element: &ProcessedWay) {
     if let Some(waterway_type) = element.tags.get("waterway") {
@@ -109,6 +111,28 @@ fn create_water_channel(
 
                 // Clear vegetation above sloped areas
                 editor.set_block(AIR, x, 1, z, Some(&[GRASS, WHEAT, CARROTS, POTATOES]), None);
+            }
+        }
+    }
+
+    // Add vegetation along the banks
+    for x in (center_x - half_width - 3)..=(center_x + half_width + 3) {
+        for z in (center_z - half_width - 3)..=(center_z + half_width + 3) {
+            let dx = (x - center_x).abs();
+            let dz = (z - center_z).abs();
+            let distance_from_center = dx.max(dz);
+
+            // Only place vegetation in the strip just outside the bank
+            if distance_from_center == half_width + 2 || distance_from_center == half_width + 3 {
+                if editor.check_for_block(x, 0, z, Some(&[GRASS_BLOCK])) {
+                    let mut rng = coord_rng(x, z, 42);
+                    match rng.random_range(0..100) {
+                        0..50 => editor.set_block(GRASS, x, 1, z, None, None),
+                        50..65 => editor.set_block(FERN, x, 1, z, None, None),
+                        65..70 => editor.set_block(OAK_LEAVES, x, 1, z, None, None),
+                        _ => {} // Natural gaps
+                    }
+                }
             }
         }
     }

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -297,6 +297,60 @@ impl<'a> WorldEditor<'a> {
         self.set_block(SIGN, x, y, z, None, None);
     }
 
+    /// Places a named banner at the given coordinates with a custom name that appears on maps.
+    /// In Java Edition, named banners show their name on maps when a player right-clicks them.
+    pub fn set_banner(
+        &mut self,
+        name: &str,
+        x: i32,
+        y: i32,
+        z: i32,
+        rotation: i32,
+    ) {
+        let absolute_y = self.get_absolute_y(x, y, z);
+        let chunk_x = x >> 4;
+        let chunk_z = z >> 4;
+        let region_x = chunk_x >> 5;
+        let region_z = chunk_z >> 5;
+
+        let mut block_entity = HashMap::new();
+        block_entity.insert(
+            "id".to_string(),
+            Value::String("minecraft:banner".to_string()),
+        );
+        block_entity.insert("x".to_string(), Value::Int(x));
+        block_entity.insert("y".to_string(), Value::Int(absolute_y));
+        block_entity.insert("z".to_string(), Value::Int(z));
+        block_entity.insert(
+            "CustomName".to_string(),
+            Value::String(format!("{{\"text\":\"{name}\"}}")),
+        );
+        block_entity.insert("keepPacked".to_string(), Value::Byte(0));
+
+        let region = self.world.get_or_create_region(region_x, region_z);
+        let chunk = region.get_or_create_chunk(chunk_x & 31, chunk_z & 31);
+
+        if let Some(chunk_data) = chunk.other.get_mut("block_entities") {
+            if let Value::List(entities) = chunk_data {
+                entities.push(Value::Compound(block_entity));
+            }
+        } else {
+            chunk.other.insert(
+                "block_entities".to_string(),
+                Value::List(vec![Value::Compound(block_entity)]),
+            );
+        }
+
+        // Place the banner block with the specified rotation
+        let mut props = HashMap::new();
+        props.insert(
+            "rotation".to_string(),
+            Value::String(rotation.to_string()),
+        );
+        let banner_with_props = BlockWithProperties::new(WHITE_BANNER, Some(Value::Compound(props)));
+        self.set_block_with_properties_absolute(banner_with_props, x, absolute_y, z, None, None);
+    }
+
     /// Adds an entity at the given coordinates (Y is ground-relative).
     #[allow(dead_code)]
     pub fn add_entity(


### PR DESCRIPTION
## Summary
This PR significantly improves road and landscape generation by adding sidewalks to major roads, introducing surface texture variation for certain road types, placing named banners for map labeling, and enhancing vegetation diversity in parks and natural areas.

## Key Changes

**Road Generation Enhancements (highways.rs)**
- Added sidewalk generation along major roads (motorway, primary, trunk, secondary, tertiary, residential, unclassified) at ground level only
- Implemented surface randomization for tracks, footways, pedestrian paths, and residential roads using deterministic coordinate-based RNG
- Added support for track roads with coarse dirt blocks
- Enhanced residential/unclassified road handling with lane-based width and stripe configuration
- Implemented named banner placement along roads for map labeling, with banners positioned at regular intervals (~100 blocks) and rotated to match road direction

**World Editor Enhancement (world_editor/mod.rs)**
- Added `set_banner()` method to place named banners with custom names that appear on Minecraft maps
- Banners are placed as block entities with proper rotation properties

**Landscape Improvements**
- **Landuse (landuse.rs)**: Enhanced vegetation variety with flowers (red, blue, yellow, white), tall grass, and dead bushes in appropriate biomes
- **Waterways (waterways.rs)**: Added vegetation along water channel banks using deterministic RNG
- **Leisure (leisure.rs)**: Increased vegetation diversity in parks with tall grass, large ferns, and park benches (oak stairs)
- **Buildings (buildings.rs)**: Added exterior sea lantern lighting along building perimeters for structures taller than 3 blocks

**Block Definitions (block_definitions.rs)**
- Added WHITE_BANNER block definition (ID 249) with proper default rotation property

**Bedrock Compatibility (bedrock_block_map.rs)**
- Added mapping for white banner to Bedrock's standing_banner block

## Implementation Details
- Surface randomization uses `coord_rng()` for deterministic, coordinate-based variation ensuring consistency across world reloads
- Sidewalks are only placed at ground level (y=0) and not for elevated/bridge roads
- Banner rotation is calculated from road direction using atan2 and converted to Minecraft's 0-15 rotation scale
- All vegetation additions use existing RNG patterns and probability distributions to maintain natural appearance

https://claude.ai/code/session_01PWbzuRzomzkkBfQwuxnGv1