### PR TITLE
fix: prevent flushed regions from being overwritten by cross-region w…

### DIFF
--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -934,30 +934,42 @@ pub fn generate_world_with_options(
             }
         }
 
-        // Flush any region columns that are now fully written.
+        // Flush completed region columns to disk to free memory.
         //
-        // A region spans 32 chunks (512 blocks) along each axis. Once the
-        // chunk_x loop advances past the last chunk_x in a region column, no
-        // further ground writes (or element writes, which finished earlier) will
-        // target that region. It is safe to serialize it to disk and free its
-        // memory.
+        // A region spans 32 chunks (512 blocks) along each axis. We delay the
+        // flush by one chunk past the region boundary so that cross-region
+        // writes (tree canopies can extend up to 3 blocks into the previous
+        // region) are captured before serialization.
         //
-        // Two cases trigger a flush for region_x:
-        //   1. chunk_x is the last chunk in its region (chunk_x & 31 == 31)
-        //   2. chunk_x is the last chunk in the bounding box (may be mid-region)
-        //
-        // In both cases every region_z column that overlaps the bounding box is
-        // flushed, because the chunk_z loop already completed all z-writes.
-        let region_x = chunk_x >> 5;
-        let is_last_chunk_in_region = (chunk_x & 31) == 31;
+        // Two cases trigger a flush:
+        //   1. chunk_x just crossed into a new region (first chunk of region N
+        //      means region N-1 is complete, including any spill from this chunk).
+        //   2. chunk_x is the last chunk in the bounding box — flush the current
+        //      region since there will be no next iteration.
+        let curr_region_x = chunk_x >> 5;
         let is_last_chunk_in_bbox = chunk_x == max_chunk_x;
 
-        if is_last_chunk_in_region || is_last_chunk_in_bbox {
+        // Detect region boundary crossing: the previous chunk belonged to a
+        // different region, so that region is now safe to flush.
+        if chunk_x > min_chunk_x {
+            let prev_region_x = (chunk_x - 1) >> 5;
+            if prev_region_x != curr_region_x {
+                let min_region_z = min_chunk_z >> 5;
+                let max_region_z = max_chunk_z >> 5;
+                for region_z in min_region_z..=max_region_z {
+                    if let Err(e) = editor.flush_region(prev_region_x, region_z) {
+                        return Err(e.to_string());
+                    }
+                }
+            }
+        }
+
+        // Last chunk in bbox: flush the current (and possibly only) region.
+        if is_last_chunk_in_bbox {
             let min_region_z = min_chunk_z >> 5;
             let max_region_z = max_chunk_z >> 5;
-
             for region_z in min_region_z..=max_region_z {
-                if let Err(e) = editor.flush_region(region_x, region_z) {
+                if let Err(e) = editor.flush_region(curr_region_x, region_z) {
                     return Err(e.to_string());
                 }
             }

--- a/src/world_editor/common.rs
+++ b/src/world_editor/common.rs
@@ -10,7 +10,7 @@ const MIN_Y: i32 = -64;
 /// Maximum Y coordinate in Minecraft (1.18+)
 const MAX_Y: i32 = 319;
 use fastnbt::{LongArray, Value};
-use fnv::FnvHashMap;
+use fnv::{FnvHashMap, FnvHashSet};
 use serde::{Deserialize, Serialize};
 
 /// Chunk structure for Java Edition NBT format
@@ -396,9 +396,34 @@ impl RegionToModify {
 #[derive(Default)]
 pub(crate) struct WorldToModify {
     pub regions: FnvHashMap<(i32, i32), RegionToModify>,
+    /// Regions that have been flushed to disk and removed from memory.
+    /// Used at save time to purge any stale re-created entries so they
+    /// don't overwrite the correct .mca files on disk.
+    flushed_regions: FnvHashSet<(i32, i32)>,
 }
 
 impl WorldToModify {
+    /// Mark a region as flushed. Any stale re-created entries (from cross-region
+    /// writes like tree canopies) will be purged before the final save.
+    #[inline]
+    pub fn mark_flushed(&mut self, region_x: i32, region_z: i32) {
+        self.flushed_regions.insert((region_x, region_z));
+    }
+
+    /// Remove any regions that were re-created after being flushed to disk.
+    ///
+    /// Cross-region writes (e.g. tree canopies extending past a region boundary)
+    /// can re-create an already-flushed region via `entry().or_default()`. These
+    /// stale entries contain only the spilled blocks — not the full region data.
+    /// Purging them before save prevents overwriting the correct `.mca` files.
+    pub fn purge_stale_regions(&mut self) {
+        if self.flushed_regions.is_empty() {
+            return;
+        }
+        self.regions
+            .retain(|key, _| !self.flushed_regions.contains(key));
+    }
+
     #[inline]
     pub fn get_or_create_region(&mut self, x: i32, z: i32) -> &mut RegionToModify {
         self.regions.entry((x, z)).or_default()

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -748,6 +748,7 @@ impl<'a> WorldEditor<'a> {
             return Ok(());
         }
 
+        self.world.mark_flushed(region_x, region_z);
         if let Some(mut region) = self.world.regions.remove(&(region_x, region_z)) {
             // Compact before serializing. In the original code path, save() calls
             // self.world.compact_sections() globally before save_java(). With
@@ -823,6 +824,12 @@ impl<'a> WorldEditor<'a> {
                 WorldFormat::BedrockMcWorld => "Bedrock Edition (.mcworld)",
             }
         );
+
+        // Drop any regions that were re-created after being flushed to disk
+        // (e.g. tree canopy leaves spilling across a region boundary). These
+        // stale entries contain only the spilled blocks and must not overwrite
+        // the correct .mca files that were already written during ground generation.
+        self.world.purge_stale_regions();
 
         // Compact sections before saving: collapses uniform Full(Vec) sections
         // (e.g. all-STONE from --fillground) back to Uniform, freeing ~4 KiB each.


### PR DESCRIPTION
…rites

Two fixes for the incremental region flushing introduced in PR #793:

1. Delay flush by one chunk past region boundaries so tree canopies (up to 3 blocks spill radius) are fully written before serialization.

2. Track flushed regions and purge any stale re-created entries at save time, preventing near-empty regions from overwriting correct .mca files.

No hot-path changes — the tracking is a single HashSet insert per flush, and purge runs once at save time.