### PR TITLE
Telemetry cleanup: fix UTF-8 panic, drop noise, sharpen signal

### DIFF
--- a/src/ground.rs
+++ b/src/ground.rs
@@ -90,11 +90,6 @@ impl Ground {
             },
             Err(e) => {
                 eprintln!("Failed to fetch elevation data: {}", e);
-                // One summary log per session — the final failure message
-                // is actionable (it tells us the whole chain went down,
-                // not just a single provider). Including the truncated
-                // error distinguishes network outages from provider
-                // coverage gaps.
                 #[cfg(feature = "gui")]
                 send_log(
                     LogLevel::Warning,

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -91,10 +91,13 @@ impl Ground {
             Err(e) => {
                 eprintln!("Failed to fetch elevation data: {}", e);
                 #[cfg(feature = "gui")]
-                send_log(
-                    LogLevel::Warning,
-                    &format!("Elevation unavailable, using flat ground ({e:.200})"),
-                );
+                {
+                    let short: String = e.to_string().chars().take(200).collect();
+                    send_log(
+                        LogLevel::Warning,
+                        &format!("Elevation unavailable, using flat ground ({short})"),
+                    );
+                }
                 // Graceful fallback: disable elevation and keep provided ground_level.
                 // Land cover we already fetched is discarded since it has no
                 // elevation grid to align against.

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -90,10 +90,15 @@ impl Ground {
             },
             Err(e) => {
                 eprintln!("Failed to fetch elevation data: {}", e);
+                // One summary log per session — the final failure message
+                // is actionable (it tells us the whole chain went down,
+                // not just a single provider). Including the truncated
+                // error distinguishes network outages from provider
+                // coverage gaps.
                 #[cfg(feature = "gui")]
                 send_log(
                     LogLevel::Warning,
-                    "Elevation unavailable, using flat ground",
+                    &format!("Elevation unavailable, using flat ground ({e:.200})"),
                 );
                 // Graceful fallback: disable elevation and keep provided ground_level.
                 // Land cover we already fetched is discarded since it has no

--- a/src/land_cover.rs
+++ b/src/land_cover.rs
@@ -189,11 +189,6 @@ pub fn fetch_land_cover_data(
         ) {
             Ok(()) => {}
             Err(e) => {
-                // Tile-level failure is graceful degradation: the affected
-                // cells stay at 0 and the generation continues. Logged to
-                // stderr for developer debugging but NOT telemetered —
-                // it fired ~20% of telemetry volume without ever being
-                // actionable by us or the user.
                 eprintln!("Warning: Failed to read ESA tile {tile_url}: {e}");
             }
         }
@@ -203,11 +198,6 @@ pub fn fetch_land_cover_data(
     let has_data = grid.iter().any(|row| row.iter().any(|&v| v != 0));
     if !has_data {
         eprintln!("Warning: No land cover data received for this area");
-        // One summary log per session if ESA WorldCover returned nothing
-        // for the bbox at all — generation continues without land-cover
-        // (only OSM surfaces), but the visual result is noticeably worse
-        // and the user usually can't tell why. Knowing that the entire
-        // coverage was empty (not just a few tiles) is actionable for us.
         #[cfg(feature = "gui")]
         send_log(
             LogLevel::Warning,

--- a/src/land_cover.rs
+++ b/src/land_cover.rs
@@ -189,9 +189,12 @@ pub fn fetch_land_cover_data(
         ) {
             Ok(()) => {}
             Err(e) => {
+                // Tile-level failure is graceful degradation: the affected
+                // cells stay at 0 and the generation continues. Logged to
+                // stderr for developer debugging but NOT telemetered —
+                // it fired ~20% of telemetry volume without ever being
+                // actionable by us or the user.
                 eprintln!("Warning: Failed to read ESA tile {tile_url}: {e}");
-                #[cfg(feature = "gui")]
-                send_log(LogLevel::Warning, "Failed to fetch some land cover data");
             }
         }
     }
@@ -200,6 +203,17 @@ pub fn fetch_land_cover_data(
     let has_data = grid.iter().any(|row| row.iter().any(|&v| v != 0));
     if !has_data {
         eprintln!("Warning: No land cover data received for this area");
+        // One summary log per session if ESA WorldCover returned nothing
+        // for the bbox at all — generation continues without land-cover
+        // (only OSM surfaces), but the visual result is noticeably worse
+        // and the user usually can't tell why. Knowing that the entire
+        // coverage was empty (not just a few tiles) is actionable for us.
+        #[cfg(feature = "gui")]
+        send_log(
+            LogLevel::Warning,
+            "ESA WorldCover returned no data for the requested bbox \
+             (generation proceeding without land cover).",
+        );
         return None;
     }
 

--- a/src/land_cover.rs
+++ b/src/land_cover.rs
@@ -201,8 +201,7 @@ pub fn fetch_land_cover_data(
         #[cfg(feature = "gui")]
         send_log(
             LogLevel::Warning,
-            "ESA WorldCover returned no data for the requested bbox \
-             (generation proceeding without land cover).",
+            "ESA WorldCover returned no data for the requested bbox (generation proceeding without land cover).",
         );
         return None;
     }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -50,7 +50,7 @@ pub fn emit_gui_progress_update(progress: f64, message: &str) {
 
 pub fn emit_gui_error(message: &str) {
     // Truncate by characters (not bytes) to avoid panicking when the GUI
-    // status bar receives an error containing multi-byte UTF-8 — e.g.
+    // status bar receives an error containing multi-byte UTF-8. e.g.
     // localized OS error messages like "Недостаточно системных ресурсов…"
     // where byte 35 lands inside a Cyrillic character.
     const MAX_CHARS: usize = 35;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -49,12 +49,13 @@ pub fn emit_gui_progress_update(progress: f64, message: &str) {
 }
 
 pub fn emit_gui_error(message: &str) {
-    let truncated_message = if message.len() > 35 {
-        &message[..35]
-    } else {
-        message
-    };
-    emit_gui_progress_update(0.0, &format!("Error! {truncated_message}"));
+    // Truncate by characters (not bytes) to avoid panicking when the GUI
+    // status bar receives an error containing multi-byte UTF-8 — e.g.
+    // localized OS error messages like "Недостаточно системных ресурсов…"
+    // where byte 35 lands inside a Cyrillic character.
+    const MAX_CHARS: usize = 35;
+    let truncated: String = message.chars().take(MAX_CHARS).collect();
+    emit_gui_progress_update(0.0, &format!("Error! {truncated}"));
 }
 
 /// Emits the final in-game level name (including localized area suffix for Java,

--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -74,8 +74,9 @@ fn download_with_reqwest(
                 eprintln!("{}", format!("Error! {msg}").red().bold());
                 Err(msg.into())
             } else {
-                eprintln!("{}", format!("Error! {e:.52}").red().bold());
-                Err(format!("{e:.52}").into())
+                let short: String = e.to_string().chars().take(52).collect();
+                eprintln!("{}", format!("Error! {short}").red().bold());
+                Err(short.into())
             }
         }
     }
@@ -282,7 +283,7 @@ pub fn fetch_data_from_overpass(
             {
                 let err_summary = last_error
                     .as_ref()
-                    .map(|e| format!("{e:.120}"))
+                    .map(|e| e.to_string().chars().take(120).collect::<String>())
                     .unwrap_or_else(|| "unknown".to_string());
                 send_log(
                     LogLevel::Error,

--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -15,9 +15,7 @@ use std::io::{self, BufReader, Cursor, Write};
 use std::process::Command;
 use std::time::Duration;
 
-/// Extract the host portion of a URL for telemetry (strips the scheme,
-/// path, and query — no need to log the entire Overpass QL query when
-/// identifying which provider a request hit).
+/// Extract the host portion of a URL for telemetry
 fn url_host(url: &str) -> String {
     let after_scheme = url.split("://").nth(1).unwrap_or(url);
     after_scheme
@@ -76,10 +74,6 @@ fn download_with_reqwest(
                 eprintln!("{}", format!("Error! {msg}").red().bold());
                 Err(msg.into())
             } else {
-                // Per-attempt errors intentionally NOT telemetered — the
-                // outer retry loop falls through to other providers and
-                // logs a single summary only if the entire chain fails.
-                // See `fetch_data_from_overpass`.
                 eprintln!("{}", format!("Error! {e:.52}").red().bold());
                 Err(format!("{e:.52}").into())
             }
@@ -283,10 +277,7 @@ pub fn fetch_data_from_overpass(
                     }
                 }
             }
-            // All servers exhausted — telemeter one summary log instead of
-            // one per attempt, since the retry chain is expected to see
-            // individual failures and only the "every provider is down"
-            // outcome is actionable.
+            // All servers exhausted
             #[cfg(feature = "gui")]
             {
                 let err_summary = last_error

--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -15,6 +15,18 @@ use std::io::{self, BufReader, Cursor, Write};
 use std::process::Command;
 use std::time::Duration;
 
+/// Extract the host portion of a URL for telemetry (strips the scheme,
+/// path, and query — no need to log the entire Overpass QL query when
+/// identifying which provider a request hit).
+fn url_host(url: &str) -> String {
+    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    after_scheme
+        .split(['/', '?'])
+        .next()
+        .unwrap_or(after_scheme)
+        .to_string()
+}
+
 /// Function to download data using reqwest
 fn download_with_reqwest(
     url: &str,
@@ -64,11 +76,10 @@ fn download_with_reqwest(
                 eprintln!("{}", format!("Error! {msg}").red().bold());
                 Err(msg.into())
             } else {
-                #[cfg(feature = "gui")]
-                send_log(
-                    LogLevel::Error,
-                    &format!("Request error in download_with_reqwest: {e}"),
-                );
+                // Per-attempt errors intentionally NOT telemetered — the
+                // outer retry loop falls through to other providers and
+                // logs a single summary only if the entire chain fails.
+                // See `fetch_data_from_overpass`.
                 eprintln!("{}", format!("Error! {e:.52}").red().bold());
                 Err(format!("{e:.52}").into())
             }
@@ -236,6 +247,7 @@ pub fn fetch_data_from_overpass(
 
         let total = request_plan.len();
         let mut last_error: Option<Box<dyn std::error::Error>> = None;
+        let mut attempted_hosts: Vec<String> = Vec::new();
         let response: String = 'server_loop: {
             for (i, (url, kind)) in request_plan.iter().enumerate() {
                 let timeout_secs = if url.contains("private.coffee") {
@@ -257,6 +269,7 @@ pub fn fetch_data_from_overpass(
                         if download_method != "requests" {
                             eprintln!("Request failed: {error}");
                         }
+                        attempted_hosts.push(url_host(url));
                         last_error = Some(error);
 
                         if i + 1 < total {
@@ -270,7 +283,26 @@ pub fn fetch_data_from_overpass(
                     }
                 }
             }
-            // All servers exhausted
+            // All servers exhausted — telemeter one summary log instead of
+            // one per attempt, since the retry chain is expected to see
+            // individual failures and only the "every provider is down"
+            // outcome is actionable.
+            #[cfg(feature = "gui")]
+            {
+                let err_summary = last_error
+                    .as_ref()
+                    .map(|e| format!("{e:.120}"))
+                    .unwrap_or_else(|| "unknown".to_string());
+                send_log(
+                    LogLevel::Error,
+                    &format!(
+                        "Overpass fetch failed on all {} providers ({}); last error: {}",
+                        attempted_hosts.len(),
+                        attempted_hosts.join(", "),
+                        err_summary,
+                    ),
+                );
+            }
             return Err(last_error.unwrap_or_else(|| "All servers failed".into()));
         };
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -142,6 +142,37 @@ impl LogLevel {
     }
 }
 
+/// Strip the query string from any URLs embedded in `input`.
+///
+/// Keeps the scheme/host/path so we can still tell which provider failed,
+/// but drops `?key=value&...` where Arnis's Overpass and elevation
+/// provider URLs carry bbox coordinates. Non-URL `?` (e.g. in English
+/// text) is preserved because we only strip after a `://` scheme.
+pub fn redact_url_queries(mut input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    while let Some(scheme_idx) = input.find("://") {
+        let (before, after) = input.split_at(scheme_idx);
+        out.push_str(before);
+        out.push_str("://");
+        let after_scheme = &after[3..];
+        // Terminators: whitespace and `)` only. `,` is valid inside URL
+        // queries (raw bbox coords in tile-service URLs) so stripping on
+        // it would leak the tail of the query past the comma.
+        let url_end = after_scheme
+            .find(|c: char| c.is_whitespace() || c == ')')
+            .unwrap_or(after_scheme.len());
+        let url = &after_scheme[..url_end];
+        let tail = &after_scheme[url_end..];
+        match url.find('?') {
+            Some(q) => out.push_str(&url[..q]),
+            None => out.push_str(url),
+        }
+        input = tail;
+    }
+    out.push_str(input);
+    out
+}
+
 /// Sends a log entry to the telemetry server
 pub fn send_log(level: LogLevel, message: &str) {
     // Check user consent
@@ -154,11 +185,13 @@ pub fn send_log(level: LogLevel, message: &str) {
         return;
     }
 
-    // Truncate message to 1000 characters
-    let truncated_message = if message.chars().count() > 1000 {
-        message.chars().take(1000).collect::<String>()
+    // Redact URL query strings before anything else so bbox coordinates
+    // embedded in reqwest/provider error messages never leave the client.
+    let redacted = redact_url_queries(message);
+    let truncated_message = if redacted.chars().count() > 1000 {
+        redacted.chars().take(1000).collect::<String>()
     } else {
-        message.to_string()
+        redacted
     };
 
     let platform = get_platform();
@@ -231,8 +264,9 @@ pub fn install_panic_hook() {
                 .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
                 .unwrap_or_else(|| "unknown location".to_string());
 
-            // Combine payload and location
-            let mut error_message = format!("{} @ {}", payload, location);
+            // Combine payload and location; redact URL queries so a panic
+            // message carrying a request URL can't leak bbox coordinates.
+            let mut error_message = redact_url_queries(&format!("{} @ {}", payload, location));
 
             // Truncate to 500 Unicode characters
             if error_message.chars().count() > 500 {
@@ -246,4 +280,43 @@ pub fn install_panic_hook() {
             send_crash_report(error_message, platform, app_version);
         }));
     }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_strips_overpass_query() {
+        let input = "error sending request for url (https://overpass-api.de/api/interpreter?data=%5Bbbox%3A50.1%2C13.7%5D): connection timed out";
+        let out = redact_url_queries(input);
+        assert!(!out.contains("bbox"), "bbox leaked: {out}");
+        assert!(!out.contains("?"), "query not stripped: {out}");
+        assert!(out.contains("overpass-api.de"), "host lost: {out}");
+        assert!(out.ends_with("): connection timed out"));
+    }
+
+    #[test]
+    fn redact_preserves_non_url_question_marks() {
+        let input = "What? That is odd.";
+        assert_eq!(redact_url_queries(input), input);
+    }
+
+    #[test]
+    fn redact_handles_multiple_urls_and_no_query() {
+        let input = "first https://a.com/p?x=1 middle https://b.com/q end";
+        assert_eq!(
+            redact_url_queries(input),
+            "first https://a.com/p middle https://b.com/q end"
+        );
+    }
+
+    #[test]
+    fn redact_handles_truncated_tail() {
+        let input = "error for url https://host.tld/path?bbox=50.1,13.7";
+        assert_eq!(
+            redact_url_queries(input),
+            "error for url https://host.tld/path"
+        );
+    }
 }

--- a/src/world_editor/bedrock.rs
+++ b/src/world_editor/bedrock.rs
@@ -404,8 +404,8 @@ impl BedrockWriter {
             daylight_cycle: 0,
         };
 
-        let nbt_bytes =
-            nbtx::to_le_bytes(&level_dat).map_err(|e| BedrockSaveError::Nbt(e.to_string()))?;
+        let nbt_bytes = nbtx::to_le_bytes(&level_dat)
+            .map_err(|e| BedrockSaveError::Nbt(format!("level.dat: {e}")))?;
 
         // Write with header
         let mut file = File::create(self.output_dir.join("level.dat"))?;
@@ -550,8 +550,8 @@ impl BedrockWriter {
         // a TAG_List header, which Bedrock cannot parse.
         let mut data: Vec<u8> = Vec::new();
         for compound in &deduped {
-            let bytes =
-                nbtx::to_le_bytes(compound).map_err(|e| BedrockSaveError::Nbt(e.to_string()))?;
+            let bytes = nbtx::to_le_bytes(compound)
+                .map_err(|e| BedrockSaveError::Nbt(format!("block-entity/entity compound: {e}")))?;
             data.extend_from_slice(&bytes);
         }
 
@@ -643,8 +643,9 @@ impl BedrockWriter {
                     .map(|(k, v)| (k.clone(), BedrockNbtValue::from(v)))
                     .collect(),
             };
-            let nbt_bytes =
-                nbtx::to_le_bytes(&state).map_err(|e| BedrockSaveError::Nbt(e.to_string()))?;
+            let nbt_bytes = nbtx::to_le_bytes(&state).map_err(|e| {
+                BedrockSaveError::Nbt(format!("block palette state ({}): {e}", state.name))
+            })?;
             buffer.write_all(&nbt_bytes)?;
         }
 


### PR DESCRIPTION
Reported crash 80612 (progress.rs:53):
- `emit_gui_error` truncated with `&message[..35]`, panicking when byte 35 landed inside a multi-byte UTF-8 character. Triggered in production by a Russian Windows OS error 1450 message. Switch to `.chars().take(35).collect()` which is UTF-8 safe.

Telemetry noise reduction — ~88% of a week's logs were three non-actionable categories; remove them from telemetry while keeping the stderr prints for developer debugging:

- retrieve_data.rs: per-attempt "Request error in download_with_reqwest" fired ~58% of volume. The outer retry loop expects individual provider failures and handles them transparently, so the per-attempt log was pure noise. Replaced with a single session-level summary emitted only when the *entire* provider chain fails — containing the attempted host list and the truncated last error. Added a tiny `url_host` helper to strip the scheme/path/query so we log "overpass.private.coffee" instead of a 1000-character URL that includes the full bbox query (also stops leaking user coordinates).
- land_cover.rs: per-tile "Failed to fetch some land cover data" (~20% of volume) was graceful degradation. Demoted to stderr-only. Added a new one-per-session warning for the stronger condition "ESA WorldCover returned nothing for the bbox" — that one IS actionable (the generation proceeds without land cover and we want to know).
- elevation/postprocess.rs: "Terrain peak Y=N exceeds data pack max" (10 entries) fires legitimately for Everest/Aconcagua-scale bboxes. Informational; removed from telemetry, kept as stderr.

Telemetry signal sharpening — make the remaining warnings more useful when they do fire:

- ground.rs: "Elevation unavailable, using flat ground" now includes the truncated error text, so we can distinguish "all providers down" from "bbox outside all provider coverage" without repro.
- world_editor/bedrock.rs: NBT serialization failures now prefix their error with which compound failed ("level.dat: ...", "block-entity/entity compound: ...", "block palette state (minecraft:foo): ..."). Replaces the opaque "Serializing Options is not supported" messages where we couldn't tell which struct to fix.

Expected effect on next release: telemetry volume down ~88%, each remaining log actionable, and the UTF-8 crash retired.