### PR TITLE
Add banner decorations for hospitals, tourism info boards, and fire hydrants

### DIFF
--- a/src/bedrock_block_map.rs
+++ b/src/bedrock_block_map.rs
@@ -499,6 +499,26 @@ pub fn to_bedrock_block(block: Block) -> BedrockBlock {
             "wall_banner",
             vec![("facing_direction", BedrockBlockStateValue::Int(2))], // default north
         ),
+        "white_wall_banner" => BedrockBlock::with_states(
+            "wall_banner",
+            vec![("facing_direction", BedrockBlockStateValue::Int(2))], // default north
+        ),
+        "blue_wall_banner" => BedrockBlock::with_states(
+            "wall_banner",
+            vec![("facing_direction", BedrockBlockStateValue::Int(2))],
+        ),
+        "black_wall_banner" => BedrockBlock::with_states(
+            "wall_banner",
+            vec![("facing_direction", BedrockBlockStateValue::Int(2))],
+        ),
+        "red_wall_banner" => BedrockBlock::with_states(
+            "wall_banner",
+            vec![("facing_direction", BedrockBlockStateValue::Int(2))],
+        ),
+        "green_wall_banner" => BedrockBlock::with_states(
+            "wall_banner",
+            vec![("facing_direction", BedrockBlockStateValue::Int(2))],
+        ),
         // Wool colors
         "white_wool" => BedrockBlock::with_states(
             "wool",
@@ -833,7 +853,15 @@ pub fn to_bedrock_block_with_properties(
     }
 
     // Handle wall banners with facing property
-    if java_name == "light_gray_wall_banner" {
+    if matches!(
+        java_name,
+        "light_gray_wall_banner"
+            | "white_wall_banner"
+            | "blue_wall_banner"
+            | "black_wall_banner"
+            | "red_wall_banner"
+            | "green_wall_banner"
+    ) {
         return convert_wall_banner(props_map);
     }
 

--- a/src/block_definitions.rs
+++ b/src/block_definitions.rs
@@ -57,7 +57,7 @@ type ColorBlockMapping = (ColorTuple, BlockOptions);
 
 #[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Debug)]
 pub struct Block {
-    id: u8,
+    id: u16,
 }
 
 // Extended block with dynamic properties
@@ -82,12 +82,12 @@ impl BlockWithProperties {
 
 impl Block {
     #[inline(always)]
-    const fn new(id: u8) -> Self {
+    const fn new(id: u16) -> Self {
         Self { id }
     }
 
     #[inline(always)]
-    pub fn id(&self) -> u8 {
+    pub fn id(&self) -> u16 {
         self.id
     }
 
@@ -334,6 +334,11 @@ impl Block {
             253 => "cyan_terracotta",
             254 => "black_wool",
             255 => "light_gray_wall_banner",
+            256 => "white_wall_banner",
+            257 => "blue_wall_banner",
+            258 => "black_wall_banner",
+            259 => "red_wall_banner",
+            260 => "green_wall_banner",
             _ => panic!("Invalid id"),
         }
     }
@@ -689,7 +694,7 @@ impl Block {
 use std::sync::Mutex;
 
 #[allow(clippy::type_complexity)]
-static STAIR_CACHE: Lazy<Mutex<HashMap<(u8, StairFacing, StairShape), BlockWithProperties>>> =
+static STAIR_CACHE: Lazy<Mutex<HashMap<(u16, StairFacing, StairShape), BlockWithProperties>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 // General function to create any stair block with facing and shape properties
@@ -984,6 +989,11 @@ pub const GRAY_CONCRETE_POWDER: Block = Block::new(252);
 pub const CYAN_TERRACOTTA: Block = Block::new(253);
 pub const BLACK_WOOL: Block = Block::new(254);
 pub const LIGHT_GRAY_WALL_BANNER: Block = Block::new(255);
+pub const WHITE_WALL_BANNER: Block = Block::new(256);
+pub const BLUE_WALL_BANNER: Block = Block::new(257);
+pub const BLACK_WALL_BANNER: Block = Block::new(258);
+pub const RED_WALL_BANNER: Block = Block::new(259);
+pub const GREEN_WALL_BANNER: Block = Block::new(260);
 
 /// Maps a block to its corresponding stair variant
 #[inline]

--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -1283,7 +1283,7 @@ fn adjust_height_for_building_type(
 ) -> i32 {
     let default_height = ((10.0 * scale_factor) as i32).max(3);
     match building_type {
-        "garage" | "shed" => ((2.0 * scale_factor) as i32).max(3),
+        "garage" | "garages" | "carport" | "shed" => ((2.0 * scale_factor) as i32).max(3),
         "apartments" if building_height == default_height => ((15.0 * scale_factor) as i32).max(3),
         "hospital" if building_height == default_height => ((23.0 * scale_factor) as i32).max(3),
         _ => building_height,
@@ -3105,6 +3105,100 @@ fn place_glass_curtain_corners(
 // Hospital Decorations
 // ============================================================================
 
+/// Places green-cross banners on the exterior walls of a hospital building.
+///
+/// For each wall segment (polygon edge), a wall banner with a green cross pattern
+/// on a white background is placed at the midpoint of the segment, facing
+/// outward.  The banner sits roughly at 2/3 of the building height so it is
+/// clearly visible from the ground.
+///
+/// Only segments that are at least 5 blocks long receive a banner — this avoids
+/// cluttering narrow corners and ensures the cross is readable.
+fn generate_hospital_green_cross(
+    editor: &mut WorldEditor,
+    element: &ProcessedWay,
+    config: &BuildingConfig,
+) {
+    if element.nodes.len() < 3 {
+        return;
+    }
+
+    // Green cross on white background — universal pharmacy/hospital symbol.
+    // Layer the full cross, then paint over the top/bottom edges with white
+    // so the vertical arm doesn't stretch the full banner height.
+    const GREEN_CROSS_PATTERNS: &[(&str, &str)] = &[
+        ("green", "minecraft:straight_cross"),
+        ("white", "minecraft:stripe_top"),
+        ("white", "minecraft:stripe_bottom"),
+        ("white", "minecraft:border"),
+    ];
+
+    let banner_y =
+        config.start_y_offset + (config.building_height * 2 / 3).max(2) + config.abs_terrain_offset;
+
+    let bounds = BuildingBounds::from_nodes(&element.nodes);
+    let center_x = (bounds.min_x + bounds.max_x) / 2;
+    let center_z = (bounds.min_z + bounds.max_z) / 2;
+
+    let mut previous_node: Option<(i32, i32)> = None;
+    for node in &element.nodes {
+        let (x2, z2) = (node.x, node.z);
+        if let Some((x1, z1)) = previous_node {
+            let seg_len = ((x2 - x1).abs()).max((z2 - z1).abs());
+            if seg_len < 5 {
+                previous_node = Some((x2, z2));
+                continue;
+            }
+
+            let mid_x = (x1 + x2) / 2;
+            let mid_z = (z1 + z2) / 2;
+
+            // Determine outward facing direction.
+            // The wall runs from (x1,z1) to (x2,z2).  We pick the cardinal
+            // direction that points away from the building centre.
+            let dx = x2 - x1;
+            let dz = z2 - z1;
+
+            // Normal vector components (perpendicular to the wall segment).
+            // Two candidates: (dz, -dx) and (-dz, dx).  Pick the one that
+            // points away from the building centre.
+            let (nx, nz) = {
+                let (n1x, n1z) = (dz, -dx);
+                let dot = (mid_x + n1x - center_x) * n1x + (mid_z + n1z - center_z) * n1z;
+                if dot >= 0 {
+                    (n1x, n1z)
+                } else {
+                    (-dz, dx)
+                }
+            };
+
+            // Convert normal to cardinal facing and banner offset
+            let (facing, bx, bz) = if nx.abs() >= nz.abs() {
+                if nx > 0 {
+                    ("east", mid_x + 1, mid_z) // banner faces east, placed east of wall
+                } else {
+                    ("west", mid_x - 1, mid_z) // banner faces west, placed west of wall
+                }
+            } else if nz > 0 {
+                ("south", mid_x, mid_z + 1) // banner faces south, placed south of wall
+            } else {
+                ("north", mid_x, mid_z - 1) // banner faces north, placed north of wall
+            };
+
+            editor.place_wall_banner(
+                WHITE_WALL_BANNER,
+                bx,
+                banner_y,
+                bz,
+                facing,
+                "white",
+                GREEN_CROSS_PATTERNS,
+            );
+        }
+        previous_node = Some((x2, z2));
+    }
+}
+
 /// Generates a helipad marking on the flat roof of a hospital.
 ///
 /// Layout (7×7 yellow concrete pad with a 5×5 "H" pattern):
@@ -3885,6 +3979,11 @@ fn generate_building_roof(
     // Hospital helipad on the flat roof
     if category == BuildingCategory::Hospital && style.roof_type == RoofType::Flat {
         generate_hospital_helipad(editor, element, roof_area, config);
+    }
+
+    // Hospital green cross banners on exterior walls
+    if category == BuildingCategory::Hospital {
+        generate_hospital_green_cross(editor, element, config);
     }
 }
 

--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -3164,7 +3164,7 @@ fn generate_hospital_green_cross(
             // points away from the building centre.
             let (nx, nz) = {
                 let (n1x, n1z) = (dz, -dx);
-                let dot = (mid_x + n1x - center_x) * n1x + (mid_z + n1z - center_z) * n1z;
+                let dot = (mid_x - center_x) * n1x + (mid_z - center_z) * n1z;
                 if dot >= 0 {
                     (n1x, n1z)
                 } else {

--- a/src/element_processing/emergency.rs
+++ b/src/element_processing/emergency.rs
@@ -52,4 +52,29 @@ fn generate_fire_hydrant(editor: &mut WorldEditor, node: &ProcessedNode) {
     // Simple hydrant: brick wall with redstone block on top
     editor.set_block(BRICK_WALL, x, 1, z, None, None);
     editor.set_block(REDSTONE_BLOCK, x, 2, z, None, None);
+
+    // Red banners with orange flame-like pattern on all four sides
+    let abs_y = editor.get_absolute_y(x, 2, z);
+    const HYDRANT_PATTERNS: &[(&str, &str)] = &[
+        ("orange", "minecraft:triangle_top"),
+        ("yellow", "minecraft:triangle_bottom"),
+        ("red", "minecraft:border"),
+    ];
+    let banner_faces: [(i32, i32, &str); 4] = [
+        (0, 1, "south"),
+        (0, -1, "north"),
+        (1, 0, "east"),
+        (-1, 0, "west"),
+    ];
+    for (dx, dz, facing) in &banner_faces {
+        editor.place_wall_banner(
+            RED_WALL_BANNER,
+            x + dx,
+            abs_y,
+            z + dz,
+            facing,
+            "red",
+            HYDRANT_PATTERNS,
+        );
+    }
 }

--- a/src/element_processing/tourisms.rs
+++ b/src/element_processing/tourisms.rs
@@ -24,9 +24,38 @@ pub fn generate_tourisms(editor: &mut WorldEditor, element: &ProcessedNode) {
             if let Some(info_type) = element.tags.get("information").map(|x: &String| x.as_str()) {
                 if info_type != "office" && info_type != "visitor_centre" {
                     // Draw an information board
-                    // TODO draw a sign with text if provided
                     editor.set_block(COBBLESTONE_WALL, x, 1, z, None, None);
                     editor.set_block(OAK_PLANKS, x, 2, z, None, None);
+
+                    // White banner with blue masking to form a lowercase "i" shape.
+                    // Layers: start white, paint blue on left/right/top/middle/border,
+                    // leaving a dot (between top and middle) and a stem below.
+                    let abs_y = editor.get_absolute_y(x, 2, z);
+                    const INFO_PATTERNS: &[(&str, &str)] = &[
+                        ("blue", "minecraft:stripe_left"),
+                        ("blue", "minecraft:stripe_right"),
+                        ("blue", "minecraft:stripe_top"),
+                        ("blue", "minecraft:stripe_middle"),
+                        ("blue", "minecraft:border"),
+                    ];
+                    // Place info banners on all four sides
+                    let banner_faces: [(i32, i32, &str); 4] = [
+                        (0, 1, "south"),
+                        (0, -1, "north"),
+                        (1, 0, "east"),
+                        (-1, 0, "west"),
+                    ];
+                    for (dx, dz, facing) in &banner_faces {
+                        editor.place_wall_banner(
+                            WHITE_WALL_BANNER,
+                            x + dx,
+                            abs_y,
+                            z + dz,
+                            facing,
+                            "white",
+                            INFO_PATTERNS,
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Add green cross banners on hospital exterior walls (Geneva-safe alternative)
- Add blue 'i' info banners on all 4 sides of tourism information boards
- Add flame-patterned banners on all 4 sides of fire hydrants
- Widen Block.id from u8 to u16 to support new banner block types
- Add wall banner blocks: white, blue, black, red, green (IDs 256-260)
- Add Bedrock block mappings for all new wall banner colors
- Cap garage/garages/carport buildings to single-story height