### PR TITLE
Revert accidental rand 0.9.3 -> 0.10.1 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
  "nbtx",
  "once_cell",
  "parquet",
- "rand 0.10.1",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",
  "reqwest",
@@ -942,17 +942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if 1.0.4",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,15 +1165,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2223,7 +2203,6 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -4556,17 +4535,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4622,12 +4590,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -5450,7 +5412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ itertools = "0.14.0"
 jsonwebtoken = "10.3.0"
 log = "0.4.27"
 once_cell = "1.21.3"
-rand = { version = "0.10.1", features = ["std", "std_rng"] }
+rand = { version = "0.9.3", features = ["std", "std_rng"] }
 rand_chacha = "0.9"
 rayon = "1.10.0"
 reqwest = { version = "0.13.1", features = ["blocking", "json", "query"] }


### PR DESCRIPTION
Commit 58e2cfe (dependabot: bump rustls-webpki 0.103.10 -> 0.103.12) also bumped the direct rand dependency from 0.9.3 to 0.10.1. rand 0.10 moved random_range / random_bool / seed_from_u64 into a separate RngExt trait that is not imported anywhere in the crate, so main fails to compile with ~160 errors.

This change keeps the intended rustls-webpki bump and restores rand to 0.9.3, which the existing code is written against.