### PR TITLE
Show world name on Start Generation button and clean up on fetch failure

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -63,6 +63,43 @@ impl Drop for SessionLock {
     }
 }
 
+/// Removes a freshly created Java world directory. Called whenever generation
+/// bails out before producing anything useful, so the user isn't left with a
+/// growing pile of empty "Arnis World N" folders.
+fn remove_new_java_world(path: &Path) {
+    if path.exists() {
+        if let Err(e) = fs::remove_dir_all(path) {
+            eprintln!("Failed to remove newly created world after failure: {e}");
+        }
+    }
+}
+
+/// RAII guard that removes a newly created Java world on drop unless disarmed.
+/// Must be declared *before* any `SessionLock` so the lock's file handle is
+/// released first (Windows blocks folder removal otherwise).
+struct NewWorldCleanup {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl NewWorldCleanup {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for NewWorldCleanup {
+    fn drop(&mut self) {
+        if self.armed {
+            remove_new_java_world(&self.path);
+        }
+    }
+}
+
 pub fn run_gui() {
     // Configure thread pool with 90% CPU cap to keep system responsive
     crate::floodfill_cache::configure_rayon_thread_pool(0.9);
@@ -737,53 +774,46 @@ fn gui_start_generation(
     // Only update player position for Java worlds - Bedrock worlds don't have a pre-existing
     // level.dat to modify (the spawn point will be set when the .mcworld is created)
     if is_new_world && world_format != "bedrock" {
-        let llbbox = match LLBBox::from_str(&bbox_text) {
-            Ok(bbox) => bbox,
-            Err(e) => {
-                let error_msg = format!("Failed to parse bounding box: {e}");
-                eprintln!("{error_msg}");
-                emit_gui_error(&error_msg);
-                return Err(error_msg);
-            }
-        };
+        let prep_result: Result<(), String> = (|| -> Result<(), String> {
+            let llbbox = LLBBox::from_str(&bbox_text)
+                .map_err(|e| format!("Failed to parse bounding box: {e}"))?;
 
-        let (transformer, xzbbox) = match CoordTransformer::llbbox_to_xzbbox(&llbbox, world_scale) {
-            Ok(result) => result,
-            Err(e) => {
-                let error_msg = format!("Failed to create coordinate transformer: {e}");
-                eprintln!("{error_msg}");
-                emit_gui_error(&error_msg);
-                return Err(error_msg);
-            }
-        };
+            let (transformer, xzbbox) = CoordTransformer::llbbox_to_xzbbox(&llbbox, world_scale)
+                .map_err(|e| format!("Failed to create coordinate transformer: {e}"))?;
 
-        let (spawn_x, spawn_z) = if let Some(coords) = spawn_point {
-            // User selected a spawn point - verify it's within bounds and convert to XZ
-            let llpoint = LLPoint::new(coords.0, coords.1)
-                .map_err(|e| format!("Failed to parse spawn point: {e}"))?;
+            let (spawn_x, spawn_z) = if let Some(coords) = spawn_point {
+                let llpoint = LLPoint::new(coords.0, coords.1)
+                    .map_err(|e| format!("Failed to parse spawn point: {e}"))?;
 
-            if llbbox.contains(&llpoint) {
-                let xzpoint = transformer.transform_point(llpoint);
-                (xzpoint.x, xzpoint.z)
+                if llbbox.contains(&llpoint) {
+                    let xzpoint = transformer.transform_point(llpoint);
+                    (xzpoint.x, xzpoint.z)
+                } else {
+                    calculate_default_spawn(&xzbbox)
+                }
             } else {
-                // Spawn point outside bounds, use default
                 calculate_default_spawn(&xzbbox)
-            }
-        } else {
-            // No user-selected spawn point - use default at X=1, Z=1 relative to world origin
-            calculate_default_spawn(&xzbbox)
-        };
+            };
 
-        // Rotate spawn point to match the rotated world
-        let (spawn_x, spawn_z) = map_transformation::rotate::rotate_xz_point(
-            spawn_x,
-            spawn_z,
-            rotation_angle.clamp(-90.0, 90.0),
-            &xzbbox,
-        );
+            let (spawn_x, spawn_z) = map_transformation::rotate::rotate_xz_point(
+                spawn_x,
+                spawn_z,
+                rotation_angle.clamp(-90.0, 90.0),
+                &xzbbox,
+            );
 
-        set_player_spawn_in_level_dat(&selected_world, spawn_x, spawn_z)
-            .map_err(|e| format!("Failed to set spawn point: {e}"))?;
+            set_player_spawn_in_level_dat(&selected_world, spawn_x, spawn_z)
+                .map_err(|e| format!("Failed to set spawn point: {e}"))?;
+
+            Ok(())
+        })();
+
+        if let Err(error_msg) = prep_result {
+            eprintln!("{error_msg}");
+            emit_gui_error(&error_msg);
+            remove_new_java_world(&PathBuf::from(&selected_world));
+            return Err(error_msg);
+        }
     }
 
     tauri::async_runtime::spawn(async move {
@@ -796,6 +826,16 @@ fn gui_start_generation(
             } else {
                 WorldFormat::JavaAnvil
             };
+
+            // Arm cleanup for freshly created Java worlds. Declared before the
+            // SessionLock so the lock's file handle is released first on drop
+            // (Windows needs that to remove the parent folder).
+            let mut cleanup_guard: Option<NewWorldCleanup> =
+                if is_new_world && world_format == WorldFormat::JavaAnvil {
+                    Some(NewWorldCleanup::new(world_path.clone()))
+                } else {
+                    None
+                };
 
             // Check available disk space before starting generation (minimum 3GB required)
             const MIN_DISK_SPACE_BYTES: u64 = 3 * 1024 * 1024 * 1024; // 3 GB
@@ -949,6 +989,9 @@ fn gui_start_generation(
                     &args,
                     generation_options.clone(),
                 );
+                if let Some(g) = cleanup_guard.as_mut() {
+                    g.disarm();
+                }
                 // Explicitly release session lock before showing Done message
                 // so Minecraft can open the world immediately
                 drop(_session_lock);
@@ -1027,6 +1070,9 @@ fn gui_start_generation(
                         &args,
                         generation_options.clone(),
                     );
+                    if let Some(g) = cleanup_guard.as_mut() {
+                        g.disarm();
+                    }
                     // Explicitly release session lock before showing Done message
                     // so Minecraft can open the world immediately
                     drop(_session_lock);
@@ -1046,19 +1092,8 @@ fn gui_start_generation(
                 }
                 Err(e) => {
                     emit_gui_error(&e.to_string());
-                    // Drop the session lock before removing the world directory, on Windows
-                    // the open lock file handle would block removal of its parent folder.
-                    drop(_session_lock);
-                    if is_new_world
-                        && world_format == WorldFormat::JavaAnvil
-                        && generation_path.exists()
-                    {
-                        if let Err(cleanup_err) = std::fs::remove_dir_all(&generation_path) {
-                            eprintln!(
-                                "Failed to remove newly created world after fetch failure: {cleanup_err}"
-                            );
-                        }
-                    }
+                    // cleanup_guard removes the new world, and SessionLock releases
+                    // its file handle first via reverse drop order.
                     Err(e.to_string())
                 }
             }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -296,6 +296,7 @@ fn add_localized_world_name(world_path: PathBuf, bbox: &LLBBox) -> PathBuf {
         };
 
     let new_name = format!("{base_name}: {truncated_area_name}");
+    let mut write_succeeded = false;
 
     // Update the level.dat file with the new name
     if let Ok(level_data) = std::fs::read(&level_path) {
@@ -306,7 +307,7 @@ fn add_localized_world_name(world_path: PathBuf, bbox: &LLBBox) -> PathBuf {
                 // Update the level name in NBT data
                 if let Value::Compound(ref mut root) = nbt_data {
                     if let Some(Value::Compound(ref mut data)) = root.get_mut("Data") {
-                        data.insert("LevelName".to_string(), Value::String(new_name));
+                        data.insert("LevelName".to_string(), Value::String(new_name.clone()));
 
                         // Save the updated NBT data
                         if let Ok(serialized_data) = fastnbt::to_bytes(&nbt_data) {
@@ -316,13 +317,18 @@ fn add_localized_world_name(world_path: PathBuf, bbox: &LLBBox) -> PathBuf {
                             );
                             if encoder.write_all(&serialized_data).is_ok() {
                                 if let Ok(compressed_data) = encoder.finish() {
-                                    if let Err(e) = std::fs::write(&level_path, compressed_data) {
-                                        eprintln!("Failed to update level.dat with area name: {e}");
-                                        #[cfg(feature = "gui")]
-                                        send_log(
-                                            LogLevel::Warning,
-                                            "Failed to update level.dat with area name",
-                                        );
+                                    match std::fs::write(&level_path, compressed_data) {
+                                        Ok(_) => write_succeeded = true,
+                                        Err(e) => {
+                                            eprintln!(
+                                                "Failed to update level.dat with area name: {e}"
+                                            );
+                                            #[cfg(feature = "gui")]
+                                            send_log(
+                                                LogLevel::Warning,
+                                                "Failed to update level.dat with area name",
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -331,6 +337,10 @@ fn add_localized_world_name(world_path: PathBuf, bbox: &LLBBox) -> PathBuf {
                 }
             }
         }
+    }
+
+    if write_succeeded {
+        progress::emit_world_name_update(&new_name);
     }
 
     // Return the original path since we didn't change the directory name
@@ -853,6 +863,7 @@ fn gui_start_generation(
                     let output_dir = crate::world_utils::get_bedrock_output_directory();
                     let (output_path, lvl_name) =
                         crate::world_utils::build_bedrock_output(&bbox, output_dir);
+                    progress::emit_world_name_update(&lvl_name);
                     (output_path, Some(lvl_name))
                 }
             };
@@ -897,7 +908,7 @@ fn gui_start_generation(
                 file: None,
                 save_json_file: None,
                 path: Some(if world_format == WorldFormat::JavaAnvil {
-                    generation_path
+                    generation_path.clone()
                 } else {
                     world_path
                 }),
@@ -1035,7 +1046,19 @@ fn gui_start_generation(
                 }
                 Err(e) => {
                     emit_gui_error(&e.to_string());
-                    // Session lock will be automatically released when _session_lock goes out of scope
+                    // Drop the session lock before removing the world directory, on Windows
+                    // the open lock file handle would block removal of its parent folder.
+                    drop(_session_lock);
+                    if is_new_world
+                        && world_format == WorldFormat::JavaAnvil
+                        && generation_path.exists()
+                    {
+                        if let Err(cleanup_err) = std::fs::remove_dir_all(&generation_path) {
+                            eprintln!(
+                                "Failed to remove newly created world after fetch failure: {cleanup_err}"
+                            );
+                        }
+                    }
                     Err(e.to_string())
                 }
             }

--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -152,6 +152,19 @@ a:hover {
   margin-bottom: 5px;
 }
 
+.world-name-label {
+  font-size: 0.8em;
+  color: #fecc44;
+  display: block;
+  line-height: 1;
+  min-height: 1em;
+  margin-top: 3px;
+  margin-bottom: -3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .map-container {
   border: none;
   border-radius: 8px;

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -289,9 +289,11 @@
     <!-- Telemetry Consent Modal (first run) -->
     <div id="telemetry-modal" class="modal" style="display: none;">
       <div class="modal-content">
-        <span class="close-button" onclick="rejectTelemetry()">&times;</span>
-        <h2>Help improve Arnis</h2>
-        <p style="text-align:left; margin-top:6px; color:#ececec;">
+        <div class="settings-header">
+          <h2>Help improve Arnis</h2>
+          <span class="close-button" onclick="rejectTelemetry()">&times;</span>
+        </div>
+        <p style="text-align:left; margin-top:12px; margin-bottom: -5px;color:#ececec;">
           We’d like to collect anonymous usage data like crashes and performance to make Arnis more stable and faster.
           <a href="https://arnismc.com/privacypolicy.html" style="color: inherit;" target="_blank">No personal data or world contents are collected.</a>
         </p>

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -32,7 +32,10 @@
             <!-- Combined Button Block -->
             <div class="button-block">
               <div class="button-block-row">
-                <button type="button" id="start-button" class="start-button" onclick="startGeneration()" data-localize="start_generation">Start Generation</button>
+                <button type="button" id="start-button" class="start-button" onclick="startGeneration()">
+                  <span data-localize="start_generation">Start Generation</span>
+                  <span id="world-name-label" class="world-name-label" data-placeholder="true">No world generated yet</span>
+                </button>
                 <button type="button" class="settings-button" onclick="openSettings()" aria-label="Settings">
                     <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>
                 </button>

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -97,7 +97,8 @@ async function localizeElement(json, elementObject, localizedStringKey) {
 
 async function applyLocalization(localization) {
   const localizationElements = {
-    "#start-button": "start_generation",
+    "#start-button > span[data-localize='start_generation']": "start_generation",
+    "#world-name-label[data-placeholder]": "no_world_generated_yet",
     "h2[data-localize='customization_settings']": "customization_settings",
     "span[data-localize='world_scale']": "world_scale",
     "span[data-localize='custom_bounding_box']": "custom_bounding_box",
@@ -248,12 +249,21 @@ function setupProgressListener() {
       if (message.startsWith("Error!")) {
         progressInfo.style.color = "#fa7878";
         generationButtonEnabled = true;
+        setWorldNameLabel("");
       } else if (message.startsWith("Done!")) {
         progressInfo.style.color = "#7bd864";
         generationButtonEnabled = true;
       } else {
         progressInfo.style.color = "#ececec";
       }
+    }
+  });
+
+  // Listen for the finalized world name (Java adds the localized area suffix
+  // during generation; Bedrock derives the name from the area up-front).
+  window.__TAURI__.event.listen("world-name-update", (event) => {
+    if (typeof event.payload === 'string') {
+      setWorldNameLabel(event.payload);
     }
   });
 
@@ -855,6 +865,23 @@ function displayBboxInfoText(bboxText) {
 
 let worldPath = "";
 
+function setWorldNameLabel(text) {
+  const label = document.getElementById('world-name-label');
+  if (!label) return;
+  if (text) {
+    label.removeAttribute('data-placeholder');
+    label.textContent = text;
+  } else {
+    label.setAttribute('data-placeholder', 'true');
+    localizeElement(window.localization, { element: label }, 'no_world_generated_yet');
+  }
+}
+
+function basenameFromPath(p) {
+  if (!p) return "";
+  return p.replace(/[\\/]+$/, "").split(/[\\/]/).pop() || "";
+}
+
 /**
  * Handles world selection errors and displays appropriate messages
  * @param {number} errorCode - Error code from the backend
@@ -872,6 +899,7 @@ function handleWorldSelectionError(errorCode) {
   localizeElement(window.localization, { element: progressInfo }, errorKey);
   progressInfo.style.color = "#fa7878";
   worldPath = "";
+  setWorldNameLabel("");
   console.error(errorCode);
 }
 
@@ -903,6 +931,7 @@ async function startGeneration() {
         const worldName = await invoke('gui_create_world', { savePath: savePath });
         if (worldName) {
           worldPath = worldName;
+          setWorldNameLabel(basenameFromPath(worldName));
         }
       } catch (error) {
         handleWorldSelectionError(error);

--- a/src/gui/locales/ar.json
+++ b/src/gui/locales/ar.json
@@ -1,6 +1,7 @@
 {
   "create_world": "إنشاء عالم",
   "no_world_selected": "لم يتم إنشاء عالم",
+  "no_world_generated_yet": "لم يتم توليد عالم بعد",
   "start_generation": "بدء البناء",
   "custom_selection_confirmed": "تم تأكيد التحديد المخصص!",
   "error_coordinates_out_of_range": "خطأ: الإحداثيات خارج النطاق أو مرتبة بشكل غير صحيح (مطلوب خط العرض قبل خط الطول).",

--- a/src/gui/locales/de.json
+++ b/src/gui/locales/de.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Welt erstellen",
   "no_world_selected": "Keine Welt erstellt",
+  "no_world_generated_yet": "Noch keine Welt generiert",
   "start_generation": "Generierung starten",
   "custom_selection_confirmed": "Benutzerdefinierte Auswahl bestätigt!",
   "error_coordinates_out_of_range": "Fehler: Koordinaten sind außerhalb des Bereichs oder falsch geordnet (Lat vor Lng erforderlich).",

--- a/src/gui/locales/en-US.json
+++ b/src/gui/locales/en-US.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Create World",
   "no_world_selected": "No world created",
+  "no_world_generated_yet": "No world generated yet",
   "start_generation": "Start Generation",
   "custom_selection_confirmed": "Custom selection confirmed!",
   "error_coordinates_out_of_range": "Error: Coordinates are out of range or incorrectly ordered (Lat before Lng required).",

--- a/src/gui/locales/es.json
+++ b/src/gui/locales/es.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Crear mundo",
   "no_world_selected": "Ningún mundo creado",
+  "no_world_generated_yet": "Ningún mundo generado todavía",
   "start_generation": "Iniciar generación",
   "custom_selection_confirmed": "¡Selección personalizada confirmada!",
   "error_coordinates_out_of_range": "Error: Las coordenadas están fuera de rango o están ordenadas incorrectamente (Lat antes de Lng requerido).",

--- a/src/gui/locales/fi.json
+++ b/src/gui/locales/fi.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Luo maailma",
   "no_world_selected": "Maailmaa ei luotu",
+  "no_world_generated_yet": "Maailmaa ei vielä generoitu",
   "start_generation": "Aloita generointi",
   "custom_selection_confirmed": "Mukautettu valinta vahvistettu!",
   "error_coordinates_out_of_range": "Virhe: Koordinaatit ovat kantaman ulkopuolella tai vääriin aseteltu (Lat ennen Lng vaadittu).",

--- a/src/gui/locales/fr-FR.json
+++ b/src/gui/locales/fr-FR.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Créer un monde",
   "no_world_selected": "Aucun monde créé",
+  "no_world_generated_yet": "Aucun monde généré pour l'instant",
   "start_generation": "Commencer la génération",
   "custom_selection_confirmed": "Sélection personnalisée confirmée !",
   "error_coordinates_out_of_range": "Erreur: Coordonnées hors de portée ou dans un ordre incorrect (besoin de la latitude avant la longitude).",

--- a/src/gui/locales/hu.json
+++ b/src/gui/locales/hu.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Világ létrehozása",
   "no_world_selected": "Nincs világ létrehozva",
+  "no_world_generated_yet": "Még nincs világ generálva",
   "start_generation": "Generálás indítása",
   "custom_selection_confirmed": "Egyéni kiválasztás megerősítve",
   "error_coordinates_out_of_range": "Hiba: A koordináták tartományon kívül vannak vagy hibásan rendezettek (a szélességi foknak a hosszúsági fok előtt kell lennie)",

--- a/src/gui/locales/ja.json
+++ b/src/gui/locales/ja.json
@@ -1,6 +1,7 @@
 {
   "create_world": "ワールドを作成",
   "no_world_selected": "ワールドが作成されていません",
+  "no_world_generated_yet": "ワールドはまだ生成されていません",
   "start_generation": "生成開始",
   "custom_selection_confirmed": "カスタム選択を確認しました！",
   "error_coordinates_out_of_range": "エラー: 座標が範囲外か順序が正しくありません（緯度を経度より先に指定してください）。",

--- a/src/gui/locales/ko.json
+++ b/src/gui/locales/ko.json
@@ -1,6 +1,7 @@
 {
   "create_world": "월드 만들기",
   "no_world_selected": "생성된 월드 없음",
+  "no_world_generated_yet": "아직 생성된 월드가 없습니다",
   "start_generation": "생성 시작",
   "custom_selection_confirmed": "사용자 지정 선택이 확인되었습니다!",
   "error_coordinates_out_of_range": "오류: 좌표가 범위를 벗어나거나 잘못된 순서입니다 (Lat이 Lng보다 먼저 필요합니다).",

--- a/src/gui/locales/lt.json
+++ b/src/gui/locales/lt.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Sukurti pasaulį",
   "no_world_selected": "Pasaulis nesukurtas",
+  "no_world_generated_yet": "Pasaulis dar nesugeneruotas",
   "start_generation": "Pradėti generaciją",
   "custom_selection_confirmed": "Rėmo pasirinkimas patvirtintas!",
   "error_coordinates_out_of_range": "Klaida: Koordinatės yra už ribų arba neteisingai išdėstytos (plat turi būti prieš ilg).",

--- a/src/gui/locales/lv.json
+++ b/src/gui/locales/lv.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Izveidot pasauli",
   "no_world_selected": "Pasaule nav izveidota",
+  "no_world_generated_yet": "Pasaule vēl nav ģenerēta",
   "start_generation": "Sākt ģenerēšanu",
   "custom_selection_confirmed": "Pielāgota izvēle apstiprināta!",
   "error_coordinates_out_of_range": "Kļūda: koordinātas ir ārpus darbības zonas vai norādītas nepareizā secībā (vispirms platums, tad garums)",

--- a/src/gui/locales/pl.json
+++ b/src/gui/locales/pl.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Utwórz świat",
   "no_world_selected": "Nie utworzono świata",
+  "no_world_generated_yet": "Nie wygenerowano jeszcze świata",
   "start_generation": "Rozpocznij generowanie",
   "custom_selection_confirmed": "Niestandardowy wybór potwierdzony!",
   "error_coordinates_out_of_range": "Błąd: Współrzędne są poza zakresem lub w złej kolejności (wymagana szerokość przed długością).",

--- a/src/gui/locales/pt-BR.json
+++ b/src/gui/locales/pt-BR.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Criar mundo",
   "no_world_selected": "Nenhum mundo criado",
+  "no_world_generated_yet": "Nenhum mundo gerado ainda",
   "start_generation": "Iniciar geração",
   "custom_selection_confirmed": "Seleção personalizada confirmada!",
   "error_coordinates_out_of_range": "Erro: as coordenadas estão fora do intervalo ou foram ordenadas incorretamente (é necessário Lat antes de Lng).",

--- a/src/gui/locales/ru.json
+++ b/src/gui/locales/ru.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Создать мир",
   "no_world_selected": "Мир не создан",
+  "no_world_generated_yet": "Мир ещё не сгенерирован",
   "start_generation": "Начать генерацию",
   "custom_selection_confirmed": "Пользовательский выбор подтвержден!",
   "error_coordinates_out_of_range": "Ошибка: Координаты находятся вне зоны действия или указаны в неправильном порядке (сначала широта, затем долгота)",

--- a/src/gui/locales/sl.json
+++ b/src/gui/locales/sl.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Ustvari svet",
   "no_world_selected": "Ni ustvarjenega sveta",
+  "no_world_generated_yet": "Svet še ni generiran",
   "start_generation": "Začni generiranje",
   "custom_selection_confirmed": "Izbira po meri potrjena!",
   "error_coordinates_out_of_range": "Napaka: Koordinate so izven obsega ali nepravilno urejene (zahtevana najprej zemljepisna širina, potem zemljepisna dolžina).",

--- a/src/gui/locales/sv.json
+++ b/src/gui/locales/sv.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Skapa värld",
   "no_world_selected": "Ingen värld skapad",
+  "no_world_generated_yet": "Ingen värld genererad ännu",
   "start_generation": "Starta generering",
   "custom_selection_confirmed": "Anpassad markering bekräftad!",
   "error_coordinates_out_of_range": "Fel: Koordinater är utanför området eller felaktigt ordnade (Lat före Lng krävs).",

--- a/src/gui/locales/ua.json
+++ b/src/gui/locales/ua.json
@@ -1,6 +1,7 @@
 {
   "create_world": "Створити світ",
   "no_world_selected": "Світ не створено",
+  "no_world_generated_yet": "Світ ще не згенеровано",
   "start_generation": "Почати генерацію",
   "custom_selection_confirmed": "Користувацький вибір підтверджено!",
   "error_coordinates_out_of_range": "Помилка: Координати поза діапазоном або неправильно впорядковані (потрібно широта перед довгота)",

--- a/src/gui/locales/zh-CN.json
+++ b/src/gui/locales/zh-CN.json
@@ -1,6 +1,7 @@
 {
   "create_world": "创建世界",
   "no_world_selected": "未创建世界",
+  "no_world_generated_yet": "尚未生成世界",
   "start_generation": "开始生成",
   "custom_selection_confirmed": "自定义选择已确认！",
   "error_coordinates_out_of_range": "错误：坐标超出范围或顺序不正确（需要先纬度后经度）。",

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -57,6 +57,16 @@ pub fn emit_gui_error(message: &str) {
     emit_gui_progress_update(0.0, &format!("Error! {truncated_message}"));
 }
 
+/// Emits the final in-game level name (including localized area suffix for Java,
+/// or the location-based name for Bedrock) so the GUI can display it.
+pub fn emit_world_name_update(name: &str) {
+    if let Some(window) = get_main_window() {
+        if let Err(e) = window.emit("world-name-update", name) {
+            eprintln!("Failed to emit world-name-update event: {e}");
+        }
+    }
+}
+
 /// Emits an event when the world map preview is ready
 pub fn emit_map_preview_ready() {
     if let Some(window) = get_main_window() {


### PR DESCRIPTION
Adds a yellow subtitle span to the Start Generation button showing the generated world name (localized "No world generated yet" when idle). The backend emits a `world-name-update` event so Java worlds can update the label to include the localized area suffix (e.g. "Arnis World 1: Berlin") after the Nominatim lookup, and Bedrock worlds show the location-derived level name.

Also removes a freshly created Java world directory if the Overpass fetch fails, so repeated failures don't leave empty "Arnis World N" folders behind. Session lock is dropped first so the folder can be removed on Windows.