### PR TITLE
Don't generate zebra crossings for unmarked crossings

### DIFF
--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -397,6 +397,17 @@ fn generate_highways_internal(
                             (y, false)
                         };
 
+                        // Check if this is a marked zebra crossing
+                        let is_zebra_crossing = highway_type == "footway"
+                            && element.tags().get("footway")
+                                == Some(&"crossing".to_string())
+                            && !matches!(
+                                element.tags().get("crossing").map(|s| s.as_str()),
+                                Some("no" | "unmarked")
+                            )
+                            && element.tags().get("crossing:markings").map(|s| s.as_str())
+                                != Some("no");
+
                         // Draw the road surface for the entire width
                         for dx in -block_range..=block_range {
                             for dz in -block_range..=block_range {
@@ -404,20 +415,7 @@ fn generate_highways_internal(
                                 let set_z: i32 = z + dz;
 
                                 // Zebra crossing logic
-                                if highway_type == "footway"
-                                    && element.tags().get("footway")
-                                        == Some(&"crossing".to_string())
-                                {
-                                    // Check if crossing should have markings
-                                    let crossing = element.tags().get("crossing");
-                                    let crossing_markings = element.tags().get("crossing:markings");
-                                    let is_unmarked = crossing == Some(&"no".to_string())
-                                        || crossing == Some(&"unmarked".to_string())
-                                        || crossing_markings == Some(&"no".to_string());
-
-                                    if is_unmarked {
-                                        continue;
-                                    }
+                                if is_zebra_crossing {
                                     let is_horizontal: bool = (x2 - x1).abs() >= (z2 - z1).abs();
                                     if is_horizontal {
                                         if set_x % 2 < 1 {
@@ -884,3 +882,4 @@ pub fn generate_aeroway(editor: &mut WorldEditor, way: &ProcessedWay, args: &Arg
         previous_node = Some((node.x, node.z));
     }
 }
+


### PR DESCRIPTION
Only generate zebra crossing markings on marked pedestrian crossings. Previously, crosswalks were placed on all footway crossings, including unmarked ones. Now they respect the `crossing=no`, `crossing=unmarked`, and `crossing:markings=no` tags to skip unmarked crossings.