### PR TITLE
Reduce Gaussian blur to preserve mountain terrain detail

### DIFF
--- a/src/elevation_data.rs
+++ b/src/elevation_data.rs
@@ -879,9 +879,9 @@ mod tests {
     }
 
     #[test]
-    fn test_output_sigma_large_bbox_no_regression() {
-        // For large areas, sigma_from_grid ≥ sigma_terrain.
-        // output_sigma = sigma_from_grid — identical to pre-fix behaviour.
+    fn test_output_sigma_large_bbox_grid_dominates() {
+        // For large areas, sigma_from_grid ≥ sigma_terrain,
+        // so output_sigma is determined by the grid-proportional component.
         let zoom: u8 = 15;
         let lat_mid_rad: f64 = 40.705_f64.to_radians();
         let mpp = 2.0 * std::f64::consts::PI * 6_378_137.0 / (2.0_f64.powi(zoom as i32) * 256.0)


### PR DESCRIPTION
The terrain sigma floor (×12) was designed to suppress SRTM rooftop artifacts in dense urban areas (Manhattan), but it flattened mountains into gentle walkable slopes everywhere. Reduce to ×3 (still covers Voronoi-block suppression from NaN-fill) and halve BASE_SIGMA_REF from 5.0 to 2.5 so the grid-proportional component also preserves more detail.

Result: mountains now have 2-3 block steps on steep faces (realistic cliff terrain) while cities remain smooth (~0.4 max step). The slope-based material system (grass → gravel → stone) will activate more often on steep terrain, adding visual realism.