### PR TITLE
Prevent tree canopies from clipping into buildings

### DIFF
--- a/src/element_processing/tree.rs
+++ b/src/element_processing/tree.rs
@@ -112,6 +112,9 @@ const ACACIA_LEAVES_FILL: [(Coord, Coord); 5] = [
 
 //////////////////////////////////////////////////
 
+/// Maximum horizontal canopy radius used by the predefined tree patterns.
+const MAX_CANOPY_RADIUS: i32 = 3;
+
 /// Helper function to set blocks in various patterns.
 fn round(editor: &mut WorldEditor, material: Block, (x, y, z): Coord, block_pattern: &[Coord]) {
     for (i, j, k) in block_pattern {
@@ -140,6 +143,26 @@ pub struct Tree<'a> {
 }
 
 impl Tree<'_> {
+    fn canopy_might_intersect_building(
+        x: i32,
+        z: i32,
+        building_footprints: Option<&BuildingFootprintBitmap>,
+    ) -> bool {
+        let Some(footprints) = building_footprints else {
+            return false;
+        };
+
+        for check_x in (x - MAX_CANOPY_RADIUS)..=(x + MAX_CANOPY_RADIUS) {
+            for check_z in (z - MAX_CANOPY_RADIUS)..=(z + MAX_CANOPY_RADIUS) {
+                if footprints.contains(check_x, check_z) {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
     /// Creates a tree at the specified coordinates.
     ///
     /// # Arguments
@@ -208,6 +231,8 @@ impl Tree<'_> {
         blacklist.push(WATER);
 
         let tree = Self::get_tree(tree_type);
+        let check_canopy_collision =
+            Self::canopy_might_intersect_building(x, z, building_footprints);
 
         // Build the logs
         editor.fill_blocks(
@@ -224,23 +249,59 @@ impl Tree<'_> {
 
         // Fill in the leaves
         for ((i1, j1, k1), (i2, j2, k2)) in tree.leaves_fill {
-            editor.fill_blocks(
-                tree.leaves_block,
-                x + i1,
-                y + j1,
-                z + k1,
-                x + i2,
-                y + j2,
-                z + k2,
-                None,
-                None,
-            );
+            if check_canopy_collision {
+                for leaf_x in (x + i1)..=(x + i2) {
+                    for leaf_y in (y + j1)..=(y + j2) {
+                        for leaf_z in (z + k1)..=(z + k2) {
+                            if building_footprints.is_none_or(|fp| !fp.contains(leaf_x, leaf_z)) {
+                                editor.set_block(
+                                    tree.leaves_block,
+                                    leaf_x,
+                                    leaf_y,
+                                    leaf_z,
+                                    None,
+                                    None,
+                                );
+                            }
+                        }
+                    }
+                }
+            } else {
+                editor.fill_blocks(
+                    tree.leaves_block,
+                    x + i1,
+                    y + j1,
+                    z + k1,
+                    x + i2,
+                    y + j2,
+                    z + k2,
+                    None,
+                    None,
+                );
+            }
         }
 
         // Do the three rounds
         for (round_range, round_pattern) in tree.round_ranges.iter().zip(ROUND_PATTERNS) {
             for offset in round_range {
-                round(editor, tree.leaves_block, (x, y + offset, z), round_pattern);
+                if check_canopy_collision {
+                    for &(i, j, k) in round_pattern {
+                        let leaf_x = x + i;
+                        let leaf_z = z + k;
+                        if building_footprints.is_none_or(|fp| !fp.contains(leaf_x, leaf_z)) {
+                            editor.set_block(
+                                tree.leaves_block,
+                                leaf_x,
+                                y + offset + j,
+                                leaf_z,
+                                None,
+                                None,
+                            );
+                        }
+                    }
+                } else {
+                    round(editor, tree.leaves_block, (x, y + offset, z), round_pattern);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR fixes a collision bug where tree canopies could extend into building interiors, as reported in #656.

Previously, tree generation only checked whether the trunk base `(x, z)` was inside a building footprint. That prevented trees from spawning fully inside buildings, but it did not prevent leaves from expanding horizontally into nearby structures.

This change keeps the existing fast path for normal tree generation, and adds a guarded slow path only when a canopy may intersect a building footprint.

## Before / After

### Before
- Trees were skipped only if the trunk base was inside a building footprint
- Leaves could still extend into nearby buildings
- This was most visible when a tree spawned just outside a wall

<img width="405" height="318" alt="image" src="https://github.com/user-attachments/assets/53377781-2aad-4cc6-a2af-1e592482d56c" />

### After
- Trees still use the normal fast path when no nearby building collision is possible
- If the canopy may overlap a building footprint, leaf placement is checked per block
- Leaves no longer enter building interiors through walls

<img width="435" height="347" alt="image" src="https://github.com/user-attachments/assets/3e831829-e6cc-4287-9fa7-ce9e092cae8a" />

## Root Cause

The tree generation logic already had a building footprint check for the trunk base:

`src/element_processing/tree.rs`

But leaf placement used unconditional canopy fill and round-pattern placement, so the trunk could be outside a building while the canopy still crossed into it.

## What Changed

### Fast / slow path canopy placement
- Added a canopy proximity pre-check using a local maximum canopy radius
- Trees that are clearly far from buildings keep the original fast placement path
- Trees near buildings switch to a slower but safe path that checks footprint overlap per leaf block

### Scope of fix
- Leaf column placement is now collision-aware when needed
- Round-pattern canopy placement is now collision-aware when needed
- Trunk placement logic is unchanged

## Testing

### Build validation
- [x] `cargo check`

### Manual validation
- [x] Tree outside building still generates normally
- [x] Tree trunk inside building footprint is skipped
- [x] Tree canopy near a building no longer places leaves into interior space
- [x] Non-adjacent trees still use the original fast path