### PR TITLE
perf: optimize bedrock save speed + fix block direction mappings

### DIFF
--- a/src/bedrock_block_map.rs
+++ b/src/bedrock_block_map.rs
@@ -1442,4 +1442,56 @@ mod tests {
             Some(BedrockBlockStateValue::Bool(false))
         ));
     }
+
+    #[test]
+    fn test_rail_shape_conversion() {
+        use crate::block_definitions::RAIL;
+
+        let cases = [
+            ("north_south", 0),
+            ("east_west", 1),
+            ("ascending_east", 2),
+            ("ascending_west", 3),
+            ("ascending_north", 4),
+            ("ascending_south", 5),
+            ("south_east", 6),
+            ("south_west", 7),
+            ("north_west", 8),
+            ("north_east", 9),
+        ];
+
+        for (shape, expected_direction) in cases {
+            let mut props = std::collections::HashMap::new();
+            props.insert(
+                "shape".to_string(),
+                fastnbt::Value::String(shape.to_string()),
+            );
+            let java_props = fastnbt::Value::Compound(props);
+
+            let bedrock = to_bedrock_block_with_properties(RAIL, Some(&java_props));
+            assert_eq!(bedrock.name, "minecraft:rail");
+            assert!(
+                matches!(
+                    bedrock.states.get("rail_direction"),
+                    Some(BedrockBlockStateValue::Int(d)) if *d == expected_direction
+                ),
+                "shape={shape}: expected rail_direction={expected_direction}, got {:?}",
+                bedrock.states.get("rail_direction")
+            );
+        }
+    }
+
+    #[test]
+    fn test_rail_default_without_properties() {
+        use crate::block_definitions::RAIL;
+
+        let bedrock = to_bedrock_block_with_properties(RAIL, None);
+        assert_eq!(bedrock.name, "minecraft:rail");
+        // RAIL (id=66) has no built-in properties, so falls back to
+        // to_bedrock_block which hardcodes rail_direction=0
+        assert!(matches!(
+            bedrock.states.get("rail_direction"),
+            Some(BedrockBlockStateValue::Int(0))
+        ));
+    }
 }

--- a/src/world_editor/bedrock.rs
+++ b/src/world_editor/bedrock.rs
@@ -1145,8 +1145,65 @@ struct BedrockLevelDat {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bedrockrs_level::level::db_interface::bedrock_key::ChunkKey;
     use serde_json::Value;
     use zip::ZipArchive;
+
+    /// Build a key using the canonical `ChunkKey` path (the source of truth from
+    /// `bedrockrs_level`) so we can compare against `build_chunk_key_bytes`.
+    fn canonical_key(chunk_key: ChunkKey) -> Vec<u8> {
+        // Replicates RustyDBInterface::build_key without needing a DB instance
+        use bedrockrs_level::level::db_interface::db::LevelDBKey;
+        use std::io::Cursor;
+        let mut key_bytes: Vec<u8> = vec![0; chunk_key.estimate_size()];
+        let mut buff: Cursor<&mut [u8]> = Cursor::new(&mut key_bytes);
+        chunk_key.write_key(&mut buff);
+        key_bytes
+    }
+
+    #[test]
+    fn build_chunk_key_bytes_matches_canonical_version() {
+        let pos = Vec2::new(5, -3);
+        let ours = build_chunk_key_bytes(pos, Dimension::Overworld, KeyTypeTag::Version, None);
+        let canonical = canonical_key(ChunkKey::chunk_marker(pos, Dimension::Overworld));
+        assert_eq!(ours, canonical, "Version key mismatch");
+    }
+
+    #[test]
+    fn build_chunk_key_bytes_matches_canonical_data3d() {
+        let pos = Vec2::new(-12, 7);
+        let ours = build_chunk_key_bytes(pos, Dimension::Overworld, KeyTypeTag::Data3D, None);
+        let canonical = canonical_key(ChunkKey::data3d(pos, Dimension::Overworld));
+        assert_eq!(ours, canonical, "Data3D key mismatch");
+    }
+
+    #[test]
+    fn build_chunk_key_bytes_matches_canonical_subchunk() {
+        let pos = Vec2::new(100, -50);
+        // Positive y index
+        let ours = build_chunk_key_bytes(
+            pos,
+            Dimension::Overworld,
+            KeyTypeTag::SubChunkPrefix,
+            Some(4),
+        );
+        let canonical = canonical_key(ChunkKey::new_subchunk(pos, Dimension::Overworld, 4));
+        assert_eq!(ours, canonical, "SubChunk y=4 key mismatch");
+    }
+
+    #[test]
+    fn build_chunk_key_bytes_matches_canonical_negative_y() {
+        let pos = Vec2::new(0, 0);
+        // Negative y index (e.g. y = -4 for sections below y=0)
+        let ours = build_chunk_key_bytes(
+            pos,
+            Dimension::Overworld,
+            KeyTypeTag::SubChunkPrefix,
+            Some(-4),
+        );
+        let canonical = canonical_key(ChunkKey::new_subchunk(pos, Dimension::Overworld, -4));
+        assert_eq!(ours, canonical, "SubChunk y=-4 key mismatch");
+    }
 
     #[test]
     fn writes_mcworld_package_with_metadata() {


### PR DESCRIPTION
Performance:
- Eliminate format!("{:?}") string allocation in palette hot loop (4096x per section) by using BedrockBlock directly as HashMap key with proper Hash/Eq impl via BTreeMap for deterministic ordering
- Merge two LevelDB passes into one: blocks + entities written in a single DB session instead of open→write→close→reopen→write→close
- Remove RustyDBInterface dependency, use raw DB with build_chunk_key_bytes

Bug fixes:
- Fix trapdoor/bed direction mapping: use 0=east,1=west,2=south,3=north (matching stairs weirdo_direction) instead of incorrect values
- Fix rail shape→rail_direction conversion: was completely missing, all rails defaulted to north-south. Now converts all 10 shapes including curved rails (with corrected north curve values 8=NW, 9=NE)