### PR TITLE
feature: Taller worlds support, WIP.

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -37,7 +37,7 @@ pub struct Args {
     pub scale: f64,
 
     /// Ground level to use in the Minecraft world
-    #[arg(long, default_value_t = -62)]
+    #[arg(long, default_value_t = -2030)]
     pub ground_level: i32,
 
     /// Enable terrain (optional)

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -17,6 +17,8 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+pub const MIN_Y: i32 = -2030;
+
 /// Generation options that can be passed separately from CLI Args
 #[derive(Clone)]
 pub struct GenerationOptions {
@@ -155,6 +157,7 @@ pub fn generate_world_with_options(
                         args,
                         &flood_fill_cache,
                         &building_footprints,
+                        &ground,
                     );
                 } else if way.tags.contains_key("natural") {
                     natural::generate_natural(
@@ -163,6 +166,7 @@ pub fn generate_world_with_options(
                         args,
                         &flood_fill_cache,
                         &building_footprints,
+                        &ground,
                     );
                 } else if way.tags.contains_key("amenity") {
                     amenities::generate_amenities(&mut editor, &element, args, &flood_fill_cache);
@@ -218,6 +222,7 @@ pub fn generate_world_with_options(
                         args,
                         &flood_fill_cache,
                         &building_footprints,
+                        &ground,
                     );
                 } else if node.tags.contains_key("amenity") {
                     amenities::generate_amenities(&mut editor, &element, args, &flood_fill_cache);
@@ -272,6 +277,7 @@ pub fn generate_world_with_options(
                         args,
                         &flood_fill_cache,
                         &building_footprints,
+                        &ground,
                     );
                 } else if rel.tags.contains_key("landuse") {
                     landuse::generate_landuse_from_relation(
@@ -280,6 +286,7 @@ pub fn generate_world_with_options(
                         args,
                         &flood_fill_cache,
                         &building_footprints,
+                        &ground,
                     );
                 } else if rel.tags.get("leisure") == Some(&"park".to_string()) {
                     leisure::generate_leisure_from_relation(

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -17,8 +17,6 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-pub const MIN_Y: i32 = -2030;
-
 /// Generation options that can be passed separately from CLI Args
 #[derive(Clone)]
 pub struct GenerationOptions {

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -172,11 +172,13 @@ pub fn generate_landuse(
                 if editor.check_for_block(x, 0, z, Some(&[GRASS_BLOCK])) {
                     let random_choice: i32 = rng.random_range(0..30);
                     if random_choice == 20 {
-                        let tree_type = match ground.level(XZPoint::new(x, z)) > crate::world_editor::CONIFERS_ONLY_ALTITUDE {
+                        let tree_type = match ground.level(XZPoint::new(x, z))
+                            > crate::world_editor::CONIFERS_ONLY_ALTITUDE
+                        {
                             true => TreeType::Spruce,
                             false => *trees_ok_to_generate
-                                     .choose(&mut rng)
-                                     .unwrap_or(&TreeType::Oak),
+                                .choose(&mut rng)
+                                .unwrap_or(&TreeType::Oak),
                         };
                         Tree::create_of_type(
                             editor,

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -1,9 +1,11 @@
 use crate::args::Args;
 use crate::block_definitions::*;
 use crate::bresenham::bresenham_line;
+use crate::coordinate_system::cartesian::XZPoint;
 use crate::deterministic_rng::element_rng;
 use crate::element_processing::tree::{Tree, TreeType};
 use crate::floodfill_cache::{BuildingFootprintBitmap, FloodFillCache};
+use crate::ground::Ground;
 use crate::osm_parser::{ProcessedMemberRole, ProcessedRelation, ProcessedWay};
 use crate::world_editor::WorldEditor;
 use rand::prelude::IndexedRandom;
@@ -15,6 +17,7 @@ pub fn generate_landuse(
     args: &Args,
     flood_fill_cache: &FloodFillCache,
     building_footprints: &BuildingFootprintBitmap,
+    ground: &std::sync::Arc<Ground>,
 ) {
     // Determine block type based on landuse tag
     let binding: String = "".to_string();
@@ -169,9 +172,12 @@ pub fn generate_landuse(
                 if editor.check_for_block(x, 0, z, Some(&[GRASS_BLOCK])) {
                     let random_choice: i32 = rng.random_range(0..30);
                     if random_choice == 20 {
-                        let tree_type = *trees_ok_to_generate
-                            .choose(&mut rng)
-                            .unwrap_or(&TreeType::Oak);
+                        let tree_type = match ground.level(XZPoint::new(x, z)) > crate::world_editor::CONIFERS_ONLY_ALTITUDE {
+                            true => TreeType::Spruce,
+                            false => *trees_ok_to_generate
+                                     .choose(&mut rng)
+                                     .unwrap_or(&TreeType::Oak),
+                        };
                         Tree::create_of_type(
                             editor,
                             (x, 1, z),
@@ -394,6 +400,7 @@ pub fn generate_landuse_from_relation(
     args: &Args,
     flood_fill_cache: &FloodFillCache,
     building_footprints: &BuildingFootprintBitmap,
+    ground: &std::sync::Arc<Ground>,
 ) {
     if rel.tags.contains_key("landuse") {
         // Process each outer member way individually using cached flood fill.
@@ -414,6 +421,7 @@ pub fn generate_landuse_from_relation(
                     args,
                     flood_fill_cache,
                     building_footprints,
+                    ground,
                 );
             }
         }

--- a/src/element_processing/natural.rs
+++ b/src/element_processing/natural.rs
@@ -4,6 +4,7 @@ use crate::bresenham::bresenham_line;
 use crate::deterministic_rng::element_rng;
 use crate::element_processing::tree::{Tree, TreeType};
 use crate::floodfill_cache::{BuildingFootprintBitmap, FloodFillCache};
+use crate::ground::Ground;
 use crate::osm_parser::{ProcessedElement, ProcessedMemberRole, ProcessedRelation, ProcessedWay};
 use crate::world_editor::WorldEditor;
 use rand::{prelude::IndexedRandom, Rng};
@@ -14,6 +15,7 @@ pub fn generate_natural(
     args: &Args,
     flood_fill_cache: &FloodFillCache,
     building_footprints: &BuildingFootprintBitmap,
+    ground: &std::sync::Arc<Ground>,
 ) {
     if let Some(natural_type) = element.tags().get("natural") {
         if natural_type == "tree" {
@@ -63,6 +65,9 @@ pub fn generate_natural(
                             trees_ok_to_generate.push(TreeType::Birch);
                         }
                     }
+                } else if ground.level(node.xz()) > crate::world_editor::CONIFERS_ONLY_ALTITUDE {
+                    // If it's high up (roughly >2.5km at 4km max), only generate spruces if not explicitly spec'd.
+                    trees_ok_to_generate.push(TreeType::Spruce);
                 } else {
                     trees_ok_to_generate.push(TreeType::Oak);
                     trees_ok_to_generate.push(TreeType::Spruce);
@@ -578,6 +583,7 @@ pub fn generate_natural_from_relation(
     args: &Args,
     flood_fill_cache: &FloodFillCache,
     building_footprints: &BuildingFootprintBitmap,
+    ground: &std::sync::Arc<Ground>,
 ) {
     if rel.tags.contains_key("natural") {
         // Process each outer member way individually using cached flood fill.
@@ -598,6 +604,7 @@ pub fn generate_natural_from_relation(
                     args,
                     flood_fill_cache,
                     building_footprints,
+                    ground,
                 );
             }
         }

--- a/src/elevation_data.rs
+++ b/src/elevation_data.rs
@@ -637,7 +637,7 @@ fn apply_gaussian_blur(heights: &[Vec<f64>], sigma: f64) -> Vec<Vec<f64>> {
                 *val = match *val > THREEQRT_MAXY {
                     false => sum / weight_sum,
                     // For VERY high highs, *sharpen* peaks with the gaussian kernel instead!
-                    true => *val * 2. - (sum / weight_sum)
+                    true => *val * 2. - (sum / weight_sum),
                 }
             }
             temp
@@ -667,7 +667,7 @@ fn apply_gaussian_blur(heights: &[Vec<f64>], sigma: f64) -> Vec<Vec<f64>> {
                 *val = match *val > THREEQRT_MAXY {
                     false => sum / weight_sum,
                     // For VERY high highs, *sharpen* peaks with the gaussian kernel instead!
-                    true => *val * 2. - (sum / weight_sum)
+                    true => *val * 2. - (sum / weight_sum),
                 }
             }
             blurred_column

--- a/src/elevation_data.rs
+++ b/src/elevation_data.rs
@@ -8,8 +8,10 @@ use image::Rgb;
 use rayon::prelude::*;
 use std::path::{Path, PathBuf};
 
+/// Minimum Y coordinate in Minecraft (build height limit)
+pub const MIN_Y: i32 = -2031;
 /// Maximum Y coordinate in Minecraft (build height limit)
-const MAX_Y: i32 = 319;
+pub const MAX_Y: i32 = 2031;
 /// AWS S3 Terrarium tiles endpoint (no API key required)
 const AWS_TERRARIUM_URL: &str =
     "https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png";
@@ -528,7 +530,7 @@ pub fn fetch_elevation_data(
 
     // Calculate available Y range in Minecraft (from ground_level to MAX_Y)
     // Leave a buffer at the top for buildings, trees, and other structures
-    const TERRAIN_HEIGHT_BUFFER: i32 = 15;
+    const TERRAIN_HEIGHT_BUFFER: i32 = 32;
     let available_y_range: f64 = (MAX_Y - TERRAIN_HEIGHT_BUFFER - ground_level) as f64;
 
     // Determine final height scale:
@@ -615,6 +617,7 @@ fn apply_gaussian_blur(heights: &[Vec<f64>], sigma: f64) -> Vec<Vec<f64>> {
 
     let height_len = heights.len();
     let width = heights[0].len();
+    const THREEQRT_MAXY: f64 = 0.75 * (MAX_Y as f64);
 
     // Horizontal pass - parallelize across rows (each row is independent)
     let after_horizontal: Vec<Vec<f64>> = heights
@@ -631,7 +634,11 @@ fn apply_gaussian_blur(heights: &[Vec<f64>], sigma: f64) -> Vec<Vec<f64>> {
                         weight_sum += k;
                     }
                 }
-                *val = sum / weight_sum;
+                *val = match *val > THREEQRT_MAXY {
+                    false => sum / weight_sum,
+                    // For VERY high highs, *sharpen* peaks with the gaussian kernel instead!
+                    true => *val * 2. - (sum / weight_sum)
+                }
             }
             temp
         })
@@ -657,7 +664,11 @@ fn apply_gaussian_blur(heights: &[Vec<f64>], sigma: f64) -> Vec<Vec<f64>> {
                         weight_sum += k;
                     }
                 }
-                *val = sum / weight_sum;
+                *val = match *val > THREEQRT_MAXY {
+                    false => sum / weight_sum,
+                    // For VERY high highs, *sharpen* peaks with the gaussian kernel instead!
+                    true => *val * 2. - (sum / weight_sum)
+                }
             }
             blurred_column
         })

--- a/src/ground_generation.rs
+++ b/src/ground_generation.rs
@@ -23,12 +23,12 @@ use crate::block_definitions::{
 };
 use crate::coordinate_system::cartesian::{XZBBox, XZPoint};
 use crate::element_processing::tree;
+use crate::elevation_data::MIN_Y;
 use crate::floodfill_cache::BuildingFootprintBitmap;
 use crate::ground::Ground;
 use crate::land_cover;
 use crate::progress::emit_gui_progress_update;
 use crate::world_editor::WorldEditor;
-use crate::world_editor::MIN_Y;
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
 use rand::Rng;

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -883,10 +883,10 @@ async function startGeneration() {
     var scale = parseFloat(document.getElementById("scale-value-slider").value);
     // var ground_level = parseInt(document.getElementById("ground-level").value, 10);
     // DEPRECATED: Ground level input removed from UI
-    var ground_level = -62;
+    var ground_level = -2030;
 
     // Validate ground_level
-    ground_level = isNaN(ground_level) || ground_level < -62 ? -62 : ground_level;
+    ground_level = isNaN(ground_level) || ground_level < -2030 ? -2030 : ground_level;
 
     // Get telemetry consent (defaults to false if not set)
     const telemetryConsent = window.getTelemetryConsent ? window.getTelemetryConsent() : false;

--- a/src/world_editor/common.rs
+++ b/src/world_editor/common.rs
@@ -4,11 +4,12 @@
 //! before they are written to either Java or Bedrock format.
 
 use crate::block_definitions::*;
+// We need to use build height limits - the world will clip the geometry above the limit even if MC can index it in theory.
+use crate::elevation_data::{MIN_Y, MAX_Y};
+/// The rough altitude above which deciduous trees stop growing naturally.
+/// Can be overridden by explicit spec, but will be used to infer biome if it's not specified.
+pub(crate) const CONIFERS_ONLY_ALTITUDE: i32 = 3 * (MAX_Y - MIN_Y) / 2;
 
-/// Minimum Y coordinate in Minecraft (1.18+)
-pub const MIN_Y: i32 = -64;
-/// Maximum Y coordinate in Minecraft (1.18+)
-const MAX_Y: i32 = 319;
 use fastnbt::{LongArray, Value};
 use fnv::FnvHashMap;
 use serde::{Deserialize, Serialize};

--- a/src/world_editor/common.rs
+++ b/src/world_editor/common.rs
@@ -5,7 +5,7 @@
 
 use crate::block_definitions::*;
 // We need to use build height limits - the world will clip the geometry above the limit even if MC can index it in theory.
-use crate::elevation_data::{MIN_Y, MAX_Y};
+use crate::elevation_data::{MAX_Y, MIN_Y};
 /// The rough altitude above which deciduous trees stop growing naturally.
 /// Can be overridden by explicit spec, but will be used to infer biome if it's not specified.
 pub(crate) const CONIFERS_ONLY_ALTITUDE: i32 = 3 * (MAX_Y - MIN_Y) / 2;

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -17,7 +17,7 @@ pub mod bedrock;
 
 // Re-export common types used internally
 pub(crate) use common::WorldToModify;
-pub use common::MIN_Y;
+pub(crate) use common::{CONIFERS_ONLY_ALTITUDE};
 
 #[cfg(feature = "bedrock")]
 pub(crate) use bedrock::{BedrockSaveError, BedrockWriter};

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -17,7 +17,7 @@ pub mod bedrock;
 
 // Re-export common types used internally
 pub(crate) use common::WorldToModify;
-pub(crate) use common::{CONIFERS_ONLY_ALTITUDE};
+pub(crate) use common::CONIFERS_ONLY_ALTITUDE;
 
 #[cfg(feature = "bedrock")]
 pub(crate) use bedrock::{BedrockSaveError, BedrockWriter};


### PR DESCRIPTION
**fix**: Invalid outliers are no longer throwing off the result due to being counted for min/max height aggregations 
**feature**: Adds a ref to Ground to Landuse/Natural processors to expose height data to the generator logic 
**refactor**: MIN_Y/MAX_Y are now exposed as common crate constants instead of being redefined in multiple places 
**tweak**: Deciduous trees should not generate at mountain altitudes by default 
**tweak**: Default min/max levels are set to 4k heigh worlds (WIP, will likely need a revert)