### PR TITLE
Fix map layout to fill window and reduce private.coffee timeout

### DIFF
--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -17,6 +17,13 @@
   --primary-accent-light: #fff2cc;
 }
 
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
 p {
   color: #ececec;
 }
@@ -24,10 +31,12 @@ p {
 .container {
   margin: 0;
   padding-top: 1vh;
+  padding-bottom: 0.5vh;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   text-align: center;
+  height: 100vh;
+  box-sizing: border-box;
 }
 
 .logo {
@@ -47,6 +56,7 @@ p {
 .row {
   display: flex;
   justify-content: center;
+  flex-shrink: 0;
 }
 
 a {
@@ -66,7 +76,8 @@ a:hover {
   justify-content: center;
   align-items: stretch;
   margin-top: 5px;
-  min-height: 70vh;
+  min-height: 420px;
+  flex: 1;
 }
 
 .section {
@@ -210,9 +221,11 @@ button:hover {
 }
 
 .footer {
-  margin-top: 20px;
+  margin-top: 8px;
+  padding-bottom: 6px;
   text-align: center;
   font-size: 0.9em;
+  flex-shrink: 0;
 }
 
 .footer-link {

--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -15,9 +15,13 @@ use std::process::Command;
 use std::time::Duration;
 
 /// Function to download data using reqwest
-fn download_with_reqwest(url: &str, query: &str) -> Result<String, Box<dyn std::error::Error>> {
+fn download_with_reqwest(
+    url: &str,
+    query: &str,
+    timeout_secs: u64,
+) -> Result<String, Box<dyn std::error::Error>> {
     let client: Client = ClientBuilder::new()
-        .timeout(Duration::from_secs(360))
+        .timeout(Duration::from_secs(timeout_secs))
         .user_agent(concat!("arnis/", env!("CARGO_PKG_VERSION")))
         .build()?;
 
@@ -190,12 +194,17 @@ pub fn fetch_data_from_overpass(
         let response: String = 'server_loop: {
             for (i, server) in servers.iter().enumerate() {
                 let url = server;
+                let timeout_secs = if url.contains("private.coffee") {
+                    120
+                } else {
+                    360
+                };
                 println!("Downloading from {url} with method {download_method}...");
                 let result = match download_method {
-                    "requests" => download_with_reqwest(url, &query),
+                    "requests" => download_with_reqwest(url, &query, timeout_secs),
                     "curl" => download_with_curl(url, &query).map_err(|e| e.into()),
                     "wget" => download_with_wget(url, &query).map_err(|e| e.into()),
-                    _ => download_with_reqwest(url, &query), // Default to requests
+                    _ => download_with_reqwest(url, &query, timeout_secs), // Default to requests
                 };
 
                 match result {


### PR DESCRIPTION
- Make map stretch to fill available viewport height when window is maximized, with proper buffer for footer version text
- Remove body default margin and prevent scrollbar overflow
- Reduce Overpass private.coffee fallback server timeout from 360s to 120s