### PR TITLE
Restore wide-road pre-flatten performance via median caching + FNV map

### DIFF
--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -7,6 +7,12 @@ use crate::osm_parser::{ProcessedElement, ProcessedWay};
 use crate::world_editor::WorldEditor;
 use std::collections::HashMap;
 
+/// Upper bound on `block_range` used by wide-road width flattening. The
+/// stamp is `2 * block_range + 1`; with `MAX_BLOCK_RANGE = 8` we can sort
+/// up to 17 samples on the stack. Keep this generous — a `debug_assert`
+/// below catches it if a caller ever exceeds it.
+const MAX_BLOCK_RANGE: usize = 8;
+
 /// Median of the ground levels along the road's width-perpendicular
 /// strip at one along-length coordinate. Pure primitive — no along-length
 /// smoothing. Callers should use `perpendicular_median_ground_y` unless
@@ -21,19 +27,65 @@ fn perpendicular_median_raw(
     block_range: i32,
     dir_horizontal: bool,
 ) -> i32 {
-    let capacity = 2 * block_range as usize + 1;
-    let mut ys: Vec<i32> = Vec::with_capacity(capacity);
+    debug_assert!(block_range as usize <= MAX_BLOCK_RANGE);
+    let len = 2 * block_range as usize + 1;
+    // Stack buffer keeps this allocation-free on a hot path that runs
+    // millions of times for a city-scale bbox.
+    let mut ys = [0i32; 2 * MAX_BLOCK_RANGE + 1];
     if dir_horizontal {
-        for t in -block_range..=block_range {
-            ys.push(editor.get_ground_level(set_x, centerline_z + t));
+        for (i, t) in (-block_range..=block_range).enumerate() {
+            ys[i] = editor.get_ground_level(set_x, centerline_z + t);
         }
     } else {
-        for t in -block_range..=block_range {
-            ys.push(editor.get_ground_level(centerline_x + t, set_z));
+        for (i, t) in (-block_range..=block_range).enumerate() {
+            ys[i] = editor.get_ground_level(centerline_x + t, set_z);
         }
     }
-    ys.sort_unstable();
-    ys[ys.len() / 2]
+    ys[..len].sort_unstable();
+    ys[len / 2]
+}
+
+/// Precompute one perpendicular-median Y per axial position in a
+/// centerline's stamp. Hot-loop optimization: inside a single centerline
+/// point's `(2b+1) × (2b+1)` stamp, every cell that shares a given axial
+/// offset (dx for horizontal travel, dz for vertical travel) produces
+/// the same target Y — `perpendicular_median_ground_y` ignores the
+/// cross-axis position entirely. Computing it once per axial value and
+/// reading from this table in the inner loop cuts `get_ground_level`
+/// call count by a factor of `2b+1` on the main road-stamp path.
+///
+/// The table layout maps axial offset `a ∈ [-block_range, block_range]`
+/// to index `(a + block_range) as usize`. `out.len()` must be at least
+/// `2 * block_range + 1`.
+#[inline]
+fn precompute_row_medians(
+    editor: &WorldEditor,
+    centerline_x: i32,
+    centerline_z: i32,
+    block_range: i32,
+    dir_horizontal: bool,
+    out: &mut [i32],
+) {
+    debug_assert!(block_range as usize <= MAX_BLOCK_RANGE);
+    let len = 2 * block_range as usize + 1;
+    debug_assert!(out.len() >= len);
+    for (i, slot) in out[..len].iter_mut().enumerate() {
+        let axial = -block_range + i as i32;
+        let (sx, sz) = if dir_horizontal {
+            (centerline_x + axial, centerline_z)
+        } else {
+            (centerline_x, centerline_z + axial)
+        };
+        *slot = perpendicular_median_ground_y(
+            editor,
+            sx,
+            sz,
+            centerline_x,
+            centerline_z,
+            block_range,
+            dir_horizontal,
+        );
+    }
 }
 
 /// Median of the ground levels along the road's width-perpendicular strip
@@ -593,6 +645,24 @@ fn generate_highways_internal(
                         // to a single statement.
                         let use_absolute_y = is_valley_bridge || flatten_width;
 
+                        // Precompute per-axial-offset perpendicular medians
+                        // once for this centerline. Every cell in the stamp
+                        // that shares an axial offset picks up the same
+                        // value — without this cache, we'd recompute the
+                        // full 3-tap median (which itself touches ~15
+                        // ground samples) for every `(dx, dz)` cell, making
+                        // wide-road rendering O(width²) per centerline.
+                        let mut row_medians = [0i32; 2 * MAX_BLOCK_RANGE + 1];
+                        if flatten_width {
+                            precompute_row_medians(
+                                editor,
+                                *x,
+                                *z,
+                                block_range,
+                                dir_horizontal,
+                                &mut row_medians,
+                            );
+                        }
                         // Draw the road surface for the entire width
                         for dx in -block_range..=block_range {
                             for dz in -block_range..=block_range {
@@ -608,15 +678,8 @@ fn generate_highways_internal(
                                 let cell_y = if is_valley_bridge {
                                     bridge_deck_y
                                 } else if flatten_width {
-                                    perpendicular_median_ground_y(
-                                        editor,
-                                        set_x,
-                                        set_z,
-                                        *x,
-                                        *z,
-                                        block_range,
-                                        dir_horizontal,
-                                    ) + offset
+                                    let axial = if dir_horizontal { dx } else { dz };
+                                    row_medians[(axial + block_range) as usize] + offset
                                 } else {
                                     offset
                                 };
@@ -834,18 +897,15 @@ fn generate_highways_internal(
                                 for (off_dx, off_dz) in [edge_a, edge_b] {
                                     let outline_x = x + sweep_dx + off_dx;
                                     let outline_z = z + sweep_dz + off_dz;
+                                    // Outline rides the same cross-section Y
+                                    // as the adjacent road cell at this
+                                    // axial offset. Reuse the precomputed
+                                    // table so we don't redo the 3-tap
+                                    // median twice per delta.
                                     let outline_y = if is_valley_bridge {
                                         bridge_deck_y
                                     } else if flatten_width {
-                                        perpendicular_median_ground_y(
-                                            editor,
-                                            outline_x,
-                                            outline_z,
-                                            *x,
-                                            *z,
-                                            block_range,
-                                            dir_horizontal,
-                                        ) + offset
+                                        row_medians[(delta + block_range) as usize] + offset
                                     } else {
                                         offset
                                     };
@@ -880,18 +940,13 @@ fn generate_highways_internal(
                             if stripe_length < dash_length {
                                 let stripe_x: i32 = *x;
                                 let stripe_z: i32 = *z;
+                                // Stripe sits on the centerline itself —
+                                // axial offset 0, so the precomputed
+                                // middle entry is the one we want.
                                 let stripe_y = if is_valley_bridge {
                                     bridge_deck_y
                                 } else if flatten_width {
-                                    perpendicular_median_ground_y(
-                                        editor,
-                                        stripe_x,
-                                        stripe_z,
-                                        *x,
-                                        *z,
-                                        block_range,
-                                        dir_horizontal,
-                                    ) + offset
+                                    row_medians[block_range as usize] + offset
                                 } else {
                                     offset
                                 };

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -29,6 +29,7 @@ use crate::ground::Ground;
 use crate::progress::emit_gui_progress_update;
 use colored::Colorize;
 use fastnbt::{IntArray, Value};
+use fnv::FnvHashMap;
 use serde::Serialize;
 use std::collections::{hash_map::Entry, HashMap};
 use std::fs::File;
@@ -125,7 +126,10 @@ pub struct WorldEditor<'a> {
     /// `ground_generation` pass builds the surface at the road's level —
     /// producing a natural-looking embankment on the low side and a cut on
     /// the high side rather than a floating strip with cliffs at the edges.
-    road_surface_overrides: HashMap<(i32, i32), i32>,
+    ///
+    /// Uses FNV hashing (not SipHash): `get_ground_level` sits on a hot
+    /// path (called per-block during placement), so the hash cost matters.
+    road_surface_overrides: FnvHashMap<(i32, i32), i32>,
     /// Optional level name for Bedrock worlds (e.g., "Arnis World: New York City")
     #[cfg(feature = "bedrock")]
     bedrock_level_name: Option<String>,
@@ -147,7 +151,7 @@ impl<'a> WorldEditor<'a> {
             llbbox,
             ground: None,
             format: WorldFormat::JavaAnvil,
-            road_surface_overrides: HashMap::new(),
+            road_surface_overrides: FnvHashMap::default(),
             #[cfg(feature = "bedrock")]
             bedrock_level_name: None,
             #[cfg(feature = "bedrock")]
@@ -178,7 +182,7 @@ impl<'a> WorldEditor<'a> {
             llbbox,
             ground: None,
             format,
-            road_surface_overrides: HashMap::new(),
+            road_surface_overrides: FnvHashMap::default(),
             #[cfg(feature = "bedrock")]
             bedrock_level_name,
             #[cfg(feature = "bedrock")]
@@ -213,10 +217,18 @@ impl<'a> WorldEditor<'a> {
     /// Checks the road-surface override map first so that a later
     /// `ground_generation` pass will build terrain matching the road's
     /// flattened cross-section. Falls back to `Ground::level` otherwise.
+    ///
+    /// The `is_empty` guard matters: this function is called per-block
+    /// during element processing, so every element placed before highways
+    /// run (most elements in small bboxes, all non-road elements before
+    /// priority-ordering kicks highways to the front) would otherwise pay
+    /// a hash + bucket-probe per call even though the map is empty.
     #[inline(always)]
     pub fn get_ground_level(&self, x: i32, z: i32) -> i32 {
-        if let Some(&y) = self.road_surface_overrides.get(&(x, z)) {
-            return y;
+        if !self.road_surface_overrides.is_empty() {
+            if let Some(&y) = self.road_surface_overrides.get(&(x, z)) {
+                return y;
+            }
         }
         if let Some(ground) = &self.ground {
             ground.level(XZPoint::new(


### PR DESCRIPTION
Commit 12c7a7d (Flatten wide roads across their width and grade terrain to match) introduced three bottlenecks that together roughly doubled generation time on `--terrain` runs (benchmark on Munich bbox: ~20s → ~36s on GitHub Actions; ~13s → ~24s locally).

Root causes, in order of impact:

1. Per-cell perpendicular-median recomputation. For every `(dx, dz)` in a centerline's `(2b+1) × (2b+1)` stamp we called `perpendicular_median_ground_y`, which kicks off a 3-tap median over three perpendicular strips — 3 × (2b+1) ≈ 15 `get_ground_level` lookups per cell. But the function ignores the cross-axis position (`set_z` for horizontal travel, `set_x` for vertical), so every cell sharing an axial offset picks up the same value. We now precompute one entry per axial offset at the top of each centerline iteration and index into it in the inner loops (main stamp, outline, stripe), dropping the call count by a factor of 2b+1.

2. `perpendicular_median_raw` allocated a `Vec` every call for up to 15 i32s. Switched to a stack buffer sized by `MAX_BLOCK_RANGE = 8` (generous ceiling; `debug_assert` catches overflow). Millions of allocations eliminated on city-scale bboxes.

3. `WorldEditor::road_surface_overrides` used `std::HashMap` (SipHash). Because `get_ground_level` now consults it on every call, and `get_ground_level` is a per-block hot path far beyond road cells, the hash cost leaked into every element handler. Switched to `FnvHashMap` and added an `is_empty()` guard so handlers running before any road has registered an override pay nothing at all.

Local measurements on the CI bbox `48.125768,11.552296,48.148565,11.593838` with `--terrain` (integer seconds, mean of 5 runs):

  pre-fix HEAD:           ~24 s
  post-fix:               ~18-19 s   (-5-6 s, matches pre-12c7a7d level)
  commit just before 12c7a7d (4922945): ~19 s

The fix recovers the full road-flatten regression. Any additional slowdown versus the April 20 baseline (~20 s CI) comes from the rest of the multi-source elevation pipeline, which is real new work, not a bug to remove here.

Semantics preserved: the precomputed table holds exactly the values the old per-cell call would have returned (`perpendicular_median_ground_y` is a pure function of axial position once the cross-axis coordinate is confirmed unused). `FnvHashMap` is API-compatible with `HashMap` for this map's use (insert + get, no ordering dependence).

Tests: 65/65 pass, clippy -D warnings clean, fmt clean.