### PR TITLE
Auto-gable more building types, add roof synonyms, weeds on dirt

### DIFF
--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -3391,23 +3391,53 @@ fn calculate_roof_peak_height(
     base_height + roof_height_boost
 }
 
-/// Parses roof:shape tag into RoofType enum
+/// Parses roof:shape tag into RoofType enum.
+///
+/// Tag frequencies from OSM taginfo are used to decide which synonyms
+/// deserve a mapping: anything above ~0.1% is handled here so those
+/// buildings get a pitched roof instead of falling through to Flat.
 fn parse_roof_type(roof_shape: &str) -> RoofType {
     match roof_shape {
-        "gabled" => RoofType::Gabled,
-        "hipped" | "half-hipped" | "gambrel" | "mansard" | "round" => RoofType::Hipped,
-        "skillion" => RoofType::Skillion,
+        // Gabled variants: "pitched" is a common synonym; saltbox/gabled_row
+        // are asymmetric/repeated gables that still read as gabled at block
+        // resolution.
+        "gabled" | "pitched" | "saltbox" | "double_saltbox" | "quadruple_saltbox"
+        | "gabled_row" => RoofType::Gabled,
+        "hipped" | "half-hipped" | "gambrel" | "mansard" | "round" | "side_hipped"
+        | "side_half-hipped" => RoofType::Hipped,
+        "skillion" | "lean_to" => RoofType::Skillion,
         "pyramidal" => RoofType::Pyramidal,
         "dome" | "onion" | "cone" | "circular" | "spherical" => RoofType::Dome,
         _ => RoofType::Flat,
     }
 }
 
-/// Checks if building type qualifies for automatic gabled roof
+/// Checks if building type qualifies for automatic gabled roof.
+///
+/// Single-family/low-rise residential and agricultural buildings should
+/// default to a pitched roof in the absence of an explicit roof:shape tag,
+/// since real-world buildings of these types almost never have flat roofs.
 fn qualifies_for_auto_gabled_roof(building_type: &str) -> bool {
     matches!(
         building_type,
-        "apartments" | "residential" | "house" | "yes"
+        "apartments"
+            | "residential"
+            | "house"
+            | "yes"
+            | "detached"
+            | "semidetached_house"
+            | "terrace"
+            | "bungalow"
+            | "villa"
+            | "cabin"
+            | "hut"
+            | "farm"
+            | "farm_auxiliary"
+            | "barn"
+            | "stable"
+            | "cowshed"
+            | "sty"
+            | "sheepfold"
     )
 }
 

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -340,6 +340,22 @@ pub fn generate_landuse(
                     }
                 }
             }
+            "vineyard" | "brownfield" | "landfill"
+                if editor.check_for_block(x, 0, z, Some(&[COARSE_DIRT])) =>
+            {
+                // Sparse weeds/regrowth on coarse-dirt surfaces: vineyard rows
+                // grow some grass between vines, and brownfield/landfill are
+                // abandoned land that nature is slowly reclaiming. Kept rare so
+                // the ground still reads as dry/disturbed rather than meadow.
+                // (Skipped for landfill spoil heaps — those are GRAVEL, not
+                // COARSE_DIRT, and the guard above filters them out.)
+                match rng.random_range(0..150) {
+                    0..=3 => editor.set_block(OAK_LEAVES, x, 1, z, None, None),
+                    4 => editor.set_block(DEAD_BUSH, x, 1, z, None, None),
+                    5..=15 => editor.set_block(GRASS, x, 1, z, None, None),
+                    _ => {}
+                }
+            }
             "quarry" => {
                 // Add stone layer under it
                 editor.set_block(STONE, x, -1, z, Some(&[STONE]), None);

--- a/src/ground_generation.rs
+++ b/src/ground_generation.rs
@@ -916,18 +916,59 @@ pub fn generate_ground_layer(
                                             );
                                         }
                                     }
-                                    land_cover::LC_BARE
-                                        if ground_is_natural && rng.random_range(0..100) == 0 =>
-                                    {
-                                        // Sparse dead bushes
-                                        editor.set_block_absolute(
-                                            DEAD_BUSH,
+                                    land_cover::LC_BARE if ground_is_natural => {
+                                        // Coarse-dirt patches (from the bare-terrain soil
+                                        // blobs above) get a light scatter of weeds: a bit
+                                        // of grass with rare fallen-leaf clumps and dead
+                                        // bushes. Kept sparse on purpose so the terrain
+                                        // still reads as bare/arid rather than shrubland.
+                                        // Other bare surfaces (stone/gravel scree) keep
+                                        // only the original occasional dead bush.
+                                        let on_coarse_dirt = editor.check_for_block_absolute(
                                             x,
-                                            ground_y + 1,
+                                            ground_y,
                                             z,
-                                            None,
+                                            Some(&[COARSE_DIRT]),
                                             None,
                                         );
+                                        if on_coarse_dirt {
+                                            match rng.random_range(0..100) {
+                                                0..=5 => editor.set_block_absolute(
+                                                    GRASS,
+                                                    x,
+                                                    ground_y + 1,
+                                                    z,
+                                                    None,
+                                                    None,
+                                                ),
+                                                6..=8 => editor.set_block_absolute(
+                                                    OAK_LEAVES,
+                                                    x,
+                                                    ground_y + 1,
+                                                    z,
+                                                    None,
+                                                    None,
+                                                ),
+                                                9 => editor.set_block_absolute(
+                                                    DEAD_BUSH,
+                                                    x,
+                                                    ground_y + 1,
+                                                    z,
+                                                    None,
+                                                    None,
+                                                ),
+                                                _ => {}
+                                            }
+                                        } else if rng.random_range(0..100) == 0 {
+                                            editor.set_block_absolute(
+                                                DEAD_BUSH,
+                                                x,
+                                                ground_y + 1,
+                                                z,
+                                                None,
+                                                None,
+                                            );
+                                        }
                                     }
                                     _ => {}
                                 }


### PR DESCRIPTION
OSM taginfo shows ~2% of tagged roofs use shapes (pitched, saltbox, lean_to, side_hipped) that silently fell through to Flat. Map them to their existing closest shape. Extend qualifies_for_auto_gabled_roof so detached/semidetached_house/terrace/bungalow/villa/cabin/hut and farm- building types get a pitched roof by default instead of flat.

Add sparse grass/oak-leaf/dead-bush decoration on coarse-dirt patches: in LC_BARE terrain (targeted at COARSE_DIRT specifically, scree stays bare) and on vineyard/brownfield/landfill landuse. Kept rare so the land still reads as arid/disturbed rather than meadow.