### PR TITLE
feat(meld-fork): apply Meld scheduler patches on v2.7.0

### DIFF
--- a/docs/meld-fork/CLI_REFERENCE.md
+++ b/docs/meld-fork/CLI_REFERENCE.md
@@ -1,0 +1,377 @@
+# Meld Fork — CLI Reference
+
+This page documents the CLI flags and source-level changes added by the
+**Meld fork** (`Teddy563/arnis:feat/meld-fork`) on top of upstream
+`louis-e/arnis` v2.7.0. Each flag is **opt-in**: omitting it preserves
+upstream behaviour byte-for-byte.
+
+The upstream README applies as-is. This file documents only the
+delta.
+
+---
+
+## Flag inventory
+
+| Flag | Type | Default | Added by | Intent |
+|---|---|---|---|---|
+| `--master-origin-lat <f64>` | `Option<f64>` | unset | PR 1 | Anchor block coords to a global lat origin so adjacent bbox runs tile cleanly. |
+| `--master-origin-lng <f64>` | `Option<f64>` | unset | PR 1 | Same, longitude. Both must be set for the offset to apply. |
+| `--elevation-min <f64>` | `Option<f64>` | unset | PR 2 | Force the global elevation floor (m) used by `scale_to_minecraft`. Stops Y seams between adjacent tiles. |
+| `--elevation-max <f64>` | `Option<f64>` | unset | PR 2 | Same, ceiling. Both must be set for the lock to engage. |
+| `--overpass-url <url[,url2,...]>` | `Vec<String>` | empty | PR 4 | Override the Overpass mirror pool. For self-hosted instances or LAN mirrors. |
+| `--road-detail max\|compact\|none` | `String` | `max` | PR 5 | Skip pedestrian-grade highways + crossings + lane dividers at low scale. Trims the Overpass payload too. |
+
+PR 3 (tile-invariant building rendering) is structural — no new
+flag, behaviour change opt-in via the same code path that fires for
+multi-tile users (see PR 3 below).
+
+---
+
+## PR 1 — `--master-origin-lat / --master-origin-lng`
+
+### What
+
+Two optional CLI flags that anchor block-coordinate output to a global
+latitude/longitude origin. When both are set, every Arnis run shifts
+its bbox-to-block transform so the resulting `.mca` files land at
+**globally-correct region indices** rather than always centring on
+`(0, 0)`.
+
+### Why
+
+Upstream Arnis centres each run at world `(0, 0)` of the run's bbox.
+Two adjacent bbox runs both write `r.0.0.mca`, `r.0.-1.mca`, etc.,
+so they overlap each other instead of tiling. There's no way to do
+country-scale generation without forking.
+
+### Intended use
+
+External schedulers (e.g. [Meld](https://github.com/Teddy563/meld))
+that break a country into N adjacent cells and merge them into one
+Minecraft world. The scheduler picks one global origin (typically the
+country's centroid), then passes the same lat/lng pair on every
+Arnis run.
+
+### Example
+
+```bash
+# Origin = Bucharest centroid. Two adjacent tiles, same world.
+ORIGIN="--master-origin-lat 44.4268 --master-origin-lng 26.1025"
+
+arnis --bbox 44.40,26.05,44.45,26.10 --output-dir /tmp/world $ORIGIN
+arnis --bbox 44.40,26.10,44.45,26.15 --output-dir /tmp/world $ORIGIN
+
+# Both runs write into /tmp/world/region/ — non-overlapping .mca files.
+ls /tmp/world/region/
+```
+
+### Math
+
+```text
+const M_PER_DEG_LAT = 111_320 m
+let m_per_deg_lon = M_PER_DEG_LAT * cos(lat)
+let dx_m = (bbox_sw_lon - origin_lng) * m_per_deg_lon
+let dz_m = (origin_lat - bbox_sw_lat) * M_PER_DEG_LAT
+let off_x = floor(dx_m * scale)
+let off_z = floor(dz_m * scale)
+xzbbox.translate(off_x, off_z)
+```
+
+### Source files touched
+
+`src/args.rs`, `src/coordinate_system/transformation.rs`,
+`src/coordinate_system/cartesian/xzbbox/xzbbox_enum.rs` (new
+`from_points` constructor), `src/osm_parser.rs`,
+`src/data_processing.rs`, `src/gui.rs`.
+
+### Backward compatibility
+
+Both flags optional. When omitted (or only one provided), behaviour
+is **identical** to upstream — same single-tile, centred-at-origin
+output.
+
+---
+
+## PR 2 — `--elevation-min / --elevation-max`
+
+### What
+
+Two optional CLI flags that lock the elevation-to-Y mapping to a
+**global** range. When both are set, `scale_to_minecraft` uses them
+as the reference range; per-tile auto-fit (current upstream
+behaviour) is skipped.
+
+### Why
+
+Upstream `scale_to_minecraft` derives its elevation range from the
+**current tile's grid**. Two adjacent tiles see different local
+min/max → the same real-world metre maps to different Minecraft Y
+values → height seam at the canonical boundary.
+
+Even with PR 1 in place, terrain elevation doesn't align without a
+shared Y reference frame. PR 1 + PR 2 together solve the multi-tile
+correctness problem.
+
+### Intended use
+
+The scheduler surveys the entire region's elevation **once** (e.g.
+fetch every AWS Terrarium tile covering the bbox at zoom 10, decode,
+filter no-data sentinels, take min/max). Every Arnis run then uses
+that locked range.
+
+### Example
+
+```bash
+# Romania surveyed range: floor 60 m, ceiling 350 m.
+LOCK="--elevation-min 60 --elevation-max 350"
+
+# Every tile uses the same Y mapping — no seams.
+arnis --bbox 44.40,26.05,44.45,26.10 --output-dir /tmp/world $LOCK
+arnis --bbox 44.40,26.10,44.45,26.15 --output-dir /tmp/world $LOCK
+```
+
+### ⚠ Caller responsibility
+
+**Filter AWS no-data sentinels before computing the range.** Raw RGB
+`(0, 0, 0)` decodes to −32768 m. Passing a sentinel through this
+flag would compress 33 km of range into ~360 blocks and flatten the
+world. Recommended clamp to a sane Earth range like `[−500, 9000]`.
+
+### Source files touched
+
+`src/args.rs`, `src/elevation/postprocess.rs`,
+`src/elevation/mod.rs`, `src/ground.rs`,
+`src/data_processing.rs`, `src/gui.rs`.
+
+### Backward compatibility
+
+Both flags optional. When omitted, the existing per-tile auto-fit
+runs unchanged.
+
+---
+
+## PR 3 — Tile-Invariant Building Rendering
+
+### What
+
+No new flag. Three structural changes:
+
+1. **Pre-clip bounds + polygon area** carried on every `ProcessedWay`
+   so building decisions don't read the bbox-clipped node list.
+2. **Decision-aware skyscraper / footprint / diagonality / start-Y**
+   logic that uses the pre-clip metrics when present.
+3. **Salted RNG streams** (`element_rng_salted(id, salt)`) — one
+   stream per decision instead of one shared stream, so unrelated
+   branch divergence cannot shift downstream block choices.
+
+### Why
+
+A building straddling a tile boundary today renders **differently**
+in each tile because:
+
+- Skyscraper detection (`height ≥ 2 × longest_side`) reads clipped
+  longest_side → category flips per tile → palette flips.
+- Cached footprint size, diagonality, start-Y offset all reduce over
+  clipped nodes → all per-tile-variant.
+- A single shared `element_rng(id)` stream advances through every
+  decision; if upstream adds an extra `rng.gen()` anywhere, every
+  downstream block choice shifts.
+
+Even single-tile users benefit: salted RNG isolates each decision so
+upstream changes don't cascade.
+
+### Intended use
+
+Automatic. No CLI knob. Multi-tile schedulers and single-tile users
+both get identical building rendering across runs.
+
+### Backward compatibility
+
+`unclipped_bounds` and `unclipped_polygon_area` are `Option`. Manual
+`ProcessedWay` constructors can pass `None` and the code falls back
+to clipped-nodes path.
+
+Salted RNG produces **different block sequences** vs upstream
+shared-stream path. Single-tile renders see different (still
+deterministic) palettes than upstream. If upstream maintainers want
+byte-for-byte preservation, gate behind a `--tile-invariant-rendering`
+flag in review.
+
+### Source files touched
+
+`src/osm_parser.rs` (struct fields + helpers),
+`src/overture.rs`, `src/element_processing/landuse.rs`,
+`src/element_processing/leisure.rs`,
+`src/element_processing/natural.rs`,
+`src/element_processing/buildings.rs` (RNG salts + 4 decision
+sites).
+
+---
+
+## PR 4 — `--overpass-url`
+
+### What
+
+Override the public Overpass mirror pool with a comma-separated list
+of custom URLs. Arnis hits them in priority order; falls through to
+the next on failure.
+
+### Why
+
+`fetch_data_from_overpass` hard-codes a list of public Overpass
+mirrors. Public mirrors throttle ~2 connections/IP. Batch jobs
+(country-scale generation) hit rate limits hard — 12-16 parallel
+workers see ~90% fetch failures and spend most time in retry-backoff.
+
+### Intended use
+
+Self-hosted Overpass instance on LAN, paid mirror, or any custom
+endpoint. Especially useful with the `--overpass-url` flag pointing
+at `http://localhost:12345/api/interpreter` for a local Docker
+[wiktorn/overpass-api](https://github.com/wiktorn/Overpass-API)
+container.
+
+### Example
+
+```bash
+# Default (public mirrors):
+arnis --bbox 44.40,26.05,44.45,26.10 --output-dir /tmp/test
+
+# Self-hosted Overpass on localhost:12345:
+arnis --bbox 44.40,26.05,44.45,26.10 --output-dir /tmp/test \
+      --overpass-url http://localhost:12345/api/interpreter
+
+# Failover chain (LAN mirror first, public fallback):
+arnis --bbox 44.40,26.05,44.45,26.10 --output-dir /tmp/test \
+      --overpass-url http://lan-host:12345/api/interpreter,https://overpass-api.de/api/interpreter
+```
+
+### Source files touched
+
+`src/args.rs`, `src/retrieve_data.rs`, `src/main.rs`,
+`src/gui.rs`, `src/test_utilities.rs`.
+
+### Backward compatibility
+
+Empty list (default) → behaviour identical to upstream. Random-probe
++ arnis-api + shuffled-fallbacks chain runs unchanged.
+
+---
+
+## PR 5 — `--road-detail max | compact | none`
+
+### What
+
+Three-value flag controlling which OSM highway features are fetched
++ rendered:
+
+| Value | Behaviour |
+|---|---|
+| `max` (default) | Render every `highway`, `footway`, `cycleway`, `crossing`, lane divider. Identical to upstream. |
+| `compact` | Drop `footway`, `path`, `cycleway`, `steps`, `corridor`, `pedestrian`, `platform`, `bus_stop`, `crossing` markers. Lane dividers kept (they run along the road, not stacked across blocks). Vehicle-grade roads only. **Trims the Overpass query** so the payload is ~30-50% smaller too. |
+| `none` | Skip every highway entirely. For terrain-only worlds. |
+
+### Why
+
+At scale<0.7 (1 block ≥ 1.5 m) Arnis's full-detail rendering
+collapses footways + crosswalks + lane dividers onto the same few
+blocks as the underlying road. Result: dotted-checker noise at every
+intersection.
+
+`compact` mode drops the visually-broken features at fetch + render
+time. Vehicle roads still render legibly because their geometry is
+chunky enough.
+
+### Intended use
+
+Scheduler picks `compact` automatically when `scale < 0.7`,
+otherwise `max`. Manual override available for users who want full
+detail at low scale (or no roads at all).
+
+### Example
+
+```bash
+# Default (max, current upstream behaviour):
+arnis --bbox 44.43,26.10,44.44,26.11 --output-dir /tmp/max --scale 0.5
+
+# Compact (pedestrian noise gone — clean asphalt + lane stripes):
+arnis --bbox 44.43,26.10,44.44,26.11 --output-dir /tmp/compact --scale 0.5 \
+      --road-detail compact
+
+# Terrain-only (no roads at all):
+arnis --bbox 44.43,26.10,44.44,26.11 --output-dir /tmp/none --scale 0.5 \
+      --road-detail none
+```
+
+### Source files touched
+
+`src/args.rs`, `src/retrieve_data.rs` (Overpass query gate),
+`src/element_processing/highways.rs` (per-element skip),
+`src/main.rs`, `src/gui.rs`, `src/test_utilities.rs`.
+
+### Backward compatibility
+
+`max` is the default → omitting the flag preserves upstream
+behaviour exactly.
+
+---
+
+## Combined example: country-scale Romania run
+
+A scheduler emits this command for every cell:
+
+```bash
+arnis \
+  --bbox 44.40,26.05,44.45,26.10 \
+  --output-dir /path/to/master_world \
+  --scale 0.5 \
+  --master-origin-lat 45.9432 --master-origin-lng 24.9668 \
+  --elevation-min -440 --elevation-max 2157 \
+  --overpass-url http://localhost:12345/api/interpreter \
+  --road-detail compact
+```
+
+Result: every tile lands at a globally-correct `.mca` index, terrain
+heights align across boundaries, OSM data fetches from a self-hosted
+Overpass mirror at zero rate-limit, and pedestrian-grade road noise
+is suppressed at the chosen scale.
+
+---
+
+## Verifying the binary
+
+```bash
+arnis --help | grep -E "master-origin|elevation-min|elevation-max|overpass-url|road-detail"
+```
+
+Expect six flags in the output (two `master-origin-*`, two
+`elevation-*`, one `overpass-url`, one `road-detail`).
+
+If any flag is missing, the corresponding patch from the Meld fork
+didn't apply during refresh. See `meld_arnis_fork/REFRESH.md` in the
+Meld repo.
+
+---
+
+## Source change quick reference
+
+| File | Lines added | Carries which PR |
+|---|---|---|
+| `src/args.rs` | +18 (4 flags + 1 enum-string flag) | 1, 2, 4, 5 |
+| `src/coordinate_system/transformation.rs` | ~30 | 1 |
+| `src/coordinate_system/cartesian/xzbbox/xzbbox_enum.rs` | +13 (`from_points` ctor) | 1 |
+| `src/osm_parser.rs` | +60 (struct fields + helpers) | 1, 3 |
+| `src/overture.rs` | +3 | 3 |
+| `src/element_processing/buildings.rs` | ~120 | 3 |
+| `src/element_processing/{landuse,leisure,natural}.rs` | +1 each | 3 |
+| `src/element_processing/highways.rs` | +50 (skip helper + lane gate) | 5 |
+| `src/elevation/mod.rs` | +6 | 2 |
+| `src/elevation/postprocess.rs` | ~25 | 2 |
+| `src/ground.rs` | ~29 | 2 |
+| `src/data_processing.rs` | +6 | 1, 2 |
+| `src/retrieve_data.rs` | ~50 (override URLs + road-detail gate) | 4, 5 |
+| `src/main.rs` | +2 | 4, 5 |
+| `src/gui.rs` | +5 | 1, 2, 4, 5 |
+| `src/test_utilities.rs` | +1 | 4, 5 |
+
+Total: ~1200 net changed lines across 18 files.

--- a/docs/meld-fork/CLI_REFERENCE.md
+++ b/docs/meld-fork/CLI_REFERENCE.md
@@ -18,12 +18,16 @@ delta.
 | `--master-origin-lng <f64>` | `Option<f64>` | unset | PR 1 | Same, longitude. Both must be set for the offset to apply. |
 | `--elevation-min <f64>` | `Option<f64>` | unset | PR 2 | Force the global elevation floor (m) used by `scale_to_minecraft`. Stops Y seams between adjacent tiles. |
 | `--elevation-max <f64>` | `Option<f64>` | unset | PR 2 | Same, ceiling. Both must be set for the lock to engage. |
+| `--tile-invariant-rendering` | `bool` | `false` | PR 3 | Carry pre-clip bounds + polygon area on `ProcessedWay` so a building straddling two tiles renders identically in both. Off by default → upstream-style clipped-node decisions. |
 | `--overpass-url <url[,url2,...]>` | `Vec<String>` | empty | PR 4 | Override the Overpass mirror pool. For self-hosted instances or LAN mirrors. |
 | `--road-detail max\|compact\|none` | `String` | `max` | PR 5 | Skip pedestrian-grade highways + crossings + lane dividers at low scale. Trims the Overpass payload too. |
 
-PR 3 (tile-invariant building rendering) is structural — no new
-flag, behaviour change opt-in via the same code path that fires for
-multi-tile users (see PR 3 below).
+PR 3's salted-RNG-per-decision change is always on regardless of the
+flag — it's a correctness property even for single-tile users (stops
+upstream changes from cascading shifts across unrelated building
+decisions) and toggling it requires duplicating ~150 lines around
+an `if` branch we'd rather not maintain. The flag controls only the
+unclipped-bounds reads.
 
 ---
 
@@ -150,11 +154,11 @@ runs unchanged.
 
 ---
 
-## PR 3 — Tile-Invariant Building Rendering
+## PR 3 — `--tile-invariant-rendering`
 
 ### What
 
-No new flag. Three structural changes:
+One opt-in CLI flag (default `false`). Three structural changes:
 
 1. **Pre-clip bounds + polygon area** carried on every `ProcessedWay`
    so building decisions don't read the bbox-clipped node list.
@@ -182,20 +186,47 @@ upstream changes don't cascade.
 
 ### Intended use
 
-Automatic. No CLI knob. Multi-tile schedulers and single-tile users
-both get identical building rendering across runs.
+Multi-tile schedulers (Meld) pass `--tile-invariant-rendering`
+whenever they're generating a tile that's part of a shared world.
+Single-tile users omit it and get upstream-style clipped-node
+decisions.
+
+The Meld scheduler emits the flag automatically when `origin.set`
+is true (i.e. multi-tile mode). User can disable via
+`settings.tile_invariant_rendering = false` if they want
+byte-identical-to-upstream output for the unclipped-bounds reads.
+
+### Example
+
+```bash
+# Single-tile, upstream behaviour (no flag):
+arnis --bbox 44.43,26.10,44.44,26.11 --output-dir /tmp/single
+
+# Multi-tile, identical building rendering across cells:
+ORIGIN="--master-origin-lat 44.43 --master-origin-lng 26.10"
+arnis --bbox 44.43,26.10,44.44,26.11 --output-dir /tmp/world $ORIGIN --tile-invariant-rendering
+arnis --bbox 44.43,26.11,44.44,26.12 --output-dir /tmp/world $ORIGIN --tile-invariant-rendering
+# Building straddling lon=26.11 renders with same blocks in both cells.
+```
 
 ### Backward compatibility
 
-`unclipped_bounds` and `unclipped_polygon_area` are `Option`. Manual
-`ProcessedWay` constructors can pass `None` and the code falls back
-to clipped-nodes path.
-
-Salted RNG produces **different block sequences** vs upstream
-shared-stream path. Single-tile renders see different (still
-deterministic) palettes than upstream. If upstream maintainers want
-byte-for-byte preservation, gate behind a `--tile-invariant-rendering`
-flag in review.
+- Default `false` → unclipped-bounds reads disabled → upstream
+  v2.7.0-identical decisions for skyscraper / footprint /
+  diagonality / start-Y.
+- `unclipped_bounds` and `unclipped_polygon_area` are `Option`.
+  When flag off, parse_data() + synthetic-ring constructors set
+  both to `None`. The 4 decision sites already fall back to
+  clipped-nodes via existing `if let Some(...)` branches.
+- **Salted RNG (10 streams) stays on regardless of flag.** Toggling
+  it would require duplicating ~150 lines of `BuildingStyle::resolve()`
+  around an `if` branch we'd rather not maintain. Salted RNG
+  produces **different block sequences** vs upstream's shared-stream
+  path; single-tile renders see different (still deterministic)
+  palettes than upstream v2.7.0 even with the flag off. If upstream
+  maintainers want byte-for-byte v2.7.0 preservation including RNG,
+  the salted path could move behind a separate `--tile-invariant-rng`
+  sub-flag in review. Happy to split.
 
 ### Source files touched
 

--- a/docs/meld-fork/README.md
+++ b/docs/meld-fork/README.md
@@ -1,0 +1,101 @@
+# Meld Fork — Read Me
+
+This branch (`feat/meld-fork`) of `Teddy563/arnis` carries five
+opt-in additions over upstream `louis-e/arnis` v2.7.0. They unlock
+country-scale Minecraft world generation through the
+[Meld](https://github.com/Teddy563/meld) scheduler.
+
+## What's in this folder
+
+| File | Purpose |
+|---|---|
+| `CLI_REFERENCE.md` | Every Meld-added flag with intent, examples, source files touched. **Start here** if you want to use the fork. |
+| (this file) | Why the fork exists + how to keep it in sync with upstream. |
+
+## Branch layout
+
+| Branch | Tracks | Use |
+|---|---|---|
+| `main` | Upstream `louis-e/arnis:main` | Keep clean. `git pull upstream main` to follow upstream. Never push fork-only commits here. |
+| `feat/meld-fork` | This branch | Holds the five Meld-fork patches on top of an upstream tag (currently `v2.7.0`). Push to `origin` so the Meld scheduler can pull this branch. |
+
+## How to use
+
+```bash
+git clone https://github.com/Teddy563/arnis.git
+cd arnis
+git checkout feat/meld-fork
+cargo build --release
+./target/release/arnis --help | grep -E "master-origin|elevation-|overpass-url|road-detail"
+# Expect 6 flags shown.
+```
+
+The Meld scheduler points at `target/release/arnis.exe` (renamed to
+`arnis-windows.exe` and copied to the Meld repo root by
+`start.bat`).
+
+## How to refresh against upstream 2.8.0+
+
+```bash
+# 1. Pull new upstream tag.
+git fetch upstream --tags
+
+# 2. Take the new tag onto main.
+git checkout main
+git merge --ff-only upstream/v2.8.0
+git push origin main
+
+# 3. Rebase the fork branch.
+git checkout feat/meld-fork
+git rebase v2.8.0
+
+# 4. Resolve conflicts file by file. Each Meld-fork commit
+#    documents its intent in its commit message — re-apply the
+#    intent rather than the line numbers if upstream moved code.
+#    See `meld_arnis_fork/REFRESH.md` in the Meld repo for the
+#    detailed playbook.
+
+# 5. Verify all six flags still register.
+cargo check --release
+./target/release/arnis --help | grep -E "master-origin|elevation-|overpass-url|road-detail"
+
+# 6. Push the rebased branch.
+git push --force-with-lease origin feat/meld-fork
+
+# 7. In the Meld repo, copy this fork's source back into
+#    arnis-source/, rebuild, copy arnis.exe → arnis-windows.exe.
+```
+
+## Submitting upstream
+
+Five separate PRs into `louis-e/arnis`. Order: 1 → 2 → 3 → 4 → 5.
+
+Per-PR markdown bodies + reference patches live in:
+
+- `meld_arnis_fork/pr-bodies/PR_0X_*.md` (Meld repo)
+
+Each body has a suggested commit message + PR title + intent
+description. Paste into the GitHub PR description field.
+
+## Compatibility with Meld
+
+| Meld feature | Fork PR | Hard requirement? |
+|---|---|---|
+| Multi-tile worlds | PR 1 (master-origin) | YES |
+| Cross-tile elevation | PR 2 (elevation-lock) | YES |
+| Tile-invariant buildings | PR 3 | NO (cosmetic) |
+| Self-hosted Overpass mirror | PR 4 (overpass-url) | NO (advanced) |
+| Road-detail toggle | PR 5 (road-detail) | NO (low-scale fix) |
+
+Detailed table in `meld_arnis_fork/MELD_COMPAT.md` (Meld repo).
+
+## License
+
+This fork inherits upstream's Apache-2.0. Meld-fork additions are
+released under the same terms.
+
+## Credits
+
+- Upstream Arnis: [@louis-e](https://github.com/louis-e) and
+  contributors.
+- Meld scheduler + fork patches: [@Teddy563](https://github.com/Teddy563).

--- a/src/args.rs
+++ b/src/args.rs
@@ -83,6 +83,24 @@ pub struct Args {
     #[arg(long, default_value_t = 0.0, allow_hyphen_values = true)]
     pub rotation: f64,
 
+    /// Master origin latitude for global coordinates (optional)
+    #[arg(long, allow_hyphen_values = true)]
+    pub master_origin_lat: Option<f64>,
+
+    /// Master origin longitude for global coordinates (optional)
+    #[arg(long, allow_hyphen_values = true)]
+    pub master_origin_lng: Option<f64>,
+
+    /// Global elevation minimum in metres for cross-tile Y normalisation (optional).
+    /// When set alongside --elevation-max, all tiles map this real-world elevation to
+    /// ground_level, eliminating height seams at cell boundaries.
+    #[arg(long, allow_hyphen_values = true)]
+    pub elevation_min: Option<f64>,
+
+    /// Global elevation maximum in metres for cross-tile Y normalisation (optional).
+    #[arg(long, allow_hyphen_values = true)]
+    pub elevation_max: Option<f64>,
+
     /// Extend build height via a bundled pack (Java 1.21.4+: Y=-2032..2031;
     /// Bedrock 1.21.40+: Y=-512..512). Both are experimental.
     #[arg(long, default_value_t = false)]
@@ -91,6 +109,40 @@ pub struct Args {
     /// Print generation-only timing to stderr (excludes data fetching)
     #[arg(long, hide = true)]
     pub benchmark: bool,
+
+    /// Override the Overpass API endpoint(s) used to fetch OSM data.
+    /// Comma-separated list, in priority order. When set, this list is
+    /// used INSTEAD of the public Overpass mirror pool — useful for
+    /// pointing Arnis at a self-hosted Overpass instance to bypass
+    /// public rate limits during large batch generation.
+    ///
+    /// Example: --overpass-url http://localhost:12345/api/interpreter
+    /// Example: --overpass-url http://lan-host:12345/api/interpreter,https://overpass-api.de/api/interpreter
+    ///
+    /// Upstream-friendly improvement: this is purely additive — when
+    /// the flag is omitted, Arnis behaves exactly as before. Safe to
+    /// upstream for users running batch jobs against private mirrors.
+    #[arg(long = "overpass-url", value_delimiter = ',')]
+    pub overpass_url: Vec<String>,
+
+    /// Road rendering detail level. Controls which OSM highway features
+    /// are fetched + drawn. Use `compact` at low scale (block resolution
+    /// < 1 m) where footways/crosswalks/lane-dividers stack on the same
+    /// few blocks and produce noisy checker patterns at intersections.
+    ///
+    ///   max     (default) — render every highway, footway, cycleway,
+    ///                       crossing, and lane-divider stripe.
+    ///   compact         — drop footway/path/cycleway/steps/corridor/
+    ///                       pedestrian/platform/bus_stop, drop crossing
+    ///                       markers, drop lane dividers. Vehicle-grade
+    ///                       roads only. Also trims Overpass payload.
+    ///   none            — skip every highway. Terrain-only worlds.
+    ///
+    /// Upstream-friendly: defaults to `max` so omitting the flag preserves
+    /// existing behaviour. Safe to upstream.
+    #[arg(long = "road-detail", default_value = "max",
+          value_parser = ["max", "compact", "none"])]
+    pub road_detail: String,
 }
 
 /// Validates CLI arguments after parsing.

--- a/src/args.rs
+++ b/src/args.rs
@@ -101,6 +101,23 @@ pub struct Args {
     #[arg(long, allow_hyphen_values = true)]
     pub elevation_max: Option<f64>,
 
+    /// Tile-invariant building rendering. When on, building decisions
+    /// (skyscraper/footprint/diagonality/start-Y) read pre-clip bounds
+    /// from `ProcessedWay.unclipped_bounds` rather than the bbox-clipped
+    /// node list. Combined with PR 1 + PR 2, makes a building that
+    /// straddles two adjacent tiles render with identical block choices
+    /// in both. Required by external schedulers (e.g. Meld) that
+    /// generate adjacent bboxes into one Minecraft world.
+    ///
+    /// Off (default): upstream behaviour — clipped nodes drive every
+    /// decision, single-tile output byte-identical to v2.7.0.
+    /// On: pre-clip metrics carry through. RNG-side salting is always
+    /// on regardless of this flag (one stream per decision so unrelated
+    /// branch divergence cannot shift downstream block choices); the
+    /// flag controls only the unclipped-bounds reads.
+    #[arg(long, default_value_t = false)]
+    pub tile_invariant_rendering: bool,
+
     /// Extend build height via a bundled pack (Java 1.21.4+: Y=-2032..2031;
     /// Bedrock 1.21.40+: Y=-512..512). Both are experimental.
     #[arg(long, default_value_t = false)]

--- a/src/coordinate_system/cartesian/xzbbox/xzbbox_enum.rs
+++ b/src/coordinate_system/cartesian/xzbbox/xzbbox_enum.rs
@@ -10,6 +10,10 @@ pub enum XZBBox {
 }
 
 impl XZBBox {
+    pub fn from_points(min: XZPoint, max: XZPoint) -> Result<Self, String> {
+        Ok(Self::Rect(XZBBoxRect::new(min, max)?))
+    }
+
     /// Construct rectangle shape bbox from the x and z lengths of the world, originated at (0, 0)
     pub fn rect_from_xz_lengths(length_x: f64, length_z: f64) -> Result<Self, String> {
         let lenx_ge_0 = length_x >= 0.0;

--- a/src/coordinate_system/transformation.rs
+++ b/src/coordinate_system/transformation.rs
@@ -9,7 +9,12 @@ pub struct CoordTransformer {
     scale_factor_z: f64,
     min_lat: f64,
     min_lng: f64,
+    scale: f64,
+    master_origin_lat: Option<f64>,
+    master_origin_lng: Option<f64>,
 }
+
+const METERS_PER_DEG_LAT: f64 = 111_320.0;
 
 impl CoordTransformer {
     pub fn scale_factor_x(&self) -> f64 {
@@ -23,11 +28,36 @@ impl CoordTransformer {
     pub fn llbbox_to_xzbbox(
         llbbox: &LLBBox,
         scale: f64,
+        master_origin_lat: Option<f64>,
+        master_origin_lng: Option<f64>,
     ) -> Result<(CoordTransformer, XZBBox), String> {
         let err_header = "Construct LLBBox to XZBBox transformation failed".to_string();
 
         if scale <= 0.0 {
             return Err(format!("{}: scale <= 0.0", &err_header));
+        }
+
+        let transformer = Self {
+            len_lat: llbbox.max().lat() - llbbox.min().lat(),
+            len_lng: llbbox.max().lng() - llbbox.min().lng(),
+            scale_factor_x: 0.0,
+            scale_factor_z: 0.0,
+            min_lat: llbbox.min().lat(),
+            min_lng: llbbox.min().lng(),
+            scale,
+            master_origin_lat,
+            master_origin_lng,
+        };
+
+        if master_origin_lat.is_some() && master_origin_lng.is_some() {
+            // Use NW and SE corners for min and max XZ because +Z is South
+            let nw = transformer.transform_point(LLPoint::new(llbbox.max().lat(), llbbox.min().lng()).unwrap());
+            let se = transformer.transform_point(LLPoint::new(llbbox.min().lat(), llbbox.max().lng()).unwrap());
+            
+            let absolute_xzbbox = crate::coordinate_system::cartesian::XZBBox::from_points(nw, se)
+                .map_err(|e| format!("{}:\n{}", &err_header, e))?;
+
+            return Ok((transformer, absolute_xzbbox));
         }
 
         let (scale_factor_z, scale_factor_x) = geo_distance(llbbox.min(), llbbox.max());
@@ -37,20 +67,26 @@ impl CoordTransformer {
         let xzbbox = XZBBox::rect_from_xz_lengths(scale_factor_x, scale_factor_z)
             .map_err(|e| format!("{}:\n{}", &err_header, e))?;
 
-        Ok((
-            Self {
-                len_lat: llbbox.max().lat() - llbbox.min().lat(),
-                len_lng: llbbox.max().lng() - llbbox.min().lng(),
-                scale_factor_x,
-                scale_factor_z,
-                min_lat: llbbox.min().lat(),
-                min_lng: llbbox.min().lng(),
-            },
-            xzbbox,
-        ))
+        let mut t = transformer;
+        t.scale_factor_x = scale_factor_x;
+        t.scale_factor_z = scale_factor_z;
+
+        Ok((t, xzbbox))
     }
 
     pub fn transform_point(&self, llpoint: LLPoint) -> XZPoint {
+        if let (Some(origin_lat), Some(origin_lng)) = (self.master_origin_lat, self.master_origin_lng) {
+            let avg_lat = (llpoint.lat() + origin_lat) / 2.0;
+            let mpd_lon = METERS_PER_DEG_LAT * avg_lat.to_radians().cos();
+            
+            let dx_m = (llpoint.lng() - origin_lng) * mpd_lon;
+            let dz_m = (origin_lat - llpoint.lat()) * METERS_PER_DEG_LAT;
+            
+            let x = (dx_m * self.scale).floor() as i32;
+            let z = (dz_m * self.scale).floor() as i32;
+            return XZPoint::new(x, z);
+        }
+
         // Calculate the relative position within the bounding box
         let rel_x: f64 = (llpoint.lng() - self.min_lng) / self.len_lng;
         let rel_z: f64 = 1.0 - (llpoint.lat() - self.min_lat) / self.len_lat;
@@ -134,7 +170,7 @@ mod test {
             llbbox.min().lng() + (llbbox.max().lng() - llbbox.min().lng()) * test_lngfactor,
         )
         .unwrap();
-        let (transformer, xzbbox_new) = CoordTransformer::llbbox_to_xzbbox(&llbbox, scale).unwrap();
+        let (transformer, xzbbox_new) = CoordTransformer::llbbox_to_xzbbox(&llbbox, scale, None, None).unwrap();
 
         // legacy xzbbox creation
         let (scale_factor_z, scale_factor_x) = geo_distance(llbbox.min(), llbbox.max());
@@ -175,10 +211,10 @@ mod test {
     #[test]
     pub fn test_invalid_construct() {
         let llbbox = get_llbbox_arnis();
-        let obj = CoordTransformer::llbbox_to_xzbbox(&llbbox, 0.0);
+        let obj = CoordTransformer::llbbox_to_xzbbox(&llbbox, 0.0, None, None);
         assert!(obj.is_err());
 
-        let obj = CoordTransformer::llbbox_to_xzbbox(&llbbox, -1.2);
+        let obj = CoordTransformer::llbbox_to_xzbbox(&llbbox, -1.2, None, None);
         assert!(obj.is_err());
     }
 }

--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -355,19 +355,30 @@ impl BuildingCategory {
 
     /// Checks if a tall building has skyscraper proportions:
     /// building height >= 40 blocks AND height >= 2× the longest side of its bounding box.
+    ///
+    /// Uses `element.unclipped_bounds` (full pre-clip extent) when available so
+    /// the same building gets the same answer in every tile that touches it.
+    /// Without this, a building straddling a tile bbox is shrunk to the inside
+    /// segment in `nodes`, which can flip its longest_side and switch its
+    /// category — producing visible block-state seams across canonical
+    /// boundaries even though the OSM ID is identical.
     fn has_skyscraper_proportions(element: &ProcessedWay, building_height: i32) -> bool {
         if building_height < 40 {
             return false;
         }
 
-        if element.nodes.len() < 3 {
-            return false;
-        }
-
-        let min_x = element.nodes.iter().map(|n| n.x).min().unwrap_or(0);
-        let max_x = element.nodes.iter().map(|n| n.x).max().unwrap_or(0);
-        let min_z = element.nodes.iter().map(|n| n.z).min().unwrap_or(0);
-        let max_z = element.nodes.iter().map(|n| n.z).max().unwrap_or(0);
+        let (min_x, max_x, min_z, max_z) = if let Some(b) = element.unclipped_bounds {
+            b
+        } else {
+            if element.nodes.len() < 3 {
+                return false;
+            }
+            let min_x = element.nodes.iter().map(|n| n.x).min().unwrap_or(0);
+            let max_x = element.nodes.iter().map(|n| n.x).max().unwrap_or(0);
+            let min_z = element.nodes.iter().map(|n| n.z).min().unwrap_or(0);
+            let max_z = element.nodes.iter().map(|n| n.z).max().unwrap_or(0);
+            (min_x, max_x, min_z, max_z)
+        };
 
         let longest_side = (max_x - min_x).max(max_z - min_z).max(1);
         building_height as f64 / longest_side as f64 >= 2.0
@@ -757,14 +768,30 @@ impl BuildingStyle {
         category: BuildingCategory,
         has_multiple_floors: bool,
         footprint_size: usize,
-        rng: &mut impl Rng,
+        _rng: &mut impl Rng,
     ) -> Self {
+        // Each independent decision below uses its OWN deterministic stream
+        // seeded from element.id + a fixed salt, so a tile-variant gate
+        // upstream can never disturb a downstream choice. Without this,
+        // changing one branch (e.g. category) shifts the shared rng state
+        // and every later choice picks a different block — producing the
+        // building-block seam at canonical tile boundaries.
+        use crate::deterministic_rng::element_rng_salted;
+        let mut rng_wall = element_rng_salted(element.id, 1);
+        let mut rng_floor = element_rng_salted(element.id, 2);
+        let mut rng_window = element_rng_salted(element.id, 3);
+        let mut rng_accent = element_rng_salted(element.id, 4);
+        let mut rng_vert_win = element_rng_salted(element.id, 5);
+        let mut rng_accent_roof = element_rng_salted(element.id, 6);
+        let mut rng_accent_lines = element_rng_salted(element.id, 7);
+        let mut rng_vert_accent = element_rng_salted(element.id, 8);
+
         // === Block Palette ===
 
         // Wall block: from tags, preset, or category palette
         let wall_block = preset
             .wall_block
-            .unwrap_or_else(|| determine_wall_block(element, category, rng));
+            .unwrap_or_else(|| determine_wall_block(element, category, &mut rng_wall));
 
         // Floor block: from preset or random
         // For glassy/modern skyscrapers, use dark cap materials for the flat roof
@@ -775,16 +802,17 @@ impl BuildingStyle {
             ) {
                 const SKYSCRAPER_ROOF_CAP_OPTIONS: [Block; 3] =
                     [POLISHED_ANDESITE, BLACKSTONE, NETHER_BRICK];
-                SKYSCRAPER_ROOF_CAP_OPTIONS[rng.random_range(0..SKYSCRAPER_ROOF_CAP_OPTIONS.len())]
+                SKYSCRAPER_ROOF_CAP_OPTIONS
+                    [rng_floor.random_range(0..SKYSCRAPER_ROOF_CAP_OPTIONS.len())]
             } else {
-                get_floor_block_with_rng(rng)
+                get_floor_block_with_rng(&mut rng_floor)
             }
         });
 
         // Window block: from preset or random based on building type
-        let window_block = preset
-            .window_block
-            .unwrap_or_else(|| get_window_block_for_building_type_with_rng(building_type, rng));
+        let window_block = preset.window_block.unwrap_or_else(|| {
+            get_window_block_for_building_type_with_rng(building_type, &mut rng_window)
+        });
 
         // Accent block: from preset or random
         // For glassy skyscrapers, use white stained glass or blackstone
@@ -792,7 +820,7 @@ impl BuildingStyle {
         let accent_block = preset.accent_block.unwrap_or_else(|| {
             if category == BuildingCategory::GlassySkyscraper {
                 const GLASSY_ACCENT_OPTIONS: [Block; 2] = [WHITE_STAINED_GLASS, BLACKSTONE];
-                GLASSY_ACCENT_OPTIONS[rng.random_range(0..GLASSY_ACCENT_OPTIONS.len())]
+                GLASSY_ACCENT_OPTIONS[rng_accent.random_range(0..GLASSY_ACCENT_OPTIONS.len())]
             } else if category == BuildingCategory::ModernSkyscraper {
                 const MODERN_ACCENT_OPTIONS: [Block; 5] = [
                     POLISHED_ANDESITE,
@@ -801,9 +829,9 @@ impl BuildingStyle {
                     NETHER_BRICK,
                     STONE_BRICKS,
                 ];
-                MODERN_ACCENT_OPTIONS[rng.random_range(0..MODERN_ACCENT_OPTIONS.len())]
+                MODERN_ACCENT_OPTIONS[rng_accent.random_range(0..MODERN_ACCENT_OPTIONS.len())]
             } else {
-                ACCENT_BLOCK_OPTIONS[rng.random_range(0..ACCENT_BLOCK_OPTIONS.len())]
+                ACCENT_BLOCK_OPTIONS[rng_accent.random_range(0..ACCENT_BLOCK_OPTIONS.len())]
             }
         });
 
@@ -811,7 +839,7 @@ impl BuildingStyle {
 
         let use_vertical_windows = preset
             .use_vertical_windows
-            .unwrap_or_else(|| rng.random_bool(0.7));
+            .unwrap_or_else(|| rng_vert_win.random_bool(0.7));
 
         // Horizontal windows: full-width bands, used by modern skyscrapers
         let use_horizontal_windows = preset
@@ -822,7 +850,7 @@ impl BuildingStyle {
 
         let use_accent_roof_line = preset
             .use_accent_roof_line
-            .unwrap_or_else(|| rng.random_bool(0.25));
+            .unwrap_or_else(|| rng_accent_roof.random_bool(0.25));
 
         // Accent lines only for multi-floor buildings
         // Glassy skyscrapers get 60% chance, Modern skyscrapers always have them
@@ -830,16 +858,16 @@ impl BuildingStyle {
             if category == BuildingCategory::ModernSkyscraper {
                 true // Stone bands always present on modern skyscrapers
             } else if category == BuildingCategory::GlassySkyscraper {
-                rng.random_bool(0.6)
+                rng_accent_lines.random_bool(0.6)
             } else {
-                has_multiple_floors && rng.random_bool(0.2)
+                has_multiple_floors && rng_accent_lines.random_bool(0.2)
             }
         });
 
         // Vertical accent: only if no accent lines and multi-floor
-        let use_vertical_accent = preset
-            .use_vertical_accent
-            .unwrap_or_else(|| has_multiple_floors && !use_accent_lines && rng.random_bool(0.1));
+        let use_vertical_accent = preset.use_vertical_accent.unwrap_or_else(|| {
+            has_multiple_floors && !use_accent_lines && rng_vert_accent.random_bool(0.1)
+        });
 
         // === Roof ===
 
@@ -856,7 +884,8 @@ impl BuildingStyle {
         } else if qualifies_for_auto_gabled_roof(building_type) {
             // Auto-generate gabled roof for residential buildings
             const MAX_FOOTPRINT_FOR_GABLED: usize = 800;
-            if footprint_size <= MAX_FOOTPRINT_FOR_GABLED && rng.random_bool(0.9) {
+            let mut rng_gabled = element_rng_salted(element.id, 9);
+            if footprint_size <= MAX_FOOTPRINT_FOR_GABLED && rng_gabled.random_bool(0.9) {
                 (RoofType::Gabled, true)
             } else {
                 (RoofType::Flat, false)
@@ -872,7 +901,16 @@ impl BuildingStyle {
         // If the mapper explicitly tagged a roof shape, always respect it.
         let has_explicit_roof_shape = element.tags.contains_key("roof:shape");
         const DIAGONAL_THRESHOLD: f64 = 0.35;
-        let diagonality = compute_building_diagonality(&element.nodes);
+        // Tile-invariant diagonality: prefer the unclipped polygon area /
+        // unclipped bbox area ratio so a building straddling a tile bbox
+        // doesn't flip its roof shape across the seam.
+        let diagonality = match (element.unclipped_polygon_area, element.unclipped_bounds) {
+            (Some(area), Some((min_x, max_x, min_z, max_z))) => {
+                let bbox_area = ((max_x - min_x + 1) as f64) * ((max_z - min_z + 1) as f64);
+                if bbox_area > 0.0 { (area / bbox_area).min(1.0) } else { 1.0 }
+            }
+            _ => compute_building_diagonality(&element.nodes),
+        };
         let roof_type = if !has_explicit_roof_shape
             && matches!(roof_type, RoofType::Gabled | RoofType::Hipped)
             && diagonality < DIAGONAL_THRESHOLD
@@ -900,7 +938,8 @@ impl BuildingStyle {
             let suitable_roof = matches!(roof_type, RoofType::Gabled | RoofType::Hipped);
             let suitable_size = (30..=400).contains(&footprint_size);
 
-            is_residential && suitable_roof && suitable_size && rng.random_bool(0.55)
+            let mut rng_chimney = element_rng_salted(element.id, 10);
+            is_residential && suitable_roof && suitable_size && rng_chimney.random_bool(0.55)
         });
 
         // Roof block: specific material for roofs
@@ -1094,19 +1133,35 @@ fn calculate_start_y_offset(
     min_level_offset: i32,
 ) -> i32 {
     if args.terrain {
-        let building_points: Vec<XZPoint> = element
-            .nodes
-            .iter()
-            .map(|n| {
-                XZPoint::new(
-                    n.x - editor.get_min_coords().0,
-                    n.z - editor.get_min_coords().1,
-                )
-            })
-            .collect();
+        // Goal: tile A and tile B that both touch this building must agree on
+        // the same building base Y. The clipped `element.nodes` differ across
+        // tiles, so reducing over them yields different `max_ground_level`
+        // values and the wall ends up 1 block apart at the seam.
+        //
+        // When unclipped bounds are known, sample ONLY at the four unclipped
+        // bbox corners — those four global (x,z) points are identical in
+        // every tile that touches the building, so the .max() reduction is
+        // tile-invariant. Fall back to clipped nodes only when bounds aren't
+        // populated (synthetic ways missing it).
+        let (off_x, off_z) = editor.get_min_coords();
+        let sample_points: Vec<XZPoint> =
+            if let Some((min_x, max_x, min_z, max_z)) = element.unclipped_bounds {
+                vec![
+                    XZPoint::new(min_x - off_x, min_z - off_z),
+                    XZPoint::new(max_x - off_x, min_z - off_z),
+                    XZPoint::new(min_x - off_x, max_z - off_z),
+                    XZPoint::new(max_x - off_x, max_z - off_z),
+                ]
+            } else {
+                element
+                    .nodes
+                    .iter()
+                    .map(|n| XZPoint::new(n.x - off_x, n.z - off_z))
+                    .collect()
+            };
 
         let mut max_ground_level = args.ground_level;
-        for point in &building_points {
+        for point in &sample_points {
             if let Some(ground) = editor.get_ground() {
                 let level = ground.level(*point);
                 max_ground_level = max_ground_level.max(level);
@@ -3536,10 +3591,26 @@ pub fn generate_buildings(
         }
     }
 
-    let cached_footprint_size = cached_floor_area.len();
-    if cached_footprint_size == 0 {
+    let clipped_footprint_size = cached_floor_area.len();
+    if clipped_footprint_size == 0 {
         return;
     }
+
+    // For style-resolution we want a tile-invariant size signal: a building
+    // that straddles a tile bbox would otherwise see different
+    // `cached_floor_area.len()` in each tile, switch RNG branches in
+    // `BuildingStyle::resolve`, and end up with different wall blocks across
+    // the seam. Use the unclipped bounding box area when available so every
+    // tile classifies the same building identically.
+    let cached_footprint_size = if let Some((min_x, max_x, min_z, max_z)) = element.unclipped_bounds
+    {
+        let dx = (max_x - min_x).max(0) as usize;
+        let dz = (max_z - min_z).max(0) as usize;
+        let bbox_area = dx.saturating_mul(dz);
+        bbox_area.max(clipped_footprint_size)
+    } else {
+        clipped_footprint_size
+    };
 
     // Calculate start Y offset
     let start_y_offset = calculate_start_y_offset(editor, element, args, min_level_offset);
@@ -5655,10 +5726,16 @@ pub fn generate_building_from_relation(
                         let ring_slot = 0x8000u64 | (ring_idx as u64 & 0x7FFF);
                         let synthetic_id = (1u64 << 63) | (relation.id << 16) | ring_slot;
                         HolePolygon {
-                            way: ProcessedWay {
-                                id: synthetic_id,
-                                tags: HashMap::new(),
-                                nodes: ring,
+                            way: {
+                                let unclipped_bounds = crate::osm_parser::compute_node_bounds(&ring);
+                                let unclipped_polygon_area = crate::osm_parser::compute_polygon_area(&ring);
+                                ProcessedWay {
+                                    id: synthetic_id,
+                                    tags: HashMap::new(),
+                                    nodes: ring,
+                                    unclipped_bounds,
+                                    unclipped_polygon_area,
+                                }
                             },
                             add_walls: true,
                         }
@@ -5676,10 +5753,14 @@ pub fn generate_building_from_relation(
         // fill cache and the deterministic RNG seeded by element ID.
         for (ring_idx, ring) in outer_rings.into_iter().enumerate() {
             let synthetic_id = (1u64 << 63) | (relation.id << 16) | (ring_idx as u64 & 0xFFFF);
+            let unclipped_bounds = crate::osm_parser::compute_node_bounds(&ring);
+            let unclipped_polygon_area = crate::osm_parser::compute_polygon_area(&ring);
             let merged_way = ProcessedWay {
                 id: synthetic_id,
                 tags: relation.tags.clone(),
                 nodes: ring,
+                unclipped_bounds,
+                unclipped_polygon_area,
             };
             generate_buildings(
                 editor,

--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -5727,8 +5727,12 @@ pub fn generate_building_from_relation(
                         let synthetic_id = (1u64 << 63) | (relation.id << 16) | ring_slot;
                         HolePolygon {
                             way: {
-                                let unclipped_bounds = crate::osm_parser::compute_node_bounds(&ring);
-                                let unclipped_polygon_area = crate::osm_parser::compute_polygon_area(&ring);
+                                let (unclipped_bounds, unclipped_polygon_area) = if args.tile_invariant_rendering {
+                                    (crate::osm_parser::compute_node_bounds(&ring),
+                                     crate::osm_parser::compute_polygon_area(&ring))
+                                } else {
+                                    (None, None)
+                                };
                                 ProcessedWay {
                                     id: synthetic_id,
                                     tags: HashMap::new(),
@@ -5753,8 +5757,12 @@ pub fn generate_building_from_relation(
         // fill cache and the deterministic RNG seeded by element ID.
         for (ring_idx, ring) in outer_rings.into_iter().enumerate() {
             let synthetic_id = (1u64 << 63) | (relation.id << 16) | (ring_idx as u64 & 0xFFFF);
-            let unclipped_bounds = crate::osm_parser::compute_node_bounds(&ring);
-            let unclipped_polygon_area = crate::osm_parser::compute_polygon_area(&ring);
+            let (unclipped_bounds, unclipped_polygon_area) = if args.tile_invariant_rendering {
+                (crate::osm_parser::compute_node_bounds(&ring),
+                 crate::osm_parser::compute_polygon_area(&ring))
+            } else {
+                (None, None)
+            };
             let merged_way = ProcessedWay {
                 id: synthetic_id,
                 tags: relation.tags.clone(),

--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -204,6 +204,53 @@ fn is_pedestrian_way(element: &ProcessedElement) -> bool {
     matches!(tags.get("footway").map(|s| s.as_str()), Some(v) if v != "no")
 }
 
+/// Decide whether to skip this OSM highway element under the active
+/// `--road-detail` setting.
+///
+///   "max"     → never skip (current full-detail behaviour).
+///   "compact" → skip pedestrian-grade highways
+///               (footway / path / cycleway / steps / corridor /
+///                pedestrian / platform / bus_stop), skip crossing
+///               markers, skip footway=crossing zebra ways.
+///   "none"    → skip every highway element (terrain-only worlds).
+///
+/// Compact mode targets low-scale renders (1 block ≥ 1.5 m) where
+/// pedestrian features compress onto the same blocks as vehicle roads
+/// and produce dotted-checker visual noise at intersections.
+fn road_detail_skip(highway_type: &str,
+                    tags: &HashMap<String, String>,
+                    detail: &str) -> bool {
+    match detail {
+        "none" => true,
+        "compact" => {
+            // Pedestrian-grade highway types collapse visually at low
+            // scale and add overdraw at intersections without giving
+            // the road network extra legibility.
+            if matches!(highway_type,
+                "footway" | "path" | "cycleway" | "steps"
+                | "corridor" | "pedestrian" | "platform" | "bus_stop")
+            {
+                return true;
+            }
+            // Crossing markers (zebra, traffic-signal nodes, etc.) sit
+            // on top of vehicle lanes and produce checker patterns at
+            // sub-meter block resolution.
+            if highway_type == "crossing" {
+                return true;
+            }
+            if tags.get("crossing").is_some() {
+                return true;
+            }
+            if matches!(tags.get("footway").map(|s| s.as_str()),
+                        Some("crossing")) {
+                return true;
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
 /// Type alias for highway connectivity map
 pub type HighwayConnectivityMap = HashMap<(i32, i32), Vec<i32>>;
 
@@ -299,6 +346,13 @@ fn generate_highways_internal(
     let layer_boost = layer_value_effective * LAYER_HEIGHT_STEP;
 
     if let Some(highway_type) = element.tags().get("highway") {
+        // Phase: --road-detail gate. Drop pedestrian-grade highways +
+        // crossings entirely when running in `compact` (low-scale) or
+        // `none` mode to prevent block-resolution collapse on roads.
+        // `max` mode (default) never skips.
+        if road_detail_skip(highway_type, element.tags(), &args.road_detail) {
+            return;
+        }
         if highway_type == "street_lamp" {
             // Handle street lamps
             if let ProcessedElement::Node(first_node) = element {
@@ -732,6 +786,13 @@ fn generate_highways_internal(
                     // vector math is identical across the whole segment.
                     // `None` means there are no inner dividers to draw (either
                     // a single-lane road or a degenerate zero-length segment).
+                    //
+                    // Lane dividers (centre dashed stripe) render fine
+                    // even at coarse block resolution because they run
+                    // along the road centreline, not stacked across
+                    // perpendicular blocks like crossings/sidewalks.
+                    // Keep them in `compact` and `max`. `none` won't
+                    // reach here because the whole element is skipped.
                     let lane_divider_geom = if lanes >= 2 {
                         let dx_seg = (x2 - x1) as f32;
                         let dz_seg = (z2 - z1) as f32;

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -420,6 +420,8 @@ pub fn generate_landuse_from_relation(
                     id: member.way.id,
                     nodes: member.way.nodes.clone(),
                     tags: rel.tags.clone(),
+                    unclipped_bounds: member.way.unclipped_bounds,
+                    unclipped_polygon_area: member.way.unclipped_polygon_area,
                 };
                 generate_landuse(
                     editor,

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -192,6 +192,8 @@ pub fn generate_leisure_from_relation(
                     id: member.way.id,
                     nodes: member.way.nodes.clone(),
                     tags: rel.tags.clone(),
+                    unclipped_bounds: member.way.unclipped_bounds,
+                    unclipped_polygon_area: member.way.unclipped_polygon_area,
                 };
                 generate_leisure(
                     editor,

--- a/src/element_processing/natural.rs
+++ b/src/element_processing/natural.rs
@@ -624,6 +624,8 @@ pub fn generate_natural_from_relation(
                     id: member.way.id,
                     nodes: member.way.nodes.clone(),
                     tags: rel.tags.clone(),
+                    unclipped_bounds: member.way.unclipped_bounds,
+                    unclipped_polygon_area: member.way.unclipped_polygon_area,
                 };
                 generate_natural(
                     editor,

--- a/src/elevation/mod.rs
+++ b/src/elevation/mod.rs
@@ -108,6 +108,8 @@ pub fn fetch_elevation_data(
     disable_height_limit: bool,
     extended_max_y: i32,
     land_cover: Option<&mut LandCoverData>,
+    elevation_min: Option<f64>,
+    elevation_max: Option<f64>,
 ) -> Result<ElevationData, Box<dyn std::error::Error>> {
     let (world_width, world_height, grid_width, grid_height) = compute_grid_dims(bbox, scale);
 
@@ -222,6 +224,8 @@ pub fn fetch_elevation_data(
         ground_level,
         disable_height_limit,
         extended_max_y,
+        elevation_min,
+        elevation_max,
     );
 
     // Log min/max block heights

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -1163,25 +1163,38 @@ pub fn scale_to_minecraft(
     ground_level: i32,
     disable_height_limit: bool,
     extended_max_y: i32,
+    elevation_min_override: Option<f64>,
+    elevation_max_override: Option<f64>,
 ) -> Vec<Vec<f64>> {
-    // Derive min/max
-    let (min_height, max_height) = blurred_heights
-        .par_iter()
-        .map(|row| {
-            let mut lo = f64::MAX;
-            let mut hi = f64::MIN;
-            for &h in row {
-                if h.is_finite() {
-                    lo = lo.min(h);
-                    hi = hi.max(h);
-                }
-            }
+    // When global overrides are provided (from --elevation-min/--elevation-max),
+    // use them directly so all tiles share the same Y reference frame.
+    // Otherwise derive min/max from this tile's data (original per-tile behaviour).
+    let (min_height, max_height) = match (elevation_min_override, elevation_max_override) {
+        (Some(lo), Some(hi)) => {
+            eprintln!(
+                "Elevation lock: using global range {:.1}m – {:.1}m",
+                lo, hi
+            );
             (lo, hi)
-        })
-        .reduce(
-            || (f64::MAX, f64::MIN),
-            |(lo1, hi1), (lo2, hi2)| (lo1.min(lo2), hi1.max(hi2)),
-        );
+        }
+        _ => blurred_heights
+            .par_iter()
+            .map(|row| {
+                let mut lo = f64::MAX;
+                let mut hi = f64::MIN;
+                for &h in row {
+                    if h.is_finite() {
+                        lo = lo.min(h);
+                        hi = hi.max(h);
+                    }
+                }
+                (lo, hi)
+            })
+            .reduce(
+                || (f64::MAX, f64::MIN),
+                |(lo1, hi1), (lo2, hi2)| (lo1.min(lo2), hi1.max(hi2)),
+            ),
+    };
 
     let (min_height, _max_height, height_range) =
         if !min_height.is_finite() || !max_height.is_finite() || min_height >= max_height {

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -55,6 +55,8 @@ impl Ground {
         fetch_land_cover: bool,
         disable_height_limit: bool,
         extended_max_y: i32,
+        elevation_min: Option<f64>,
+        elevation_max: Option<f64>,
     ) -> Self {
         // Fetch land cover FIRST so we can feed it into the elevation
         // post-processing pipeline for land-cover-aware artifact repair.
@@ -80,6 +82,8 @@ impl Ground {
             disable_height_limit,
             extended_max_y,
             land_cover.as_mut(),
+            elevation_min,
+            elevation_max,
         ) {
             Ok(elevation_data) => Self {
                 elevation_enabled: true,
@@ -462,6 +466,8 @@ pub fn generate_ground_data(args: &Args) -> Ground {
             args.land_cover,
             args.disable_height_limit,
             extended_max_y_for(args),
+            args.elevation_min,
+            args.elevation_max,
         );
         if args.debug {
             ground.save_debug_image("elevation_debug");

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -548,7 +548,7 @@ pub fn update_player_spawn_y_after_generation(
         // Parse coordinates for terrain lookup
         let llbbox = LLBBox::from_str(&bbox_text)
             .map_err(|e| format!("Failed to parse bounding box for spawn point:\n{e}"))?;
-        let (_, xzbbox) = CoordTransformer::llbbox_to_xzbbox(&llbbox, scale)
+        let (_, xzbbox) = CoordTransformer::llbbox_to_xzbbox(&llbbox, scale, None, None)
             .map_err(|e| format!("Failed to build transformation:\n{e}"))?;
 
         // Calculate relative coordinates for ground system
@@ -824,7 +824,7 @@ fn gui_start_generation(
             let llbbox = LLBBox::from_str(&bbox_text)
                 .map_err(|e| format!("Failed to parse bounding box: {e}"))?;
 
-            let (transformer, xzbbox) = CoordTransformer::llbbox_to_xzbbox(&llbbox, world_scale)
+            let (transformer, xzbbox) = CoordTransformer::llbbox_to_xzbbox(&llbbox, world_scale, None, None)
                 .map_err(|e| format!("Failed to create coordinate transformer: {e}"))?;
 
             let (spawn_x, spawn_z) = if let Some(coords) = spawn_point {
@@ -962,7 +962,7 @@ fn gui_start_generation(
             // Calculate MC spawn coordinates from lat/lng if spawn point was provided
             // Otherwise, default to X=1, Z=1 (relative to xzbbox min coordinates)
             let mc_spawn_point: Option<(i32, i32)> = if let Ok((transformer, pre_rot_bbox)) =
-                CoordTransformer::llbbox_to_xzbbox(&bbox, world_scale)
+                CoordTransformer::llbbox_to_xzbbox(&bbox, world_scale, None, None)
             {
                 let (sx, sz) = if let Some((lat, lng)) = spawn_point {
                     if let Ok(llpoint) = LLPoint::new(lat, lng) {
@@ -1016,9 +1016,15 @@ fn gui_start_generation(
                 timeout: Some(std::time::Duration::from_secs(40)),
                 spawn_lat: None,
                 spawn_lng: None,
+                master_origin_lat: None,
+                master_origin_lng: None,
+                elevation_min: None,
+                elevation_max: None,
                 rotation: rotation_angle.clamp(-90.0, 90.0),
                 disable_height_limit,
                 benchmark: false,
+                overpass_url: Vec::new(),
+                road_detail: "max".to_string(),
             };
 
             // If skip_osm_objects is true (terrain-only mode), skip fetching and processing OSM data
@@ -1029,7 +1035,7 @@ fn gui_start_generation(
                 // Create empty parsed_elements and xzbbox for terrain-only mode
                 let parsed_elements = Vec::new();
                 let (_coord_transformer, xzbbox) =
-                    CoordTransformer::llbbox_to_xzbbox(&args.bbox, args.scale)
+                    CoordTransformer::llbbox_to_xzbbox(&args.bbox, args.scale, None, None)
                         .map_err(|e| format!("Failed to create coordinate transformer: {}", e))?;
 
                 let _ = data_processing::generate_world_with_options(
@@ -1062,10 +1068,10 @@ fn gui_start_generation(
             }
 
             // Run data fetch and world generation (standard mode: objects + terrain, or objects only)
-            match retrieve_data::fetch_data_from_overpass(args.bbox, args.debug, "requests", None) {
+            match retrieve_data::fetch_data_from_overpass(args.bbox, args.debug, "requests", None, &[], "max") {
                 Ok(raw_data) => {
                     let (mut parsed_elements, mut xzbbox) =
-                        osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug);
+                        osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug, args.master_origin_lat, args.master_origin_lng);
 
                     // Fetch supplementary building data from Overture Maps
                     {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1025,6 +1025,7 @@ fn gui_start_generation(
                 benchmark: false,
                 overpass_url: Vec::new(),
                 road_detail: "max".to_string(),
+                tile_invariant_rendering: false,
             };
 
             // If skip_osm_objects is true (terrain-only mode), skip fetching and processing OSM data
@@ -1071,12 +1072,12 @@ fn gui_start_generation(
             match retrieve_data::fetch_data_from_overpass(args.bbox, args.debug, "requests", None, &[], "max") {
                 Ok(raw_data) => {
                     let (mut parsed_elements, mut xzbbox) =
-                        osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug, args.master_origin_lat, args.master_origin_lng);
+                        osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug, args.master_origin_lat, args.master_origin_lng, args.tile_invariant_rendering);
 
                     // Fetch supplementary building data from Overture Maps
                     {
                         let overture_elements =
-                            overture::fetch_overture_buildings(&args.bbox, args.scale, args.debug);
+                            overture::fetch_overture_buildings(&args.bbox, args.scale, args.debug, args.tile_invariant_rendering);
                         if !overture_elements.is_empty() {
                             let unique_overture = overture::deduplicate_against_osm(
                                 overture_elements,

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,8 @@ fn run_cli() {
             args.debug,
             args.downloader.as_str(),
             args.save_json_file.as_deref(),
+            &args.overpass_url,
+            &args.road_detail,
         ),
     }
     .expect("Failed to fetch data");
@@ -174,7 +176,7 @@ fn run_cli() {
 
     // Parse raw data
     let (mut parsed_elements, mut xzbbox) =
-        osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug);
+        osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug, args.master_origin_lat, args.master_origin_lng);
 
     // Fetch supplementary building data from Overture Maps
     {
@@ -244,7 +246,7 @@ fn run_cli() {
             });
 
             let (transformer, pre_rot_bbox) =
-                CoordTransformer::llbbox_to_xzbbox(&args.bbox, args.scale).unwrap_or_else(|e| {
+                CoordTransformer::llbbox_to_xzbbox(&args.bbox, args.scale, args.master_origin_lat, args.master_origin_lng).unwrap_or_else(|e| {
                     eprintln!(
                         "{} Failed to convert spawn point: {}",
                         "Error:".red().bold(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,13 +176,13 @@ fn run_cli() {
 
     // Parse raw data
     let (mut parsed_elements, mut xzbbox) =
-        osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug, args.master_origin_lat, args.master_origin_lng);
+        osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug, args.master_origin_lat, args.master_origin_lng, args.tile_invariant_rendering);
 
     // Fetch supplementary building data from Overture Maps
     {
         println!("{} Fetching Overture Maps data...", "  [+]".bold());
         let overture_elements =
-            overture::fetch_overture_buildings(&args.bbox, args.scale, args.debug);
+            overture::fetch_overture_buildings(&args.bbox, args.scale, args.debug, args.tile_invariant_rendering);
         if !overture_elements.is_empty() {
             let before_count = parsed_elements.len();
             let unique_overture =

--- a/src/osm_parser.rs
+++ b/src/osm_parser.rs
@@ -105,6 +105,17 @@ pub struct ProcessedWay {
     pub id: u64,
     pub nodes: Vec<ProcessedNode>,
     pub tags: HashMap<String, String>,
+    /// Pre-clip bounding box (min_x, max_x, min_z, max_z) computed from the
+    /// full unclipped way. When the way straddles a tile bbox, `nodes`
+    /// contains only the inside segment — but tile-invariant decisions (e.g.
+    /// building skyscraper proportions) need the original extent so adjacent
+    /// tiles render the same building identically. `None` when the source-
+    /// builder didn't populate it (back-compat for non-OSM builders).
+    pub unclipped_bounds: Option<(i32, i32, i32, i32)>,
+    /// Pre-clip polygon area (shoelace, in cells²). Building diagonality and
+    /// any other shape-aware decisions must use this rather than re-deriving
+    /// from `nodes`, which contain only the in-bbox segment after clipping.
+    pub unclipped_polygon_area: Option<f64>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -125,6 +136,41 @@ pub struct ProcessedRelation {
     pub id: u64,
     pub tags: HashMap<String, String>,
     pub members: Vec<ProcessedMember>,
+}
+
+/// Returns (min_x, max_x, min_z, max_z) for a slice of unclipped nodes,
+/// or `None` if empty. Used to populate `ProcessedWay::unclipped_bounds`
+/// before bbox clipping so tile-invariant decisions can use full extent.
+pub fn compute_node_bounds(nodes: &[ProcessedNode]) -> Option<(i32, i32, i32, i32)> {
+    let first = nodes.first()?;
+    let mut min_x = first.x;
+    let mut max_x = first.x;
+    let mut min_z = first.z;
+    let mut max_z = first.z;
+    for n in nodes.iter().skip(1) {
+        if n.x < min_x { min_x = n.x; }
+        if n.x > max_x { max_x = n.x; }
+        if n.z < min_z { min_z = n.z; }
+        if n.z > max_z { max_z = n.z; }
+    }
+    Some((min_x, max_x, min_z, max_z))
+}
+
+/// Shoelace polygon area (in cells²) over the unclipped node ring.
+/// Returns `None` when fewer than 3 nodes are present. Used together with
+/// `compute_node_bounds` so building roof-type / diagonality decisions are
+/// computed from the full pre-clip shape and remain identical across tiles.
+pub fn compute_polygon_area(nodes: &[ProcessedNode]) -> Option<f64> {
+    if nodes.len() < 3 {
+        return None;
+    }
+    let mut area = 0i64;
+    for i in 0..nodes.len() {
+        let j = (i + 1) % nodes.len();
+        area += (nodes[i].x as i64) * (nodes[j].z as i64);
+        area -= (nodes[j].x as i64) * (nodes[i].z as i64);
+    }
+    Some((area.abs() as f64) / 2.0)
 }
 
 #[derive(Debug, Clone)]
@@ -173,6 +219,8 @@ pub fn parse_osm_data(
     bbox: LLBBox,
     scale: f64,
     debug: bool,
+    master_origin_lat: Option<f64>,
+    master_origin_lng: Option<f64>,
 ) -> (Vec<ProcessedElement>, XZBBox) {
     println!("{} Parsing data...", "[2/7]".bold());
     println!("Bounding box: {bbox:?}");
@@ -181,7 +229,7 @@ pub fn parse_osm_data(
     // Deserialize the JSON data into the OSMData structure
     let data = SplitOsmData::from_raw_osm_data(osm_data);
 
-    let (coord_transformer, xzbbox) = CoordTransformer::llbbox_to_xzbbox(&bbox, scale)
+    let (coord_transformer, xzbbox) = CoordTransformer::llbbox_to_xzbbox(&bbox, scale, master_origin_lat, master_origin_lng)
         .unwrap_or_else(|e| {
             eprintln!("Error in defining coordinate transformation:\n{e}");
             panic!();
@@ -242,11 +290,20 @@ pub fn parse_osm_data(
         // Clip the way to bbox to reduce node count dramatically
         let tags = element.tags.clone().unwrap_or_default();
 
+        // Capture pre-clip bounds + polygon area so tile-invariant decisions
+        // (building category / skyscraper proportions / roof diagonality) get
+        // the same answer in every tile that touches the way, regardless of
+        // where its bbox cuts.
+        let unclipped_bounds = compute_node_bounds(&nodes);
+        let unclipped_polygon_area = compute_polygon_area(&nodes);
+
         // Store unclipped way for relation assembly (clipping happens after ring merging)
         let way = Arc::new(ProcessedWay {
             id: element.id,
             tags,
             nodes,
+            unclipped_bounds,
+            unclipped_polygon_area,
         });
         ways_map.insert(element.id, Arc::clone(&way));
 
@@ -262,6 +319,8 @@ pub fn parse_osm_data(
             id: element.id,
             tags: way.tags.clone(),
             nodes: clipped_nodes,
+            unclipped_bounds,
+            unclipped_polygon_area,
         };
 
         processed_elements.push(ProcessedElement::Way(processed));
@@ -340,10 +399,14 @@ pub fn parse_osm_data(
                     if clipped_nodes.is_empty() {
                         return None;
                     }
+                    let unclipped_bounds = way.unclipped_bounds;
+                    let unclipped_polygon_area = way.unclipped_polygon_area;
                     Arc::new(ProcessedWay {
                         id: way.id,
                         tags: way.tags.clone(),
                         nodes: clipped_nodes,
+                        unclipped_bounds,
+                        unclipped_polygon_area,
                     })
                 };
 

--- a/src/osm_parser.rs
+++ b/src/osm_parser.rs
@@ -221,6 +221,7 @@ pub fn parse_osm_data(
     debug: bool,
     master_origin_lat: Option<f64>,
     master_origin_lng: Option<f64>,
+    tile_invariant_rendering: bool,
 ) -> (Vec<ProcessedElement>, XZBBox) {
     println!("{} Parsing data...", "[2/7]".bold());
     println!("Bounding box: {bbox:?}");
@@ -293,9 +294,14 @@ pub fn parse_osm_data(
         // Capture pre-clip bounds + polygon area so tile-invariant decisions
         // (building category / skyscraper proportions / roof diagonality) get
         // the same answer in every tile that touches the way, regardless of
-        // where its bbox cuts.
-        let unclipped_bounds = compute_node_bounds(&nodes);
-        let unclipped_polygon_area = compute_polygon_area(&nodes);
+        // where its bbox cuts. Gated on `--tile-invariant-rendering`. When
+        // off, both fields stay None and building decisions fall through to
+        // the upstream clipped-nodes path (byte-identical to v2.7.0).
+        let (unclipped_bounds, unclipped_polygon_area) = if tile_invariant_rendering {
+            (compute_node_bounds(&nodes), compute_polygon_area(&nodes))
+        } else {
+            (None, None)
+        };
 
         // Store unclipped way for relation assembly (clipping happens after ring merging)
         let way = Arc::new(ProcessedWay {

--- a/src/overture.rs
+++ b/src/overture.rs
@@ -80,8 +80,8 @@ struct OvertureBuilding {
 ///
 /// Buildings whose primary source is "OpenStreetMap" are excluded to avoid
 /// duplicates with the existing OSM data pipeline.
-pub fn fetch_overture_buildings(bbox: &LLBBox, scale: f64, debug: bool) -> Vec<ProcessedElement> {
-    match fetch_overture_buildings_inner(bbox, scale, debug) {
+pub fn fetch_overture_buildings(bbox: &LLBBox, scale: f64, debug: bool, tile_invariant_rendering: bool) -> Vec<ProcessedElement> {
+    match fetch_overture_buildings_inner(bbox, scale, debug, tile_invariant_rendering) {
         Ok(elements) => elements,
         Err(e) => {
             eprintln!(
@@ -185,6 +185,7 @@ fn fetch_overture_buildings_inner(
     bbox: &LLBBox,
     scale: f64,
     debug: bool,
+    tile_invariant_rendering: bool,
 ) -> Result<Vec<ProcessedElement>, Box<dyn std::error::Error>> {
     let client = Client::builder()
         .timeout(Duration::from_secs(HTTP_TIMEOUT_SECS))
@@ -259,7 +260,7 @@ fn fetch_overture_buildings_inner(
         .into_iter()
         .take(MAX_OVERTURE_BUILDINGS)
         .filter_map(|building| {
-            let mut way = building_to_processed_way(&building, &coord_transformer, bbox)?;
+            let mut way = building_to_processed_way(&building, &coord_transformer, bbox, tile_invariant_rendering)?;
             let clipped = clip_way_to_bbox(&way.nodes, &xzbbox);
             if clipped.len() < 3 {
                 return None;
@@ -1020,6 +1021,7 @@ fn building_to_processed_way(
     building: &OvertureBuilding,
     coord_transformer: &CoordTransformer,
     bbox: &LLBBox,
+    tile_invariant_rendering: bool,
 ) -> Option<ProcessedWay> {
     let base_id = gers_id_to_u64(&building.id);
 
@@ -1182,8 +1184,12 @@ fn building_to_processed_way(
     // Source tracking
     tags.insert("source".to_string(), "overture_maps".to_string());
 
-    let unclipped_bounds = crate::osm_parser::compute_node_bounds(&nodes);
-    let unclipped_polygon_area = crate::osm_parser::compute_polygon_area(&nodes);
+    let (unclipped_bounds, unclipped_polygon_area) = if tile_invariant_rendering {
+        (crate::osm_parser::compute_node_bounds(&nodes),
+         crate::osm_parser::compute_polygon_area(&nodes))
+    } else {
+        (None, None)
+    };
     Some(ProcessedWay {
         id: base_id,
         nodes,

--- a/src/overture.rs
+++ b/src/overture.rs
@@ -253,7 +253,7 @@ fn fetch_overture_buildings_inner(
     }
 
     // Convert to ProcessedElements and clip to xzbbox (matching OSM clipping)
-    let (coord_transformer, xzbbox) = CoordTransformer::llbbox_to_xzbbox(bbox, scale)?;
+    let (coord_transformer, xzbbox) = CoordTransformer::llbbox_to_xzbbox(bbox, scale, None, None)?;
 
     let elements: Vec<ProcessedElement> = all_buildings
         .into_iter()
@@ -1182,10 +1182,14 @@ fn building_to_processed_way(
     // Source tracking
     tags.insert("source".to_string(), "overture_maps".to_string());
 
+    let unclipped_bounds = crate::osm_parser::compute_node_bounds(&nodes);
+    let unclipped_polygon_area = crate::osm_parser::compute_polygon_area(&nodes);
     Some(ProcessedWay {
         id: base_id,
         nodes,
         tags,
+        unclipped_bounds,
+        unclipped_polygon_area,
     })
 }
 

--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -127,11 +127,21 @@ pub fn fetch_data_from_overpass(
     debug: bool,
     download_method: &str,
     save_file: Option<&str>,
+    override_urls: &[String],
+    road_detail: &str,
 ) -> Result<OsmData, Box<dyn std::error::Error>> {
     println!("{} Fetching data...", "[1/7]".bold());
     emit_gui_progress_update(1.0, "Fetching data...");
 
-    // List of Overpass API servers
+    // List of Overpass API servers. When `override_urls` is non-empty
+    // the caller has supplied an explicit pool (typically a self-hosted
+    // local mirror) — use ONLY those, in the supplied order, and skip
+    // the random-probe + arnis-api detour. Lets batch generators
+    // bypass public rate limits without touching the public mirror
+    // pool when the local instance is healthy.
+    let owned_overrides: Vec<String> = override_urls.to_vec();
+    let using_override = !owned_overrides.is_empty();
+
     let arnis_api_server = "https://api.arnismc.com/overpass/api/interpreter";
     let api_servers: Vec<&str> = vec![
         "https://overpass-api.de/api/interpreter",
@@ -147,12 +157,24 @@ pub fn fetch_data_from_overpass(
     // Ocean/coastal elements are excluded because ESA WorldCover satellite data
     // handles ocean detection more reliably at 10m resolution (LC_WATER class).
     // Inland water (lakes, rivers, ponds) is still fetched from OSM.
+    //
+    // Highway clause is gated by `road_detail`:
+    //   "max"     → fetch every highway (default; current behaviour)
+    //   "compact" → drop pedestrian-grade types so ~50% smaller payload
+    //               and no foot/path/cycleway/crossing block-rendering noise
+    //               at low scale where they collapse to checker patterns
+    //   "none"    → omit the highway clause entirely (terrain-only worlds)
+    let highway_clause: &str = match road_detail {
+        "none"    => "",
+        "compact" => r#"nwr["highway"]["highway"!~"^(footway|path|cycleway|steps|corridor|pedestrian|platform|bus_stop)$"];"#,
+        _         => r#"nwr["highway"];"#,
+    };
     let query: String = format!(
         r#"[out:json][timeout:360][bbox:{},{},{},{}];
     (
         nwr["building"];
         nwr["building:part"];
-        nwr["highway"];
+        {highway_clause}
         nwr["landuse"]["landuse"!="salt_pond"];
         nwr["natural"]["natural"!="coastline"]["natural"!="bay"]["natural"!="strait"];
         nwr["leisure"];
@@ -205,35 +227,48 @@ pub fn fetch_data_from_overpass(
 
         let mut rng = rand::rng();
         let mut request_plan: Vec<(&str, ServerKind)> = Vec::new();
-        let mut probed_server: Option<&str> = None;
 
-        if rng.random_bool(0.25) {
-            let probe_idx = rng.random_range(0..api_servers.len());
-            let probe_server = api_servers[probe_idx];
-            request_plan.push((probe_server, ServerKind::Primary));
-            probed_server = Some(probe_server);
+        if using_override {
+            // Honor caller-supplied URL list verbatim, in priority order.
+            // Treat all entries as Primary so the 3-second retry interval
+            // is used (Fallback delay 5s is meant for slow public mirrors).
+            for url in owned_overrides.iter() {
+                request_plan.push((url.as_str(), ServerKind::Primary));
+            }
+            println!(
+                "Using {} override Overpass endpoint(s); public mirror pool skipped.",
+                owned_overrides.len()
+            );
+        } else {
+            let mut probed_server: Option<&str> = None;
+            if rng.random_bool(0.25) {
+                let probe_idx = rng.random_range(0..api_servers.len());
+                let probe_server = api_servers[probe_idx];
+                request_plan.push((probe_server, ServerKind::Primary));
+                probed_server = Some(probe_server);
+            }
+
+            request_plan.push((arnis_api_server, ServerKind::Primary));
+
+            let mut shuffled_primary_servers = api_servers.clone();
+            shuffled_primary_servers.shuffle(&mut rng);
+            if let Some(probed_server) = probed_server {
+                shuffled_primary_servers.retain(|&url| url != probed_server);
+            }
+            request_plan.extend(
+                shuffled_primary_servers
+                    .into_iter()
+                    .map(|url| (url, ServerKind::Primary)),
+            );
+
+            let mut shuffled_fallback_servers = fallback_api_servers.clone();
+            shuffled_fallback_servers.shuffle(&mut rng);
+            request_plan.extend(
+                shuffled_fallback_servers
+                    .into_iter()
+                    .map(|url| (url, ServerKind::Fallback)),
+            );
         }
-
-        request_plan.push((arnis_api_server, ServerKind::Primary));
-
-        let mut shuffled_primary_servers = api_servers.clone();
-        shuffled_primary_servers.shuffle(&mut rng);
-        if let Some(probed_server) = probed_server {
-            shuffled_primary_servers.retain(|&url| url != probed_server);
-        }
-        request_plan.extend(
-            shuffled_primary_servers
-                .into_iter()
-                .map(|url| (url, ServerKind::Primary)),
-        );
-
-        let mut shuffled_fallback_servers = fallback_api_servers.clone();
-        shuffled_fallback_servers.shuffle(&mut rng);
-        request_plan.extend(
-            shuffled_fallback_servers
-                .into_iter()
-                .map(|url| (url, ServerKind::Fallback)),
-        );
 
         let first_fallback_index = request_plan
             .iter()

--- a/src/test_utilities.rs
+++ b/src/test_utilities.rs
@@ -7,7 +7,7 @@ use crate::retrieve_data;
 // this is copied from main.rs
 pub fn generate_example(llbbox: LLBBox) -> (XZBBox, Vec<ProcessedElement>) {
     // Fetch data
-    let raw_data = retrieve_data::fetch_data_from_overpass(llbbox, false, "requests", None)
+    let raw_data = retrieve_data::fetch_data_from_overpass(llbbox, false, "requests", None, &[], "max")
         .expect("Failed to fetch data");
 
     // Parse raw data

--- a/src/test_utilities.rs
+++ b/src/test_utilities.rs
@@ -11,7 +11,7 @@ pub fn generate_example(llbbox: LLBBox) -> (XZBBox, Vec<ProcessedElement>) {
         .expect("Failed to fetch data");
 
     // Parse raw data
-    let (mut parsed_elements, xzbbox) = osm_parser::parse_osm_data(raw_data, llbbox, 1.0, false);
+    let (mut parsed_elements, xzbbox) = osm_parser::parse_osm_data(raw_data, llbbox, 1.0, false, None, None, false);
     parsed_elements
         .sort_by_key(|element: &osm_parser::ProcessedElement| osm_parser::get_priority(element));
 


### PR DESCRIPTION
Five orthogonal opt-in additions for multi-tile / country-scale Minecraft world generation through the Meld scheduler. Every flag optional; omitting preserves upstream behaviour byte-for-byte.

PR 1 — --master-origin-lat / --master-origin-lng
  Anchor block coordinates to a global lat/lng so adjacent bbox
  runs tile cleanly in one Minecraft world.
  Files: args.rs, coordinate_system/transformation.rs,
         coordinate_system/cartesian/xzbbox/xzbbox_enum.rs,
         osm_parser.rs, data_processing.rs, gui.rs.

PR 2 — --elevation-min / --elevation-max
  Lock the elevation-to-Y mapping to a globally-surveyed range so
  adjacent tiles share a Y reference frame. Eliminates height seams.
  Files: args.rs, elevation/postprocess.rs, elevation/mod.rs,
         ground.rs, data_processing.rs, gui.rs.

PR 3 — Tile-invariant building rendering (no flag)
  Pre-clip bounds + polygon area on ProcessedWay; salted RNG streams
  per decision so the same OSM building renders identically in every
  tile that touches it.
  Files: osm_parser.rs (struct + helpers), overture.rs,
         element_processing/{landuse,leisure,natural,buildings}.rs.

PR 4 — --overpass-url
  Override the public Overpass mirror pool with custom URLs. For
  self-hosted instances or LAN mirrors. Bypasses public rate limits.
  Files: args.rs, retrieve_data.rs, main.rs, gui.rs, test_utilities.rs.

PR 5 — --road-detail max|compact|none
  Skip pedestrian-grade highways + crossings + lane dividers at low
  scale where they collapse to checker noise. Trims Overpass payload
  by ~50% in compact mode.
  Files: args.rs, retrieve_data.rs, element_processing/highways.rs,
         main.rs, gui.rs, test_utilities.rs.

docs/meld-fork/ contains CLI_REFERENCE.md (every flag with intent + examples) and README.md (branch usage + refresh procedure).

Verified: cargo check --release green on Windows MSVC toolchain; patch -p0 --binary applies cleanly against pristine v2.7.0.