### PR TITLE
fix: set consistent User-Agent header on all HTTP clients

### DIFF
--- a/src/elevation_data.rs
+++ b/src/elevation_data.rs
@@ -321,7 +321,10 @@ pub fn fetch_elevation_data(
     }
 
     // Create a shared HTTP client for connection pooling
-    let client = reqwest::blocking::Client::new();
+    let client = reqwest::blocking::Client::builder()
+        .user_agent(format!("arnis/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| e.to_string())?;
 
     // Download tiles in parallel with limited concurrency to be respectful to AWS
     let num_tiles = tiles.len();

--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 fn download_with_reqwest(url: &str, query: &str) -> Result<String, Box<dyn std::error::Error>> {
     let client: Client = ClientBuilder::new()
         .timeout(Duration::from_secs(360))
+        .user_agent(format!("arnis/{}", env!("CARGO_PKG_VERSION")))
         .build()?;
 
     let response: Result<reqwest::blocking::Response, reqwest::Error> =
@@ -253,11 +254,14 @@ pub fn fetch_data_from_overpass(
 
 /// Fetches a short area name using Nominatim for the given lat/lon
 pub fn fetch_area_name(lat: f64, lon: f64) -> Result<Option<String>, Box<dyn std::error::Error>> {
-    let client = Client::builder().timeout(Duration::from_secs(20)).build()?;
+    let client = Client::builder()
+        .timeout(Duration::from_secs(20))
+        .user_agent(format!("arnis/{}", env!("CARGO_PKG_VERSION")))
+        .build()?;
 
     let url = format!("https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat={lat}&lon={lon}&addressdetails=1");
 
-    let resp = client.get(&url).header("User-Agent", "arnis-rust").send()?;
+    let resp = client.get(&url).send()?;
 
     if !resp.status().is_success() {
         return Ok(None);

--- a/src/version_check.rs
+++ b/src/version_check.rs
@@ -11,13 +11,13 @@ const REMOTE_CARGO_TOML_URL: &str =
 /// Fetches the latest version from the remote Cargo.toml file and compares it with the local version.
 /// Returns `true` if a newer version is available, `false` otherwise.
 pub fn check_for_updates() -> Result<bool, Box<dyn Error>> {
-    let client: Client = Client::new();
+    let client: Client = Client::builder()
+        .user_agent(format!("arnis/{}", env!("CARGO_PKG_VERSION")))
+        .build()?;
 
-    // Fetch the remote Cargo.toml file with a User-Agent header
-    let response: Result<reqwest::blocking::Response, ReqwestError> = client
-        .get(REMOTE_CARGO_TOML_URL)
-        .header("User-Agent", "arnis-client")
-        .send();
+    // Fetch the remote Cargo.toml file
+    let response: Result<reqwest::blocking::Response, ReqwestError> =
+        client.get(REMOTE_CARGO_TOML_URL).send();
 
     match response {
         Ok(res) => {


### PR DESCRIPTION
All outgoing HTTP requests now identify as arnis/<version> via the client builder, complying with OSM tile usage policy and Overpass API guidelines. Removes ad-hoc per-request User-Agent headers in favor of a single client-level setting.