### PR TITLE
fix: show user-friendly error messages for Overpass API HTTP failures

### DIFF
--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -194,7 +194,9 @@ pub fn fetch_data_from_overpass(
                         return Err(error);
                     }
 
-                    eprintln!("Request failed: {error}");
+                    if download_method != "requests" {
+                        eprintln!("Request failed: {error}");
+                    }
                     println!("Switching to fallback server...");
                     url = fallback_api_servers.choose(&mut rand::rng()).unwrap();
                     attempt += 1;


### PR DESCRIPTION
Replace the generic "Received response code: 403" with actionable messages: 403 → "Server overloaded, please try again", 429 → rate limit hint, 5xx → "temporarily unavailable". Also raise the GUI error truncation limit from 35 to 60 chars so messages are no longer cut off, and log the actual error before switching to the fallback server.