### PR TITLE
Add --benchmark flag to measure generation time without network latency

### DIFF
--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -68,7 +68,7 @@ jobs:
           peak_mem=${{ steps.benchmark.outputs.peak_memory }}
           gen_time=${{ steps.benchmark.outputs.gen_time }}
 
-          baseline_time=30
+          baseline_time=20
           diff=$((duration - baseline_time))
           abs_diff=${diff#-}
 

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -43,11 +43,13 @@ jobs:
       - name: Run benchmark command with memory tracking
         id: benchmark
         run: |
-          /usr/bin/time -v ./target/release/arnis --path="./world" --terrain --bbox="48.125768 11.552296 48.148565 11.593838" 2> benchmark_log.txt
+          /usr/bin/time -v ./target/release/arnis --path="./world" --terrain --benchmark --bbox="48.125768 11.552296 48.148565 11.593838" 2> benchmark_log.txt
           grep "Maximum resident set size" benchmark_log.txt | awk '{print $6}' > peak_mem_kb.txt
           peak_kb=$(cat peak_mem_kb.txt)
           peak_mb=$((peak_kb / 1024))
           echo "peak_memory=${peak_mb}" >> $GITHUB_OUTPUT
+          gen_time=$(grep -oP '(?<=generation_time=)\d+' benchmark_log.txt || echo "")
+          echo "gen_time=${gen_time}" >> $GITHUB_OUTPUT
 
       - name: End timer and calculate duration
         id: end_time
@@ -64,16 +66,25 @@ jobs:
           minutes=$((duration / 60))
           seconds=$((duration % 60))
           peak_mem=${{ steps.benchmark.outputs.peak_memory }}
+          gen_time=${{ steps.benchmark.outputs.gen_time }}
 
           baseline_time=30
           diff=$((duration - baseline_time))
           abs_diff=${diff#-}
 
-          if [ "$diff" -lt -5 ]; then
+          # Use generation-only time for verdict when available
+          if [ -n "$gen_time" ]; then
+            eval_diff=$((gen_time - baseline_time))
+          else
+            eval_diff=$diff
+          fi
+          eval_abs_diff=${eval_diff#-}
+
+          if [ "$eval_diff" -lt -5 ]; then
             verdict="✅ This PR **improves generation time**."
-          elif [ "$abs_diff" -le 4 ]; then
+          elif [ "$eval_abs_diff" -le 4 ]; then
             verdict="🟢 Generation time is unchanged."
-          elif [ "$diff" -le 15 ]; then
+          elif [ "$eval_diff" -le 10 ]; then
             verdict="⚠️ This PR **worsens generation time**."
           else
             verdict="🚨 This PR **drastically worsens generation time**."
@@ -92,6 +103,9 @@ jobs:
           {
             echo "summary<<EOF"
             echo "⏱️ Benchmark run finished in **${minutes}m ${seconds}s**"
+            if [ -n "$gen_time" ]; then
+              echo "🏗️ Generation time: **${gen_time}s** (excl. data fetching)"
+            fi
             echo "🧠 Peak memory usage: **${peak_mem} MB**${mem_annotation}"
             echo ""
             echo "📈 Compared against baseline: **${baseline_time}s**"

--- a/src/args.rs
+++ b/src/args.rs
@@ -89,6 +89,10 @@ pub struct Args {
     /// Requires a Minecraft data pack that increases the world height.
     #[arg(long, default_value_t = false)]
     pub disable_height_limit: bool,
+
+    /// Print generation-only timing to stderr (excludes data fetching)
+    #[arg(long, hide = true)]
+    pub benchmark: bool,
 }
 
 /// Validates CLI arguments after parsing.

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -37,6 +37,7 @@ pub fn generate_world_with_options(
 ) -> Result<PathBuf, String> {
     let output_path = options.path.clone();
     let world_format = options.format;
+    let generation_start = args.benchmark.then(std::time::Instant::now);
 
     // Create editor with appropriate format
     let mut editor: WorldEditor = WorldEditor::new_with_format_and_name(
@@ -354,6 +355,11 @@ pub fn generate_world_with_options(
     // Save world
     if let Err(e) = editor.save() {
         return Err(e.to_string());
+    }
+
+    if let Some(start) = generation_start {
+        let gen_secs = start.elapsed().as_secs();
+        eprintln!("[BENCHMARK] generation_time={gen_secs}");
     }
 
     emit_gui_progress_update(99.0, "Finalizing world...");

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -916,6 +916,7 @@ fn gui_start_generation(
                 spawn_lng: None,
                 rotation: rotation_angle.clamp(-90.0, 90.0),
                 disable_height_limit,
+                benchmark: false,
             };
 
             // If skip_osm_objects is true (terrain-only mode), skip fetching and processing OSM data


### PR DESCRIPTION
Adds a hidden --benchmark CLI flag that prints generation-only timing to stderr, and updates the CI workflow to use it for more accurate performance verdicts.