### PR TITLE
Extend build height via bundled datapack (Java) and behavior pack (Bedrock)

### DIFF
--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -76,7 +76,7 @@ jobs:
           # the road-flatten perf fix (PR #965), and the grid-precision shrink.
           # Update this value whenever main-branch generation changes materially
           # so the verdict thresholds below stay meaningful.
-          baseline_time=30
+          baseline_time=27
           diff=$((duration - baseline_time))
           abs_diff=${diff#-}
 

--- a/assets/minecraft/bp_tall/dimensions/overworld.json
+++ b/assets/minecraft/bp_tall/dimensions/overworld.json
@@ -1,0 +1,17 @@
+{
+  "format_version": "1.18.0",
+  "minecraft:dimension": {
+    "description": {
+      "identifier": "minecraft:overworld"
+    },
+    "components": {
+      "minecraft:dimension_bounds": {
+        "min": -512,
+        "max": 512
+      },
+      "minecraft:generation": {
+        "generator_type": "void"
+      }
+    }
+  }
+}

--- a/assets/minecraft/bp_tall/manifest.json
+++ b/assets/minecraft/bp_tall/manifest.json
@@ -1,0 +1,17 @@
+{
+  "format_version": 2,
+  "header": {
+    "name": "Arnis Extended Build Height",
+    "description": "Extends the Overworld build height for Arnis-generated worlds.",
+    "uuid": "a7f3b2e0-8c4d-4e92-9b1a-3d7f5c8e4a61",
+    "version": [1, 0, 0],
+    "min_engine_version": [1, 21, 40]
+  },
+  "modules": [
+    {
+      "type": "data",
+      "uuid": "b8e4c3f1-9d5e-4fa3-ac2b-4e8f6d9f5b72",
+      "version": [1, 0, 0]
+    }
+  ]
+}

--- a/assets/minecraft/datapack_tall/data/minecraft/dimension_type/overworld.json
+++ b/assets/minecraft/datapack_tall/data/minecraft/dimension_type/overworld.json
@@ -1,0 +1,23 @@
+{
+  "ambient_light": 0.0,
+  "bed_works": true,
+  "coordinate_scale": 1.0,
+  "effects": "minecraft:overworld",
+  "has_ceiling": false,
+  "has_raids": true,
+  "has_skylight": true,
+  "height": 4064,
+  "infiniburn": "#minecraft:infiniburn_overworld",
+  "logical_height": 4064,
+  "min_y": -2032,
+  "monster_spawn_block_light_limit": 0,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "max_inclusive": 7,
+    "min_inclusive": 0
+  },
+  "natural": true,
+  "piglin_safe": false,
+  "respawn_anchor_works": false,
+  "ultrawarm": false
+}

--- a/assets/minecraft/datapack_tall/pack.mcmeta
+++ b/assets/minecraft/datapack_tall/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 61,
+    "description": "Arnis extended build height (1.21.4)"
+  }
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -83,10 +83,8 @@ pub struct Args {
     #[arg(long, default_value_t = 0.0, allow_hyphen_values = true)]
     pub rotation: f64,
 
-    /// Disable the Minecraft build height limit (Y=319).
-    /// When enabled, terrain will use realistic 1:1 scaling without compression,
-    /// even if it exceeds the vanilla height limit.
-    /// Requires a Minecraft data pack that increases the world height.
+    /// Extend build height via a bundled pack (Java 1.21.4+: Y=-2032..2031;
+    /// Bedrock 1.21.40+: Y=-512..512). Both are experimental.
     #[arg(long, default_value_t = false)]
     pub disable_height_limit: bool,
 

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -47,6 +47,7 @@ pub fn generate_world_with_options(
         options.format,
         options.level_name.clone(),
         options.spawn_point,
+        args.disable_height_limit,
     );
     let ground = Arc::new(ground);
 

--- a/src/elevation/mod.rs
+++ b/src/elevation/mod.rs
@@ -106,6 +106,7 @@ pub fn fetch_elevation_data(
     scale: f64,
     ground_level: i32,
     disable_height_limit: bool,
+    extended_max_y: i32,
     land_cover: Option<&mut LandCoverData>,
 ) -> Result<ElevationData, Box<dyn std::error::Error>> {
     let (world_width, world_height, grid_width, grid_height) = compute_grid_dims(bbox, scale);
@@ -215,7 +216,13 @@ pub fn fetch_elevation_data(
         );
     }
 
-    let mc_heights = scale_to_minecraft(&height_grid, scale, ground_level, disable_height_limit);
+    let mc_heights = scale_to_minecraft(
+        &height_grid,
+        scale,
+        ground_level,
+        disable_height_limit,
+        extended_max_y,
+    );
 
     // Log min/max block heights
     let mut min_block_height = f64::MAX;

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -1,6 +1,4 @@
 use crate::land_cover::{LandCoverData, LC_BUILT_UP, LC_WATER};
-#[cfg(feature = "gui")]
-use crate::telemetry::{send_log, LogLevel};
 use rayon::prelude::*;
 use std::collections::VecDeque;
 
@@ -1157,11 +1155,14 @@ pub fn filter_elevation_outliers(height_grid: &mut [Vec<f64>]) {
 }
 
 /// Scale raw elevation (meters) to Minecraft Y coordinates, keeping f64 precision.
+/// `extended_max_y` is the cap when `disable_height_limit` is on (Java datapack:
+/// 2031; Bedrock BP: 512); ignored otherwise.
 pub fn scale_to_minecraft(
     blurred_heights: &[Vec<f64>],
     scale: f64,
     ground_level: i32,
     disable_height_limit: bool,
+    extended_max_y: i32,
 ) -> Vec<Vec<f64>> {
     // Derive min/max
     let (min_height, max_height) = blurred_heights
@@ -1189,16 +1190,17 @@ pub fn scale_to_minecraft(
             (min_height, max_height, max_height - min_height)
         };
 
-    let ideal_scaled_range: f64 = height_range * scale;
-    let available_y_range: f64 = (MAX_Y - TERRAIN_HEIGHT_BUFFER - ground_level) as f64;
+    let effective_max_y = if disable_height_limit {
+        extended_max_y
+    } else {
+        MAX_Y
+    };
+    let upper_clamp = (effective_max_y - TERRAIN_HEIGHT_BUFFER) as f64;
 
-    let scaled_range: f64 = if disable_height_limit {
-        eprintln!(
-            "Height limit disabled: {:.1}m range => {:.0} blocks (no compression)",
-            height_range, ideal_scaled_range
-        );
-        ideal_scaled_range
-    } else if ideal_scaled_range <= available_y_range {
+    let ideal_scaled_range: f64 = height_range * scale;
+    let available_y_range: f64 = (effective_max_y - TERRAIN_HEIGHT_BUFFER - ground_level) as f64;
+
+    let scaled_range: f64 = if ideal_scaled_range <= available_y_range {
         eprintln!(
             "Realistic elevation: {:.1}m range fits in {} available blocks",
             height_range, available_y_range as i32
@@ -1229,41 +1231,11 @@ pub fn scale_to_minecraft(
                     };
                     let scaled_height: f64 = relative_height * scaled_range;
                     let mc_y = ground_level as f64 + scaled_height;
-                    if disable_height_limit {
-                        mc_y
-                    } else {
-                        mc_y.clamp(ground_level as f64, (MAX_Y - TERRAIN_HEIGHT_BUFFER) as f64)
-                    }
+                    mc_y.clamp(ground_level as f64, upper_clamp)
                 })
                 .collect()
         })
         .collect();
-
-    // Warn if terrain exceeds the absolute Minecraft data pack maximum
-    const DATA_PACK_MAX_Y: i32 = 2031;
-    if disable_height_limit {
-        let max_block_height = mc_heights
-            .iter()
-            .flat_map(|row| row.iter())
-            .copied()
-            .fold(f64::MIN, f64::max)
-            .round() as i32;
-        if max_block_height > DATA_PACK_MAX_Y {
-            eprintln!(
-                "Warning: Terrain peak reaches Y={}, which exceeds the maximum data pack height (Y={}). \
-                 Blocks above Y={} will be truncated.",
-                max_block_height, DATA_PACK_MAX_Y, DATA_PACK_MAX_Y
-            );
-            #[cfg(feature = "gui")]
-            send_log(
-                LogLevel::Warning,
-                &format!(
-                    "Terrain peak Y={} exceeds data pack max Y={}. Blocks will be truncated.",
-                    max_block_height, DATA_PACK_MAX_Y
-                ),
-            );
-        }
-    }
 
     mc_heights
 }

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -54,6 +54,7 @@ impl Ground {
         ground_level: i32,
         fetch_land_cover: bool,
         disable_height_limit: bool,
+        extended_max_y: i32,
     ) -> Self {
         // Fetch land cover FIRST so we can feed it into the elevation
         // post-processing pipeline for land-cover-aware artifact repair.
@@ -77,6 +78,7 @@ impl Ground {
             scale,
             ground_level,
             disable_height_limit,
+            extended_max_y,
             land_cover.as_mut(),
         ) {
             Ok(elevation_data) => Self {
@@ -456,6 +458,7 @@ pub fn generate_ground_data(args: &Args) -> Ground {
             args.ground_level,
             args.land_cover,
             args.disable_height_limit,
+            extended_max_y_for(args),
         );
         if args.debug {
             ground.save_debug_image("elevation_debug");
@@ -463,4 +466,14 @@ pub fn generate_ground_data(args: &Args) -> Ground {
         return ground;
     }
     Ground::new_flat(args.ground_level)
+}
+
+/// Per-format build-height cap when the user opts into extended build height:
+/// 2031 for the Java datapack, 512 for the Bedrock behavior pack.
+pub(crate) fn extended_max_y_for(args: &Args) -> i32 {
+    if args.bedrock {
+        512
+    } else {
+        2031
+    }
 }

--- a/src/ground_generation.rs
+++ b/src/ground_generation.rs
@@ -355,12 +355,14 @@ pub fn generate_ground_layer(
                                 // any more — that's a normal hiking incline where
                                 // grass and trees belong.
                                 if slope > 8 {
-                                    // Sheer cliff: deepslate face with weathered breaks.
+                                    // Sheer cliff: each column is 100% one material
+                                    // so the downward under-fill matches the surface,
+                                    // producing vertical stripes of cobbled/deepslate.
                                     let h = land_cover::coord_hash(x, z);
-                                    if h.is_multiple_of(4) {
-                                        (COBBLED_DEEPSLATE, DEEPSLATE) // 25%
+                                    if h.is_multiple_of(2) {
+                                        (COBBLED_DEEPSLATE, COBBLED_DEEPSLATE)
                                     } else {
-                                        (DEEPSLATE, DEEPSLATE) // 75%
+                                        (DEEPSLATE, DEEPSLATE)
                                     }
                                 } else if slope > 6 {
                                     // Very steep rock face: stone-dominant with
@@ -495,8 +497,8 @@ pub fn generate_ground_layer(
                                 // class to pick instead).
                                 if slope > 8 {
                                     let h = land_cover::coord_hash(x, z);
-                                    if h.is_multiple_of(4) {
-                                        (COBBLED_DEEPSLATE, DEEPSLATE)
+                                    if h.is_multiple_of(2) {
+                                        (COBBLED_DEEPSLATE, COBBLED_DEEPSLATE)
                                     } else {
                                         (DEEPSLATE, DEEPSLATE)
                                     }
@@ -648,7 +650,7 @@ pub fn generate_ground_layer(
                                     // neighbor, capped to avoid excessive work on
                                     // extreme elevation changes (same cap as the
                                     // universal depth fill below).
-                                    (ground_y - min_neighbor_y + 1).clamp(2, 32)
+                                    (ground_y - min_neighbor_y + 1).clamp(2, 64)
                                 } else {
                                     2
                                 };
@@ -1002,7 +1004,7 @@ pub fn generate_ground_layer(
                                     min_neighbor_y = ny;
                                 }
                             }
-                            let depth = (ground_y - min_neighbor_y + 1).clamp(2, 32);
+                            let depth = (ground_y - min_neighbor_y + 1).clamp(2, 64);
                             let y_max = ground_y - 1;
                             let y_min = (ground_y - depth).max(MIN_Y + 1);
                             if y_min <= y_max {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -851,6 +851,11 @@ fn gui_start_generation(
             set_player_spawn_in_level_dat(&selected_world, spawn_x, spawn_z)
                 .map_err(|e| format!("Failed to set spawn point: {e}"))?;
 
+            if disable_height_limit {
+                crate::world_utils::install_tall_datapack(std::path::Path::new(&selected_world))
+                    .map_err(|e| format!("Failed to install tall-world datapack: {e}"))?;
+            }
+
             Ok(())
         })();
 

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -140,11 +140,11 @@
         <!-- Section: World -->
         <div class="settings-section-header" data-localize="settings_section_world">World</div>
 
-        <!-- Disable Height Limit Toggle -->
+        <!-- Extend Build Height Toggle -->
         <div class="settings-row">
           <label for="disable-height-limit-toggle">
-            <span data-localize="disable_height_limit">Disable Height Limit</span>
-            <span class="tooltip-icon" data-tooltip="Disable the vanilla Y=319 build height cap. Terrain will use realistic 1:1 scaling without compression. Requires a Minecraft data pack that increases the world height.">?</span>
+            <span data-localize="disable_height_limit">Extend build height</span>
+            <span class="tooltip-icon" data-tooltip="Bundles a pack that raises the build height for 1:1 terrain. Java 1.21.4+ / Bedrock 1.21.40+ (experimental, no Realms)">?</span>
           </label>
           <div class="settings-control">
             <input type="checkbox" id="disable-height-limit-toggle" name="disable-height-limit-toggle">
@@ -256,7 +256,7 @@
         <!-- Telemetry Consent Toggle -->
         <div class="settings-row">
           <label for="telemetry-toggle" style="white-space: nowrap;">
-            <span>Anonymous Crash Reports</span>
+            <span data-localize="anonymous_crash_reports">Anonymous Crash Reports</span>
             <span class="tooltip-icon" data-tooltip="Send anonymous crash data to help improve Arnis">?</span>
           </label>
           <div class="settings-control">

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -117,6 +117,7 @@ async function applyLocalization(localization) {
     "span[data-localize='fillground']": "fillground",
     "span[data-localize='land_cover']": "land_cover",
     "span[data-localize='disable_height_limit']": "disable_height_limit",
+    "span[data-localize='anonymous_crash_reports']": "anonymous_crash_reports",
     "span[data-localize='map_theme']": "map_theme",
     "span[data-localize='save_path']": "save_path",
     "span[data-localize='rotation_angle']": "rotation_angle",
@@ -523,23 +524,18 @@ function updateFormatToggleUI(format) {
 
   const heightLimitToggle = document.getElementById('disable-height-limit-toggle');
 
+  // Toggle now supported on both formats (Java datapack + Bedrock BP).
+  if (heightLimitToggle) {
+    heightLimitToggle.disabled = false;
+    heightLimitToggle.parentElement.closest('.settings-row').style.opacity = '1';
+  }
+
   if (format === 'java') {
     javaBtn.classList.add('format-active');
     bedrockBtn.classList.remove('format-active');
-    // Re-enable height limit toggle for Java
-    if (heightLimitToggle) {
-      heightLimitToggle.disabled = false;
-      heightLimitToggle.parentElement.closest('.settings-row').style.opacity = '1';
-    }
   } else {
     javaBtn.classList.remove('format-active');
     bedrockBtn.classList.add('format-active');
-    // Disable height limit toggle for Bedrock (not supported)
-    if (heightLimitToggle) {
-      heightLimitToggle.checked = false;
-      heightLimitToggle.disabled = true;
-      heightLimitToggle.parentElement.closest('.settings-row').style.opacity = '0.5';
-    }
     // Clear world path for bedrock (auto-generated)
     worldPath = "";
   }

--- a/src/gui/locales/ar.json
+++ b/src/gui/locales/ar.json
@@ -42,7 +42,7 @@
   "roof": "توليد السقف",
   "fillground": "ملء الأرض",
   "land_cover": "تصنيف الأرض",
-  "disable_height_limit": "تعطيل حد الارتفاع",
+  "disable_height_limit": "توسيع ارتفاع البناء",
   "bedrock_auto_generated": "يتم إنشاء عالم Bedrock تلقائيًا",
   "save_path": "مسار الحفظ",
   "rotation_angle": "زاوية الدوران",
@@ -51,5 +51,6 @@
   "settings_section_map": "الخريطة والإدخال",
   "settings_section_application": "التطبيق",
   "clear_tile_cache": "مسح ذاكرة البلاطات",
-  "clear_tile_cache_button": "مسح"
+  "clear_tile_cache_button": "مسح",
+  "anonymous_crash_reports": "تقارير الأعطال المجهولة"
 }

--- a/src/gui/locales/de.json
+++ b/src/gui/locales/de.json
@@ -42,7 +42,7 @@
   "roof": "Dach Generierung",
   "fillground": "Boden füllen",
   "land_cover": "Landbedeckung",
-  "disable_height_limit": "Höhenlimit deaktivieren",
+  "disable_height_limit": "Bauhöhe erweitern",
   "bedrock_auto_generated": "Bedrock-Welt wird automatisch generiert",
   "save_path": "Speicherpfad",
   "rotation_angle": "Rotationswinkel",
@@ -51,5 +51,6 @@
   "settings_section_map": "Karte & Eingabe",
   "settings_section_application": "Anwendung",
   "clear_tile_cache": "Tile-Cache leeren",
-  "clear_tile_cache_button": "Leeren"
+  "clear_tile_cache_button": "Leeren",
+  "anonymous_crash_reports": "Anonyme Absturzberichte"
 }

--- a/src/gui/locales/en-US.json
+++ b/src/gui/locales/en-US.json
@@ -42,7 +42,7 @@
   "roof": "Roof Generation",
   "fillground": "Fill Ground",
   "land_cover": "Land Cover",
-  "disable_height_limit": "Disable Height Limit",
+  "disable_height_limit": "Extend build height",
   "bedrock_auto_generated": "Bedrock world is auto-generated",
   "save_path": "Save Path",
   "rotation_angle": "Rotation Angle",
@@ -51,5 +51,6 @@
   "settings_section_map": "Map & Input",
   "settings_section_application": "Application",
   "clear_tile_cache": "Clear Tile Cache",
-  "clear_tile_cache_button": "Clear"
+  "clear_tile_cache_button": "Clear",
+  "anonymous_crash_reports": "Anonymous Crash Reports"
 }

--- a/src/gui/locales/es.json
+++ b/src/gui/locales/es.json
@@ -42,7 +42,7 @@
   "roof": "Generación de Tejado",
   "fillground": "Rellenar Suelo",
   "land_cover": "Cobertura del suelo",
-  "disable_height_limit": "Desactivar límite de altura",
+  "disable_height_limit": "Ampliar altura de construcción",
   "bedrock_auto_generated": "El mundo Bedrock se genera automáticamente",
   "save_path": "Ruta de guardado",
   "rotation_angle": "Ángulo de Rotación",
@@ -51,5 +51,6 @@
   "settings_section_map": "Mapa y entrada",
   "settings_section_application": "Aplicación",
   "clear_tile_cache": "Borrar caché de tiles",
-  "clear_tile_cache_button": "Borrar"
+  "clear_tile_cache_button": "Borrar",
+  "anonymous_crash_reports": "Informes de fallos anónimos"
 }

--- a/src/gui/locales/fi.json
+++ b/src/gui/locales/fi.json
@@ -42,7 +42,7 @@
   "roof": "Katon luonti",
   "fillground": "Täytä maa",
   "land_cover": "Maanpeite",
-  "disable_height_limit": "Poista korkeusraja käytöstä",
+  "disable_height_limit": "Laajenna rakennuskorkeutta",
   "bedrock_auto_generated": "Bedrock-maailma luodaan automaattisesti",
   "save_path": "Tallennuspolku",
   "rotation_angle": "Kiertokulma",
@@ -51,5 +51,6 @@
   "settings_section_map": "Kartta ja syöte",
   "settings_section_application": "Sovellus",
   "clear_tile_cache": "Tyhjennä laattojen välimuisti",
-  "clear_tile_cache_button": "Tyhjennä"
+  "clear_tile_cache_button": "Tyhjennä",
+  "anonymous_crash_reports": "Anonyymit kaatumisraportit"
 }

--- a/src/gui/locales/fr-FR.json
+++ b/src/gui/locales/fr-FR.json
@@ -42,7 +42,7 @@
   "roof": "Génération de toit",
   "fillground": "Remplir le sol",
   "land_cover": "Couverture du sol",
-  "disable_height_limit": "Désactiver la limite de hauteur",
+  "disable_height_limit": "Étendre la hauteur de construction",
   "bedrock_auto_generated": "Le monde Bedrock est généré automatiquement",
   "save_path": "Chemin de sauvegarde",
   "rotation_angle": "Angle de Rotation",
@@ -51,5 +51,6 @@
   "settings_section_map": "Carte et saisie",
   "settings_section_application": "Application",
   "clear_tile_cache": "Vider le cache de tuiles",
-  "clear_tile_cache_button": "Vider"
+  "clear_tile_cache_button": "Vider",
+  "anonymous_crash_reports": "Rapports d'erreurs anonymes"
 }

--- a/src/gui/locales/hu.json
+++ b/src/gui/locales/hu.json
@@ -42,7 +42,7 @@
   "roof": "Tető generálás",
   "fillground": "Talaj feltöltése",
   "land_cover": "Felszínborítás",
-  "disable_height_limit": "Magasságkorlát kikapcsolása",
+  "disable_height_limit": "Építési magasság kiterjesztése",
   "bedrock_auto_generated": "A Bedrock világ automatikusan generálódik",
   "save_path": "Mentési útvonal",
   "rotation_angle": "Forgatási Szög",
@@ -51,5 +51,6 @@
   "settings_section_map": "Térkép és bevitel",
   "settings_section_application": "Alkalmazás",
   "clear_tile_cache": "Csempe-gyorsítótár törlése",
-  "clear_tile_cache_button": "Törlés"
+  "clear_tile_cache_button": "Törlés",
+  "anonymous_crash_reports": "Névtelen összeomlási jelentések"
 }

--- a/src/gui/locales/ja.json
+++ b/src/gui/locales/ja.json
@@ -42,7 +42,7 @@
   "roof": "屋根生成",
   "fillground": "地面を埋める",
   "land_cover": "土地被覆",
-  "disable_height_limit": "高さ制限を無効にする",
+  "disable_height_limit": "建築高さを拡張",
   "bedrock_auto_generated": "Bedrock ワールドは自動生成されます",
   "save_path": "保存先",
   "rotation_angle": "回転角度",
@@ -51,5 +51,6 @@
   "settings_section_map": "マップと入力",
   "settings_section_application": "アプリケーション",
   "clear_tile_cache": "タイルキャッシュをクリア",
-  "clear_tile_cache_button": "クリア"
+  "clear_tile_cache_button": "クリア",
+  "anonymous_crash_reports": "匿名クラッシュレポート"
 }

--- a/src/gui/locales/ko.json
+++ b/src/gui/locales/ko.json
@@ -42,7 +42,7 @@
   "roof": "지붕 생성",
   "fillground": "지면 채우기",
   "land_cover": "토지 피복",
-  "disable_height_limit": "높이 제한 비활성화",
+  "disable_height_limit": "건축 높이 확장",
   "bedrock_auto_generated": "Bedrock 월드는 자동 생성됩니다",
   "save_path": "저장 경로",
   "rotation_angle": "회전 각도",
@@ -51,5 +51,6 @@
   "settings_section_map": "지도 및 입력",
   "settings_section_application": "애플리케이션",
   "clear_tile_cache": "타일 캐시 지우기",
-  "clear_tile_cache_button": "지우기"
+  "clear_tile_cache_button": "지우기",
+  "anonymous_crash_reports": "익명 크래시 보고"
 }

--- a/src/gui/locales/lt.json
+++ b/src/gui/locales/lt.json
@@ -42,7 +42,7 @@
   "roof": "Stogo generavimas",
   "fillground": "Užpildyti pagrindą",
   "land_cover": "Žemės danga",
-  "disable_height_limit": "Išjungti aukščio ribą",
+  "disable_height_limit": "Praplėsti statybos aukštį",
   "bedrock_auto_generated": "Bedrock pasaulis generuojamas automatiškai",
   "save_path": "Išsaugojimo kelias",
   "rotation_angle": "Pasukimo Kampas",
@@ -51,5 +51,6 @@
   "settings_section_map": "Žemėlapis ir įvestis",
   "settings_section_application": "Programa",
   "clear_tile_cache": "Išvalyti plytelių talpyklą",
-  "clear_tile_cache_button": "Išvalyti"
+  "clear_tile_cache_button": "Išvalyti",
+  "anonymous_crash_reports": "Anoniminės avarijų ataskaitos"
 }

--- a/src/gui/locales/lv.json
+++ b/src/gui/locales/lv.json
@@ -42,7 +42,7 @@
   "roof": "Jumta ģenerēšana",
   "fillground": "Aizpildīt zemi",
   "land_cover": "Zemes segums",
-  "disable_height_limit": "Atspējot augstuma ierobežojumu",
+  "disable_height_limit": "Paplašināt būvniecības augstumu",
   "bedrock_auto_generated": "Bedrock pasaule tiek ģenerēta automātiski",
   "save_path": "Saglabāšanas ceļš",
   "rotation_angle": "Rotācijas Leņķis",
@@ -51,5 +51,6 @@
   "settings_section_map": "Karte un ievade",
   "settings_section_application": "Lietotne",
   "clear_tile_cache": "Notīrīt flīžu kešatmiņu",
-  "clear_tile_cache_button": "Notīrīt"
+  "clear_tile_cache_button": "Notīrīt",
+  "anonymous_crash_reports": "Anonīmi avāriju ziņojumi"
 }

--- a/src/gui/locales/pl.json
+++ b/src/gui/locales/pl.json
@@ -42,7 +42,7 @@
   "roof": "Generowanie dachu",
   "fillground": "Wypełnij podłoże",
   "land_cover": "Pokrycie terenu",
-  "disable_height_limit": "Wyłącz limit wysokości",
+  "disable_height_limit": "Rozszerz wysokość budowania",
   "bedrock_auto_generated": "Świat Bedrock jest generowany automatycznie",
   "save_path": "Ścieżka zapisu",
   "rotation_angle": "Kąt Obrotu",
@@ -51,5 +51,6 @@
   "settings_section_map": "Mapa i dane",
   "settings_section_application": "Aplikacja",
   "clear_tile_cache": "Wyczyść pamięć kafelków",
-  "clear_tile_cache_button": "Wyczyść"
+  "clear_tile_cache_button": "Wyczyść",
+  "anonymous_crash_reports": "Anonimowe raporty o awariach"
 }

--- a/src/gui/locales/pt-BR.json
+++ b/src/gui/locales/pt-BR.json
@@ -42,7 +42,7 @@
   "roof": "Geração do telhado",
   "fillground": "Preencher solo",
   "land_cover": "Cobertura do solo",
-  "disable_height_limit": "Desativar limite de altura",
+  "disable_height_limit": "Ampliar altura de construção",
   "bedrock_auto_generated": "O mundo de bedrock é gerado automaticamente",
   "save_path": "Caminho de salvamento",
   "rotation_angle": "Ângulo de Rotação",
@@ -51,5 +51,6 @@
   "settings_section_map": "Mapa e entrada",
   "settings_section_application": "Aplicação",
   "clear_tile_cache": "Limpar cache de tiles",
-  "clear_tile_cache_button": "Limpar"
+  "clear_tile_cache_button": "Limpar",
+  "anonymous_crash_reports": "Relatórios anônimos de falhas"
 }

--- a/src/gui/locales/ru.json
+++ b/src/gui/locales/ru.json
@@ -42,7 +42,7 @@
   "roof": "Генерация Крыши",
   "fillground": "Заполнить Землю",
   "land_cover": "Земельный покров",
-  "disable_height_limit": "Отключить ограничение высоты",
+  "disable_height_limit": "Расширить высоту строительства",
   "bedrock_auto_generated": "Мир Bedrock генерируется автоматически",
   "save_path": "Путь сохранения",
   "rotation_angle": "Угол Поворота",
@@ -51,5 +51,6 @@
   "settings_section_map": "Карта и ввод",
   "settings_section_application": "Приложение",
   "clear_tile_cache": "Очистить кэш тайлов",
-  "clear_tile_cache_button": "Очистить"
+  "clear_tile_cache_button": "Очистить",
+  "anonymous_crash_reports": "Анонимные отчёты о сбоях"
 }

--- a/src/gui/locales/sl.json
+++ b/src/gui/locales/sl.json
@@ -42,7 +42,7 @@
   "roof": "Generiranje strehe",
   "fillground": "Zapolni tla",
   "land_cover": "Pokritost tal",
-  "disable_height_limit": "Onemogoči omejitev višine",
+  "disable_height_limit": "Razširi višino gradnje",
   "bedrock_auto_generated": "Bedrock svet je samodejno ustvarjen",
   "save_path": "Pot shranjevanja",
   "rotation_angle": "Kot zasuka",
@@ -51,5 +51,6 @@
   "settings_section_map": "Zemljevid in vnos",
   "settings_section_application": "Aplikacija",
   "clear_tile_cache": "Počisti predpomnilnik ploščic",
-  "clear_tile_cache_button": "Počisti"
+  "clear_tile_cache_button": "Počisti",
+  "anonymous_crash_reports": "Anonimna poročila o napakah"
 }

--- a/src/gui/locales/sv.json
+++ b/src/gui/locales/sv.json
@@ -42,7 +42,7 @@
   "roof": "Takgenerering",
   "fillground": "Fyll mark",
   "land_cover": "Marktäcke",
-  "disable_height_limit": "Inaktivera höjdgräns",
+  "disable_height_limit": "Utöka byggnadshöjd",
   "bedrock_auto_generated": "Bedrock-världen genereras automatiskt",
   "save_path": "Sökväg",
   "rotation_angle": "Rotationsvinkel",
@@ -51,5 +51,6 @@
   "settings_section_map": "Karta och inmatning",
   "settings_section_application": "Applikation",
   "clear_tile_cache": "Rensa plattcache",
-  "clear_tile_cache_button": "Rensa"
+  "clear_tile_cache_button": "Rensa",
+  "anonymous_crash_reports": "Anonyma kraschrapporter"
 }

--- a/src/gui/locales/ua.json
+++ b/src/gui/locales/ua.json
@@ -42,7 +42,7 @@
   "roof": "Генерація даху",
   "fillground": "Заповнити землю",
   "land_cover": "Земельне покриття",
-  "disable_height_limit": "Вимкнути обмеження висоти",
+  "disable_height_limit": "Розширити висоту будівництва",
   "bedrock_auto_generated": "Bedrock світ генерується автоматично",
   "save_path": "Шлях збереження",
   "rotation_angle": "Кут Обертання",
@@ -51,5 +51,6 @@
   "settings_section_map": "Карта та введення",
   "settings_section_application": "Застосунок",
   "clear_tile_cache": "Очистити кеш плиток",
-  "clear_tile_cache_button": "Очистити"
+  "clear_tile_cache_button": "Очистити",
+  "anonymous_crash_reports": "Анонімні звіти про збої"
 }

--- a/src/gui/locales/zh-CN.json
+++ b/src/gui/locales/zh-CN.json
@@ -42,7 +42,7 @@
   "roof": "屋顶生成",
   "fillground": "填充地面",
   "land_cover": "土地覆盖",
-  "disable_height_limit": "禁用高度限制",
+  "disable_height_limit": "扩展建造高度",
   "bedrock_auto_generated": "Bedrock 世界自动生成",
   "save_path": "存档路径",
   "rotation_angle": "旋转角度",
@@ -51,5 +51,6 @@
   "settings_section_map": "地图与输入",
   "settings_section_application": "应用",
   "clear_tile_cache": "清除瓦片缓存",
-  "clear_tile_cache_button": "清除"
+  "clear_tile_cache_button": "清除",
+  "anonymous_crash_reports": "匿名崩溃报告"
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -266,6 +266,16 @@ fn run_cli() {
         _ => None,
     };
 
+    // Derive terrain-aware spawn Y while `ground` is still in scope (it gets
+    // moved into `generate_world_with_options` below). Used only for Java's
+    // post-generation `set_spawn_in_level_dat` call — Bedrock derives spawn Y
+    // independently inside `BedrockWriter::write_level_dat`.
+    let spawn_y_for_java = spawn_point.map(|(sx, sz)| {
+        use coordinate_system::cartesian::XZPoint;
+        let rel = XZPoint::new(sx - xzbbox.min_x(), sz - xzbbox.min_z());
+        ground.level(rel) + 3
+    });
+
     // Build generation options
     let generation_options = data_processing::GenerationOptions {
         path: generation_path.clone(),
@@ -294,10 +304,13 @@ fn run_cli() {
 
             // For Java Edition, update spawn point in level.dat if provided
             if !args.bedrock {
-                if let Some((spawn_x, spawn_z)) = spawn_point {
-                    if let Err(e) =
-                        world_utils::set_spawn_in_level_dat(&generation_path, spawn_x, spawn_z)
-                    {
+                if let (Some((spawn_x, spawn_z)), Some(spawn_y)) = (spawn_point, spawn_y_for_java) {
+                    if let Err(e) = world_utils::set_spawn_in_level_dat(
+                        &generation_path,
+                        spawn_x,
+                        spawn_y,
+                        spawn_z,
+                    ) {
                         eprintln!(
                             "{} Failed to set spawn point in level.dat: {}",
                             "Warning:".yellow().bold(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,20 @@ fn run_cli() {
             "Created new world at: {}",
             world_path.display().to_string().bright_white().bold()
         );
+        if args.disable_height_limit {
+            if let Err(e) = world_utils::install_tall_datapack(&world_path) {
+                eprintln!(
+                    "{} Failed to install tall-world datapack: {}",
+                    "Error:".red().bold(),
+                    e
+                );
+                std::process::exit(1);
+            }
+            eprintln!(
+                "Note: tall-world datapack installed (requires Minecraft 1.21.4+). \
+                 First load will prompt 'Experimental Features'; world can't be uploaded to Realms."
+            );
+        }
         (world_path, None)
     };
 

--- a/src/world_editor/bedrock.rs
+++ b/src/world_editor/bedrock.rs
@@ -236,6 +236,11 @@ impl BedrockWriter {
             .as_secs() as i64;
 
         // Extended worlds require 1.21.40+ for Custom Biomes / dimension_bounds.
+        // Only the user-facing version markers are bumped; network_version and
+        // inventory_version stay at 1.21.0 because they're used for multiplayer
+        // protocol and inventory storage format, neither of which changes with
+        // the dimension_bounds feature. Bedrock tolerates this mix — what it
+        // gates on is last_opened_with_version and minimum_compatible_client_version.
         let version_array: Vec<i32> = if self.extend_build_height {
             vec![1, 21, 40, 0, 0]
         } else {

--- a/src/world_editor/bedrock.rs
+++ b/src/world_editor/bedrock.rs
@@ -128,6 +128,7 @@ pub struct BedrockWriter {
     level_name: String,
     spawn_point: Option<(i32, i32)>,
     ground: Option<Arc<Ground>>,
+    extend_build_height: bool,
 }
 
 impl BedrockWriter {
@@ -137,6 +138,7 @@ impl BedrockWriter {
         level_name: String,
         spawn_point: Option<(i32, i32)>,
         ground: Option<Arc<Ground>>,
+        extend_build_height: bool,
     ) -> Self {
         // If the path ends with .mcworld, use it as the final archive path
         // and create a temp directory without that extension for working files
@@ -151,6 +153,7 @@ impl BedrockWriter {
             level_name,
             spawn_point,
             ground,
+            extend_build_height,
         }
     }
 
@@ -232,8 +235,12 @@ impl BedrockWriter {
             .unwrap_or_default()
             .as_secs() as i64;
 
-        // Version array for Bedrock 1.21.x compatibility
-        let version_array = vec![1, 21, 0, 0, 0];
+        // Extended worlds require 1.21.40+ for Custom Biomes / dimension_bounds.
+        let version_array: Vec<i32> = if self.extend_build_height {
+            vec![1, 21, 40, 0, 0]
+        } else {
+            vec![1, 21, 0, 0, 0]
+        };
 
         // Build complete level.dat NBT structure
         let level_dat = BedrockLevelDat {
@@ -364,8 +371,14 @@ impl BedrockWriter {
             show_days_played: false,
             locator_bar: true,
             tnt_explosion_drop_decay: true,
-            saved_with_toggled_experiments: false,
-            experiments_ever_used: false,
+            // dimension_bounds is gated behind the Custom Biomes experiment;
+            // without these three flags the bundled BP is silently ignored
+            // and blocks above Y=319 disappear on first load.
+            saved_with_toggled_experiments: self.extend_build_height,
+            experiments_ever_used: self.extend_build_height,
+            experiments: BedrockExperiments {
+                data_driven_biomes: self.extend_build_height,
+            },
 
             // Editor
             editor_world_type: 0,
@@ -739,6 +752,33 @@ impl BedrockWriter {
         const WORLD_ICON: &[u8] = include_bytes!("../../assets/minecraft/world_icon.jpeg");
         writer.start_file("world_icon.jpeg", options)?;
         writer.write_all(WORLD_ICON)?;
+
+        if self.extend_build_height {
+            const BP_MANIFEST: &[u8] =
+                include_bytes!("../../assets/minecraft/bp_tall/manifest.json");
+            const BP_OVERWORLD: &[u8] =
+                include_bytes!("../../assets/minecraft/bp_tall/dimensions/overworld.json");
+            // Must match header.uuid in bp_tall/manifest.json.
+            const BP_HEADER_UUID: &str = "a7f3b2e0-8c4d-4e92-9b1a-3d7f5c8e4a61";
+
+            writer.add_directory("behavior_packs/", options)?;
+            writer.add_directory("behavior_packs/arnis_tall/", options)?;
+            writer.add_directory("behavior_packs/arnis_tall/dimensions/", options)?;
+
+            writer.start_file("behavior_packs/arnis_tall/manifest.json", options)?;
+            writer.write_all(BP_MANIFEST)?;
+
+            writer.start_file(
+                "behavior_packs/arnis_tall/dimensions/overworld.json",
+                options,
+            )?;
+            writer.write_all(BP_OVERWORLD)?;
+
+            writer.start_file("world_behavior_packs.json", options)?;
+            let world_bp_json =
+                format!(r#"[{{"pack_id":"{}","version":[1,0,0]}}]"#, BP_HEADER_UUID);
+            writer.write_all(world_bp_json.as_bytes())?;
+        }
 
         // Add db directory and its contents
         let db_path = self.output_dir.join("db");
@@ -1124,6 +1164,11 @@ struct BedrockLevelDat {
     saved_with_toggled_experiments: bool,
     #[serde(rename = "experiments_ever_used")]
     experiments_ever_used: bool,
+    /// Always emitted with all-false contents on standard worlds.
+    /// nbtx can't skip optional fields, and an all-false compound
+    /// is a no-op to Bedrock.
+    #[serde(rename = "experiments")]
+    experiments: BedrockExperiments,
 
     // Editor
     #[serde(rename = "editorWorldType")]
@@ -1150,6 +1195,14 @@ struct BedrockLevelDat {
     // Daylight cycle
     #[serde(rename = "daylightCycle")]
     daylight_cycle: i32,
+}
+
+/// Bedrock experimental-features NBT toggles. Must pair with
+/// `experiments_ever_used` + `saved_with_toggled_experiments` on the root.
+#[derive(Serialize)]
+struct BedrockExperiments {
+    /// Gates data-driven worldgen, incl. `minecraft:dimension_bounds`.
+    data_driven_biomes: bool,
 }
 
 #[cfg(test)]
@@ -1224,9 +1277,15 @@ mod tests {
         let xzbbox = XZBBox::rect_from_xz_lengths(15.0, 15.0).unwrap();
         let llbbox = LLBBox::new(0.0, 0.0, 1.0, 1.0).unwrap();
 
-        BedrockWriter::new(output_dir.clone(), "test-world".to_string(), None, None)
-            .write_world(&world, &xzbbox, &llbbox)
-            .expect("write_world");
+        BedrockWriter::new(
+            output_dir.clone(),
+            "test-world".to_string(),
+            None,
+            None,
+            false,
+        )
+        .write_world(&world, &xzbbox, &llbbox)
+        .expect("write_world");
 
         // The temp directory should be cleaned up, but mcworld should exist
         let mcworld_path = output_dir.with_extension("mcworld");
@@ -1270,6 +1329,7 @@ mod tests {
             "spawn-test".to_string(),
             Some((42, 84)),
             None,
+            false,
         )
         .write_world(&world, &xzbbox, &llbbox)
         .expect("write_world");
@@ -1277,5 +1337,75 @@ mod tests {
         // Verify the mcworld was created
         let mcworld_path = output_dir.with_extension("mcworld");
         assert!(mcworld_path.exists(), "mcworld file should exist");
+    }
+
+    #[test]
+    fn writes_mcworld_with_tall_behavior_pack_when_extended() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let output_dir = temp_dir.path().join("bedrock_world_tall");
+
+        let world = WorldToModify::default();
+        let xzbbox = XZBBox::rect_from_xz_lengths(15.0, 15.0).unwrap();
+        let llbbox = LLBBox::new(0.0, 0.0, 1.0, 1.0).unwrap();
+
+        BedrockWriter::new(
+            output_dir.clone(),
+            "tall-world".to_string(),
+            None,
+            None,
+            true,
+        )
+        .write_world(&world, &xzbbox, &llbbox)
+        .expect("write_world");
+
+        let mcworld_path = output_dir.with_extension("mcworld");
+        let file = fs::File::open(&mcworld_path).expect("mcworld archive exists");
+        let mut archive = ZipArchive::new(file).expect("zip readable");
+
+        let mut entries: Vec<String> = Vec::new();
+        for i in 0..archive.len() {
+            if let Ok(f) = archive.by_index(i) {
+                entries.push(f.name().to_string());
+            }
+        }
+
+        assert!(
+            entries.contains(&"world_behavior_packs.json".to_string()),
+            "missing world_behavior_packs.json: {entries:?}"
+        );
+        assert!(
+            entries.contains(&"behavior_packs/arnis_tall/manifest.json".to_string()),
+            "missing BP manifest: {entries:?}"
+        );
+        assert!(
+            entries.contains(&"behavior_packs/arnis_tall/dimensions/overworld.json".to_string()),
+            "missing BP overworld.json: {entries:?}"
+        );
+
+        // Pack won't load if header.uuid and pack_id drift apart.
+        let manifest_bytes = {
+            let mut f = archive
+                .by_name("behavior_packs/arnis_tall/manifest.json")
+                .expect("open manifest");
+            let mut buf = Vec::new();
+            std::io::Read::read_to_end(&mut f, &mut buf).expect("read manifest");
+            buf
+        };
+        let world_bp_bytes = {
+            let mut f = archive
+                .by_name("world_behavior_packs.json")
+                .expect("open world_behavior_packs.json");
+            let mut buf = Vec::new();
+            std::io::Read::read_to_end(&mut f, &mut buf).expect("read world_bp");
+            buf
+        };
+        let manifest: Value = serde_json::from_slice(&manifest_bytes).expect("manifest JSON");
+        let world_bp: Value = serde_json::from_slice(&world_bp_bytes).expect("world_bp JSON");
+        let header_uuid = manifest["header"]["uuid"].as_str().expect("header.uuid");
+        let listed_uuid = world_bp[0]["pack_id"].as_str().expect("pack_id");
+        assert_eq!(
+            header_uuid, listed_uuid,
+            "BP header UUID must match world_behavior_packs.json pack_id"
+        );
     }
 }

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -136,6 +136,8 @@ pub struct WorldEditor<'a> {
     /// Optional spawn point for Bedrock worlds (x, z coordinates)
     #[cfg(feature = "bedrock")]
     bedrock_spawn_point: Option<(i32, i32)>,
+    #[cfg(feature = "bedrock")]
+    bedrock_extend_height: bool,
 }
 
 impl<'a> WorldEditor<'a> {
@@ -156,6 +158,8 @@ impl<'a> WorldEditor<'a> {
             bedrock_level_name: None,
             #[cfg(feature = "bedrock")]
             bedrock_spawn_point: None,
+            #[cfg(feature = "bedrock")]
+            bedrock_extend_height: false,
         }
     }
 
@@ -174,6 +178,7 @@ impl<'a> WorldEditor<'a> {
         #[cfg_attr(not(feature = "bedrock"), allow(unused_variables))] bedrock_spawn_point: Option<
             (i32, i32),
         >,
+        #[cfg_attr(not(feature = "bedrock"), allow(unused_variables))] bedrock_extend_height: bool,
     ) -> Self {
         Self {
             world_dir,
@@ -187,6 +192,8 @@ impl<'a> WorldEditor<'a> {
             bedrock_level_name,
             #[cfg(feature = "bedrock")]
             bedrock_spawn_point,
+            #[cfg(feature = "bedrock")]
+            bedrock_extend_height,
         }
     }
 
@@ -1144,6 +1151,7 @@ impl<'a> WorldEditor<'a> {
             level_name,
             self.bedrock_spawn_point,
             self.ground.clone(),
+            self.bedrock_extend_height,
         )
         .write_world(&self.world, self.xzbbox, &self.llbbox)
     }

--- a/src/world_utils.rs
+++ b/src/world_utils.rs
@@ -206,6 +206,101 @@ pub fn create_new_world(base_path: &Path) -> Result<String, String> {
     Ok(new_world_path.display().to_string())
 }
 
+/// Name of the bundled Java datapack that extends the Overworld build height.
+pub const TALL_DATAPACK_NAME: &str = "arnis_tall";
+
+/// Install the bundled tall-world datapack into a Java world and register it
+/// in `level.dat`'s `Data.DataPacks.Enabled` so it auto-activates on first
+/// load. Pack assets target Minecraft 1.21.4 (matching the bundled level.dat
+/// template) — older clients will refuse to load the world.
+pub fn install_tall_datapack(world_path: &Path) -> Result<(), String> {
+    const PACK_MCMETA: &[u8] = include_bytes!("../assets/minecraft/datapack_tall/pack.mcmeta");
+    const OVERWORLD_JSON: &[u8] = include_bytes!(
+        "../assets/minecraft/datapack_tall/data/minecraft/dimension_type/overworld.json"
+    );
+
+    let dp_root = world_path.join("datapacks").join(TALL_DATAPACK_NAME);
+    let dim_dir = dp_root
+        .join("data")
+        .join("minecraft")
+        .join("dimension_type");
+    fs::create_dir_all(&dim_dir)
+        .map_err(|e| format!("Failed to create datapack directories: {e}"))?;
+
+    fs::write(dp_root.join("pack.mcmeta"), PACK_MCMETA)
+        .map_err(|e| format!("Failed to write pack.mcmeta: {e}"))?;
+    fs::write(dim_dir.join("overworld.json"), OVERWORLD_JSON)
+        .map_err(|e| format!("Failed to write overworld.json: {e}"))?;
+
+    register_tall_datapack_in_level_dat(world_path)?;
+
+    Ok(())
+}
+
+/// Idempotent — entry goes after `"vanilla"` so our override wins.
+fn register_tall_datapack_in_level_dat(world_path: &Path) -> Result<(), String> {
+    let level_path = world_path.join("level.dat");
+    if !level_path.exists() {
+        return Err(format!("level.dat not found at {level_path:?}"));
+    }
+
+    let raw = fs::read(&level_path).map_err(|e| format!("Failed to read level.dat: {e}"))?;
+    let mut decoder = GzDecoder::new(raw.as_slice());
+    let mut decompressed = Vec::new();
+    decoder
+        .read_to_end(&mut decompressed)
+        .map_err(|e| format!("Failed to decompress level.dat: {e}"))?;
+
+    let mut root: Value = fastnbt::from_bytes(&decompressed)
+        .map_err(|e| format!("Failed to parse level.dat NBT: {e}"))?;
+
+    let entry = format!("file/{TALL_DATAPACK_NAME}");
+
+    {
+        let data = match root {
+            Value::Compound(ref mut r) => match r.get_mut("Data") {
+                Some(Value::Compound(ref mut d)) => d,
+                _ => return Err("level.dat missing Data compound".to_string()),
+            },
+            _ => return Err("level.dat root is not a compound".to_string()),
+        };
+
+        let data_packs = data
+            .entry("DataPacks".to_string())
+            .or_insert_with(|| Value::Compound(Default::default()));
+        let Value::Compound(ref mut dp) = data_packs else {
+            return Err("level.dat Data.DataPacks is not a compound".to_string());
+        };
+
+        let enabled = dp
+            .entry("Enabled".to_string())
+            .or_insert_with(|| Value::List(Vec::new()));
+        let Value::List(ref mut list) = enabled else {
+            return Err("level.dat Data.DataPacks.Enabled is not a list".to_string());
+        };
+
+        let already_enabled = list
+            .iter()
+            .any(|v| matches!(v, Value::String(s) if s == &entry));
+        if !already_enabled {
+            list.push(Value::String(entry));
+        }
+    }
+
+    let serialized =
+        fastnbt::to_bytes(&root).map_err(|e| format!("Failed to serialize level.dat: {e}"))?;
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder
+        .write_all(&serialized)
+        .map_err(|e| format!("Failed to compress level.dat: {e}"))?;
+    let compressed = encoder
+        .finish()
+        .map_err(|e| format!("Failed to finalize level.dat compression: {e}"))?;
+    fs::write(&level_path, compressed).map_err(|e| format!("Failed to write level.dat: {e}"))?;
+
+    Ok(())
+}
+
 /// Sets the player spawn point in an existing Java Edition level.dat file.
 ///
 /// Updates both the world spawn point (SpawnX/SpawnY/SpawnZ) and the player

--- a/src/world_utils.rs
+++ b/src/world_utils.rs
@@ -237,7 +237,9 @@ pub fn install_tall_datapack(world_path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-/// Idempotent — entry goes after `"vanilla"` so our override wins.
+/// Appends the pack entry if missing. Expected to run on a fresh level.dat
+/// template whose Enabled list starts with `["vanilla"]`, so the appended
+/// entry naturally lands after vanilla and our dimension_type override wins.
 fn register_tall_datapack_in_level_dat(world_path: &Path) -> Result<(), String> {
     let level_path = world_path.join("level.dat");
     if !level_path.exists() {
@@ -304,11 +306,15 @@ fn register_tall_datapack_in_level_dat(world_path: &Path) -> Result<(), String> 
 /// Sets the player spawn point in an existing Java Edition level.dat file.
 ///
 /// Updates both the world spawn point (SpawnX/SpawnY/SpawnZ) and the player
-/// position if a Player compound exists. The Y coordinate is set to 150 as a
-/// safe default above terrain; Minecraft will adjust it on first load.
-pub fn set_spawn_in_level_dat(world_path: &Path, spawn_x: i32, spawn_z: i32) -> Result<(), String> {
-    let spawn_y = 150;
-
+/// position if a Player compound exists. Callers derive `spawn_y` from the
+/// generated terrain so the player spawns above ground even in extended-height
+/// worlds where terrain may reach Y≈2000.
+pub fn set_spawn_in_level_dat(
+    world_path: &Path,
+    spawn_x: i32,
+    spawn_y: i32,
+    spawn_z: i32,
+) -> Result<(), String> {
     let level_path = world_path.join("level.dat");
     if !level_path.exists() {
         return Err(format!("level.dat not found at {level_path:?}"));


### PR DESCRIPTION
The existing --disable-height-limit flag previously only told the elevation pipeline to skip compression, but generated worlds still cut off terrain at Y=319 because neither Java nor Bedrock honor extended ranges without the appropriate world extension.

Java (1.21.4+): installs a datapack into <world>/datapacks/arnis_tall/ with an overworld dimension_type override (Y=-2032..2031) and registers it in level.dat's DataPacks.Enabled so it activates on first load.

Bedrock (1.21.40+): bundles a behavior pack with minecraft:dimension_bounds (Y=-512..512) into the .mcworld archive, plus world_behavior_packs.json to auto-activate it. Writes the data_driven_biomes experiment flag to level.dat (and the required experiments_ever_used / saved_with_toggled_experiments markers) — without these, Bedrock silently falls back to vanilla bounds.

scale_to_minecraft now honors per-format caps instead of hard-coding 2031. Re-enables the GUI toggle for Bedrock (previously force-disabled) and renames the label to "Extend build height" across all locales.

Minor unrelated tweaks in the same branch:
- Cliff faces now mix cobbled/plain deepslate per-column (50/50) instead of always plain deepslate in the under-fill
- Doubled under-fill depth cap from 32 to 64 blocks to seal deeper cliffs
- Added missing data-localize hook on "Anonymous Crash Reports" toggle + translations across all 19 locales