### PR TITLE
Render rail bridges as proper structures and stop lifting unlabelled bridge decks

### DIFF
--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -87,6 +87,9 @@ pub fn generate_world_with_options(
     let bridge_surface =
         bridges::BridgeSurfaceMap::build(&elements, &bridge_structures, args.scale);
 
+    let rail_bridge_internal_endpoints =
+        railways::collect_rail_bridge_internal_endpoints(&elements);
+
     // Process all elements (no longer need to partition boundaries)
     let elements_count: usize = elements.len();
     let process_pb: ProgressBar = ProgressBar::new(elements_count as u64);
@@ -225,7 +228,12 @@ pub fn generate_world_with_options(
                         waterways::generate_waterways(&mut editor, way);
                     }
                 } else if way.tags.contains_key("railway") {
-                    railways::generate_railways(&mut editor, way, &mut subway_points);
+                    railways::generate_railways(
+                        &mut editor,
+                        way,
+                        &mut subway_points,
+                        &rail_bridge_internal_endpoints,
+                    );
                 } else if way.tags.contains_key("roller_coaster") {
                     railways::generate_roller_coaster(&mut editor, way);
                 } else if way.tags.contains_key("aeroway") || way.tags.contains_key("area:aeroway")

--- a/src/element_processing/bridges.rs
+++ b/src/element_processing/bridges.rs
@@ -247,19 +247,13 @@ impl BridgeStructureMap {
                 }
             }
 
-            // Effective layer for this structure: max of members; default 1 if any member has bridge tag and no layer.
+            // Max explicit layer; unlabelled members contribute 0 so a pure-unlabelled group stays at terrain.
             let mut max_layer = 0;
-            let mut had_unlabelled = false;
             for &idx in group_indices {
                 let way = bridge_ways[idx];
-                let raw = way.tags.get("layer").and_then(|v| v.parse::<i32>().ok());
-                match raw {
-                    Some(l) => max_layer = max_layer.max(l.max(0)),
-                    None => had_unlabelled = true,
+                if let Some(l) = way.tags.get("layer").and_then(|v| v.parse::<i32>().ok()) {
+                    max_layer = max_layer.max(l.max(0));
                 }
-            }
-            if max_layer == 0 && had_unlabelled {
-                max_layer = 1;
             }
 
             // Sample terrain Ys: every endpoint plus a small set of midpoints across the group.

--- a/src/element_processing/railways.rs
+++ b/src/element_processing/railways.rs
@@ -12,7 +12,7 @@ const RAIL_BRIDGE_DIP_THRESHOLD: i32 = 4;
 const RAIL_BRIDGE_RAMP_MIN: usize = 8;
 const RAIL_BRIDGE_RAMP_MAX: usize = 30;
 const RAIL_BRIDGE_RAMP_FRACTION: f32 = 0.25;
-const RAIL_BRIDGE_PILLAR_INTERVAL: i32 = 8;
+const RAIL_BRIDGE_PILLAR_INTERVAL: usize = 8;
 
 pub type RailBridgeInternalEndpoints = HashSet<(i32, i32)>;
 
@@ -110,13 +110,19 @@ fn renders_as_rail_bridge(way: &ProcessedWay) -> bool {
     if way.nodes.len() < 2 || !is_rail_bridge(way) {
         return false;
     }
-    let is_subway = railway_type == "subway"
-        || way.tags.get("subway").map(|v| v == "yes").unwrap_or(false);
+    let is_subway =
+        railway_type == "subway" || way.tags.get("subway").map(|v| v == "yes").unwrap_or(false);
     if is_subway {
         return false;
     }
-    if ["proposed", "abandoned", "construction", "razed", "turntable"]
-        .contains(&railway_type.as_str())
+    if [
+        "proposed",
+        "abandoned",
+        "construction",
+        "razed",
+        "turntable",
+    ]
+    .contains(&railway_type.as_str())
     {
         return false;
     }
@@ -268,7 +274,8 @@ fn generate_rail_bridge(
     let start_internal = internal_endpoints.contains(&start_xz);
     let end_internal = internal_endpoints.contains(&end_xz);
 
-    // Ensure ramp_length >= max ramping height delta + 1 so per-cell linear delta stays <= 1 (rail step limit).
+    // Ramp length sized so per-cell linear delta stays <= 1 (rail step limit). No horizontal cap:
+    // when needed > total/2 the start/end ramps overlap and min(start, end) below produces a pyramid.
     let mut needed = 0usize;
     if !start_internal {
         needed = needed.max((deck_y - start_ground).max(0) as usize);
@@ -279,30 +286,31 @@ fn generate_rail_bridge(
     let needed = needed + 1;
 
     let raw_ramp = (total as f32 * RAIL_BRIDGE_RAMP_FRACTION) as usize;
-    let cap = (total / 2).max(1);
     let ramp_length = raw_ramp
         .clamp(RAIL_BRIDGE_RAMP_MIN, RAIL_BRIDGE_RAMP_MAX)
-        .max(needed)
-        .min(cap);
+        .max(needed);
     let denom = ramp_length.saturating_sub(1).max(1) as f32;
 
     let bridge_ys: Vec<i32> = (0..total)
         .map(|tds| {
-            let linear_y = if !start_internal && tds < ramp_length && deck_y > start_ground {
+            // Two rising ramps from each endpoint, capped at deck_y. min combines them: trapezoid
+            // for long bridges (both ramps reach deck_y mid-span), pyramid for short ones.
+            let start_ramp_y = if start_internal {
+                deck_y
+            } else {
                 let t = (tds as f32 / denom).min(1.0);
                 let span = (deck_y - start_ground) as f32;
                 (start_ground as f32 + span * t).round() as i32
-            } else if !end_internal
-                && last_idx.saturating_sub(tds) < ramp_length
-                && deck_y > end_ground
-            {
+            };
+            let end_ramp_y = if end_internal {
+                deck_y
+            } else {
                 let dist_from_end = last_idx.saturating_sub(tds);
                 let t = (dist_from_end as f32 / denom).min(1.0);
                 let span = (deck_y - end_ground) as f32;
                 (end_ground as f32 + span * t).round() as i32
-            } else {
-                deck_y
             };
+            let linear_y = start_ramp_y.min(end_ramp_y);
             // Clamp to local terrain so a mid-ramp hillside doesn't bury the deck/foundation.
             linear_y.max(terrain_ys[tds])
         })
@@ -320,13 +328,13 @@ fn generate_rail_bridge(
         let next_y = if i + 1 < total { bridge_ys[i + 1] } else { y };
         let rail_block = determine_rail_with_slope((bx, bz), prev_xz, next_xz, prev_y, y, next_y);
 
-        // Foundation slab, gravel bed (sleeper every 4 blocks), rail on top.
+        // Foundation slab, gravel bed (sleeper every 4 cells along the centerline), rail on top.
         editor.set_block_absolute(STONE_BRICKS, bx, y - 1, bz, None, None);
-        let bed_block = if bx % 4 == 0 { OAK_LOG } else { GRAVEL };
+        let bed_block = if i % 4 == 0 { OAK_LOG } else { GRAVEL };
         editor.set_block_absolute(bed_block, bx, y, bz, None, None);
         editor.set_block_absolute(rail_block, bx, y + 1, bz, None, None);
 
-        if (bx + bz).rem_euclid(RAIL_BRIDGE_PILLAR_INTERVAL) == 0 {
+        if i % RAIL_BRIDGE_PILLAR_INTERVAL == 0 {
             let ground_y = terrain_ys[i];
             let pillar_top = y - 2;
             if pillar_top > ground_y {

--- a/src/element_processing/railways.rs
+++ b/src/element_processing/railways.rs
@@ -239,12 +239,13 @@ fn generate_rail_bridge(
         return;
     }
 
-    // Sample terrain at every centerline cell, not just OSM nodes, so a hill mid-span
-    // still clears the deck.
+    // Sample terrain at every centerline cell, not just OSM nodes, so a hill mid-span still clears the deck.
+    let mut terrain_ys: Vec<i32> = Vec::with_capacity(all_points.len());
     let mut max_y = i32::MIN;
     let mut min_y = i32::MAX;
     for &(bx, bz) in &all_points {
         let y = editor.get_ground_level(bx, bz);
+        terrain_ys.push(y);
         max_y = max_y.max(y);
         min_y = min_y.min(y);
     }
@@ -258,25 +259,36 @@ fn generate_rail_bridge(
 
     let total = all_points.len();
     let last_idx = total - 1;
+
+    let start_xz = all_points[0];
+    let end_xz = all_points[last_idx];
+    let start_ground = terrain_ys[0];
+    let end_ground = terrain_ys[last_idx];
+    // Shared endpoints stay at deck Y to avoid a mid-bridge dip between adjacent segments.
+    let start_internal = internal_endpoints.contains(&start_xz);
+    let end_internal = internal_endpoints.contains(&end_xz);
+
+    // Ensure ramp_length >= max ramping height delta + 1 so per-cell linear delta stays <= 1 (rail step limit).
+    let mut needed = 0usize;
+    if !start_internal {
+        needed = needed.max((deck_y - start_ground).max(0) as usize);
+    }
+    if !end_internal {
+        needed = needed.max((deck_y - end_ground).max(0) as usize);
+    }
+    let needed = needed + 1;
+
     let raw_ramp = (total as f32 * RAIL_BRIDGE_RAMP_FRACTION) as usize;
     let cap = (total / 2).max(1);
     let ramp_length = raw_ramp
         .clamp(RAIL_BRIDGE_RAMP_MIN, RAIL_BRIDGE_RAMP_MAX)
+        .max(needed)
         .min(cap);
-
-    let start_xz = (way.nodes[0].x, way.nodes[0].z);
-    let end_node = &way.nodes[way.nodes.len() - 1];
-    let end_xz = (end_node.x, end_node.z);
-    let start_ground = editor.get_ground_level(start_xz.0, start_xz.1);
-    let end_ground = editor.get_ground_level(end_xz.0, end_xz.1);
-    // Shared endpoints stay at deck Y to avoid a mid-bridge dip between adjacent segments.
-    let start_internal = internal_endpoints.contains(&start_xz);
-    let end_internal = internal_endpoints.contains(&end_xz);
     let denom = ramp_length.saturating_sub(1).max(1) as f32;
 
     let bridge_ys: Vec<i32> = (0..total)
         .map(|tds| {
-            if !start_internal && tds < ramp_length && deck_y > start_ground {
+            let linear_y = if !start_internal && tds < ramp_length && deck_y > start_ground {
                 let t = (tds as f32 / denom).min(1.0);
                 let span = (deck_y - start_ground) as f32;
                 (start_ground as f32 + span * t).round() as i32
@@ -290,7 +302,9 @@ fn generate_rail_bridge(
                 (end_ground as f32 + span * t).round() as i32
             } else {
                 deck_y
-            }
+            };
+            // Clamp to local terrain so a mid-ramp hillside doesn't bury the deck/foundation.
+            linear_y.max(terrain_ys[tds])
         })
         .collect();
 
@@ -313,7 +327,7 @@ fn generate_rail_bridge(
         editor.set_block_absolute(rail_block, bx, y + 1, bz, None, None);
 
         if (bx + bz).rem_euclid(RAIL_BRIDGE_PILLAR_INTERVAL) == 0 {
-            let ground_y = editor.get_ground_level(bx, bz);
+            let ground_y = terrain_ys[i];
             let pillar_top = y - 2;
             if pillar_top > ground_y {
                 for py in (ground_y + 1)..=pillar_top {

--- a/src/element_processing/railways.rs
+++ b/src/element_processing/railways.rs
@@ -1,13 +1,20 @@
 use crate::block_definitions::*;
 use crate::bresenham::bresenham_line;
-use crate::osm_parser::ProcessedWay;
+use crate::osm_parser::{ProcessedElement, ProcessedWay};
 use crate::world_editor::WorldEditor;
-
-/// Number of blocks per OSM layer level (matches highway elevation step).
-const LAYER_HEIGHT_STEP: i32 = 6;
+use std::collections::{HashMap, HashSet};
 
 /// Vertical offset in blocks from the terrain surface to the tunnel ceiling.
 const SUBWAY_DEPTH: i32 = 3;
+
+const RAIL_BRIDGE_FLAT_CLEARANCE: i32 = 4;
+const RAIL_BRIDGE_DIP_THRESHOLD: i32 = 4;
+const RAIL_BRIDGE_RAMP_MIN: usize = 8;
+const RAIL_BRIDGE_RAMP_MAX: usize = 30;
+const RAIL_BRIDGE_RAMP_FRACTION: f32 = 0.25;
+const RAIL_BRIDGE_PILLAR_INTERVAL: i32 = 8;
+
+pub type RailBridgeInternalEndpoints = HashSet<(i32, i32)>;
 
 /// Half-width of the outer stone shell (total footprint = 2 * WALL_RADIUS + 1 = 5).
 const WALL_RADIUS: i32 = 2;
@@ -43,124 +50,248 @@ pub fn generate_railways(
     editor: &mut WorldEditor,
     element: &ProcessedWay,
     subway_points: &mut Vec<(i32, i32)>,
+    rail_bridge_internal_endpoints: &RailBridgeInternalEndpoints,
 ) {
-    if let Some(railway_type) = element.tags.get("railway") {
-        // Subway lines get their own two-phase generation pipeline.
-        let is_subway = railway_type == "subway"
-            || element
-                .tags
-                .get("subway")
-                .map(|v| v == "yes")
-                .unwrap_or(false);
-        if is_subway {
-            generate_subway_shell(editor, element, subway_points);
+    let Some(railway_type) = element.tags.get("railway") else {
+        return;
+    };
+
+    let is_subway = railway_type == "subway"
+        || element
+            .tags
+            .get("subway")
+            .map(|v| v == "yes")
+            .unwrap_or(false);
+    if is_subway {
+        generate_subway_shell(editor, element, subway_points);
+        return;
+    }
+
+    if [
+        "proposed",
+        "abandoned",
+        "construction",
+        "razed",
+        "turntable",
+    ]
+    .contains(&railway_type.as_str())
+    {
+        return;
+    }
+
+    if let Some(tunnel) = element.tags.get("tunnel") {
+        if tunnel == "yes" {
             return;
         }
+    }
 
-        if [
-            "proposed",
-            "abandoned",
-            "construction",
-            "razed",
-            "turntable",
-        ]
-        .contains(&railway_type.as_str())
-        {
-            return;
+    if is_rail_bridge(element) {
+        generate_rail_bridge(editor, element, rail_bridge_internal_endpoints);
+    } else {
+        generate_at_grade_rail(editor, element);
+    }
+}
+
+fn is_rail_bridge(way: &ProcessedWay) -> bool {
+    if way.tags.get("indoor").map(|v| v.as_str()) == Some("yes") {
+        return false;
+    }
+    way.tags
+        .get("bridge")
+        .map(|v| v.as_str())
+        .is_some_and(|v| v != "no")
+}
+
+/// Endpoints shared by 2+ rail-bridge ways — used to suppress per-way ramps mid-bridge.
+pub fn collect_rail_bridge_internal_endpoints(
+    elements: &[ProcessedElement],
+) -> RailBridgeInternalEndpoints {
+    let mut counts: HashMap<(i32, i32), u32> = HashMap::new();
+    for elem in elements {
+        let ProcessedElement::Way(w) = elem else {
+            continue;
+        };
+        if !w.tags.contains_key("railway") || w.nodes.len() < 2 || !is_rail_bridge(w) {
+            continue;
         }
+        let s = &w.nodes[0];
+        let e = &w.nodes[w.nodes.len() - 1];
+        *counts.entry((s.x, s.z)).or_default() += 1;
+        if (e.x, e.z) != (s.x, s.z) {
+            *counts.entry((e.x, e.z)).or_default() += 1;
+        }
+    }
+    counts
+        .into_iter()
+        .filter_map(|(k, c)| (c > 1).then_some(k))
+        .collect()
+}
 
-        if let Some(tunnel) = element.tags.get("tunnel") {
-            if tunnel == "yes" {
-                return;
+fn generate_at_grade_rail(editor: &mut WorldEditor, element: &ProcessedWay) {
+    for i in 1..element.nodes.len() {
+        let prev_node = element.nodes[i - 1].xz();
+        let cur_node = element.nodes[i].xz();
+
+        let points = bresenham_line(prev_node.x, 0, prev_node.z, cur_node.x, 0, cur_node.z);
+        let smoothed_points = smooth_diagonal_rails(&points);
+
+        for j in 0..smoothed_points.len() {
+            let (bx, _, bz) = smoothed_points[j];
+
+            let prev_ground = if j > 0 {
+                let (px, _, pz) = smoothed_points[j - 1];
+                editor.get_ground_level(px, pz)
+            } else {
+                editor.get_ground_level(bx, bz)
+            };
+            let next_ground = if j + 1 < smoothed_points.len() {
+                let (nx, _, nz) = smoothed_points[j + 1];
+                editor.get_ground_level(nx, nz)
+            } else {
+                editor.get_ground_level(bx, bz)
+            };
+            let current_ground = editor.get_ground_level(bx, bz);
+
+            // Fill any vertical gap under the rail when terrain rises step-wise.
+            if prev_ground < current_ground {
+                for fill_y in prev_ground..current_ground {
+                    editor.set_block_absolute(GRAVEL, bx, fill_y, bz, None, None);
+                }
+            }
+
+            editor.set_block(GRAVEL, bx, 0, bz, None, None);
+
+            let prev_xz = if j > 0 {
+                let (px, _, pz) = smoothed_points[j - 1];
+                Some((px, pz))
+            } else {
+                None
+            };
+            let next_xz = if j + 1 < smoothed_points.len() {
+                let (nx, _, nz) = smoothed_points[j + 1];
+                Some((nx, nz))
+            } else {
+                None
+            };
+
+            let rail_block = determine_rail_with_slope(
+                (bx, bz),
+                prev_xz,
+                next_xz,
+                prev_ground,
+                current_ground,
+                next_ground,
+            );
+
+            editor.set_block(rail_block, bx, 1, bz, None, None);
+
+            if bx % 4 == 0 {
+                editor.set_block(OAK_LOG, bx, 0, bz, None, None);
             }
         }
+    }
+}
 
-        // Respect the OSM `layer` tag so elevated railways (bridges, overpasses)
-        // are placed above ground level instead of clipping through it.
-        let layer_value: i32 = element
-            .tags
-            .get("layer")
-            .and_then(|l| l.parse::<i32>().ok())
-            .unwrap_or(0)
-            .max(0); // underground (<0) is handled by the tunnel check above
+fn generate_rail_bridge(
+    editor: &mut WorldEditor,
+    way: &ProcessedWay,
+    internal_endpoints: &RailBridgeInternalEndpoints,
+) {
+    if way.nodes.len() < 2 {
+        return;
+    }
 
-        let layer_offset = layer_value * LAYER_HEIGHT_STEP;
+    let mut max_y = i32::MIN;
+    let mut min_y = i32::MAX;
+    for node in &way.nodes {
+        let y = editor.get_ground_level(node.x, node.z);
+        max_y = max_y.max(y);
+        min_y = min_y.min(y);
+    }
+    let dip = max_y - min_y;
+    // Flat span: lift by clearance so the structure is visible. Canyon span: deck at terrain_max.
+    let deck_y = if dip < RAIL_BRIDGE_DIP_THRESHOLD {
+        max_y + RAIL_BRIDGE_FLAT_CLEARANCE
+    } else {
+        max_y
+    };
 
-        for i in 1..element.nodes.len() {
-            let prev_node = element.nodes[i - 1].xz();
-            let cur_node = element.nodes[i].xz();
+    let mut all_points: Vec<(i32, i32)> = Vec::new();
+    for window in way.nodes.windows(2) {
+        let bp = bresenham_line(window[0].x, 0, window[0].z, window[1].x, 0, window[1].z);
+        let smoothed = smooth_diagonal_rails(&bp);
+        for (bx, _, bz) in smoothed.iter() {
+            if all_points.last() != Some(&(*bx, *bz)) {
+                all_points.push((*bx, *bz));
+            }
+        }
+    }
+    if all_points.is_empty() {
+        return;
+    }
 
-            let points = bresenham_line(prev_node.x, 0, prev_node.z, cur_node.x, 0, cur_node.z);
-            let smoothed_points = smooth_diagonal_rails(&points);
+    let total = all_points.len();
+    let last_idx = total - 1;
+    let raw_ramp = (total as f32 * RAIL_BRIDGE_RAMP_FRACTION) as usize;
+    let cap = (total / 2).max(1);
+    let ramp_length = raw_ramp
+        .clamp(RAIL_BRIDGE_RAMP_MIN, RAIL_BRIDGE_RAMP_MAX)
+        .min(cap);
 
-            for j in 0..smoothed_points.len() {
-                let (bx, _, bz) = smoothed_points[j];
+    let start_xz = (way.nodes[0].x, way.nodes[0].z);
+    let end_node = &way.nodes[way.nodes.len() - 1];
+    let end_xz = (end_node.x, end_node.z);
+    let start_ground = editor.get_ground_level(start_xz.0, start_xz.1);
+    let end_ground = editor.get_ground_level(end_xz.0, end_xz.1);
+    // Shared endpoints stay at deck Y to avoid a mid-bridge dip between adjacent segments.
+    let start_internal = internal_endpoints.contains(&start_xz);
+    let end_internal = internal_endpoints.contains(&end_xz);
+    let denom = ramp_length.saturating_sub(1).max(1) as f32;
 
-                // Base offsets from ground level.
-                // When layer_offset > 0 the rail floats above terrain (bridge/overpass).
-                let gravel_y = layer_offset;
-                let rail_y = layer_offset + 1;
+    let bridge_ys: Vec<i32> = (0..total)
+        .map(|tds| {
+            if !start_internal && tds < ramp_length && deck_y > start_ground {
+                let t = (tds as f32 / denom).min(1.0);
+                let span = (deck_y - start_ground) as f32;
+                (start_ground as f32 + span * t).round() as i32
+            } else if !end_internal
+                && last_idx.saturating_sub(tds) < ramp_length
+                && deck_y > end_ground
+            {
+                let dist_from_end = last_idx.saturating_sub(tds);
+                let t = (dist_from_end as f32 / denom).min(1.0);
+                let span = (deck_y - end_ground) as f32;
+                (end_ground as f32 + span * t).round() as i32
+            } else {
+                deck_y
+            }
+        })
+        .collect();
 
-                // --- Terrain-slope detection (only for at-grade railways) ---
-                // When terrain is enabled and layer == 0 we try to place ascending
-                // rail variants so consecutive blocks stay visually connected even
-                // when the ground rises or falls by one block per step.
-                let prev_ground = if j > 0 {
-                    let (px, _, pz) = smoothed_points[j - 1];
-                    editor.get_ground_level(px, pz)
-                } else {
-                    editor.get_ground_level(bx, bz)
-                };
+    for (i, &(bx, bz)) in all_points.iter().enumerate() {
+        let y = bridge_ys[i];
+        let prev_xz = if i > 0 { Some(all_points[i - 1]) } else { None };
+        let next_xz = if i + 1 < total {
+            Some(all_points[i + 1])
+        } else {
+            None
+        };
+        let prev_y = if i > 0 { bridge_ys[i - 1] } else { y };
+        let next_y = if i + 1 < total { bridge_ys[i + 1] } else { y };
+        let rail_block = determine_rail_with_slope((bx, bz), prev_xz, next_xz, prev_y, y, next_y);
 
-                let next_ground = if j + 1 < smoothed_points.len() {
-                    let (nx, _, nz) = smoothed_points[j + 1];
-                    editor.get_ground_level(nx, nz)
-                } else {
-                    editor.get_ground_level(bx, bz)
-                };
+        // Foundation slab, gravel bed (sleeper every 4 blocks), rail on top.
+        editor.set_block_absolute(STONE_BRICKS, bx, y - 1, bz, None, None);
+        let bed_block = if bx % 4 == 0 { OAK_LOG } else { GRAVEL };
+        editor.set_block_absolute(bed_block, bx, y, bz, None, None);
+        editor.set_block_absolute(rail_block, bx, y + 1, bz, None, None);
 
-                let current_ground = editor.get_ground_level(bx, bz);
-
-                // Fill the vertical gap under the rail when terrain rises steeply
-                // so there is always a solid gravel block supporting the track.
-                if layer_offset == 0 && prev_ground < current_ground {
-                    for fill_y in prev_ground..current_ground {
-                        editor.set_block_absolute(GRAVEL, bx, fill_y, bz, None, None);
-                    }
-                }
-
-                editor.set_block(GRAVEL, bx, gravel_y, bz, None, None);
-
-                let prev_xz = if j > 0 {
-                    let (px, _, pz) = smoothed_points[j - 1];
-                    Some((px, pz))
-                } else {
-                    None
-                };
-                let next_xz = if j + 1 < smoothed_points.len() {
-                    let (nx, _, nz) = smoothed_points[j + 1];
-                    Some((nx, nz))
-                } else {
-                    None
-                };
-
-                let rail_block = if layer_offset == 0 {
-                    determine_rail_with_slope(
-                        (bx, bz),
-                        prev_xz,
-                        next_xz,
-                        prev_ground,
-                        current_ground,
-                        next_ground,
-                    )
-                } else {
-                    determine_rail_direction((bx, bz), prev_xz, next_xz)
-                };
-
-                editor.set_block(rail_block, bx, rail_y, bz, None, None);
-
-                if bx % 4 == 0 {
-                    editor.set_block(OAK_LOG, bx, gravel_y, bz, None, None);
+        if (bx + bz).rem_euclid(RAIL_BRIDGE_PILLAR_INTERVAL) == 0 {
+            let ground_y = editor.get_ground_level(bx, bz);
+            let pillar_top = y - 2;
+            if pillar_top > ground_y {
+                for py in (ground_y + 1)..=pillar_top {
+                    editor.set_block_absolute(STONE_BRICKS, bx, py, bz, None, None);
                 }
             }
         }

--- a/src/element_processing/railways.rs
+++ b/src/element_processing/railways.rs
@@ -102,7 +102,31 @@ fn is_rail_bridge(way: &ProcessedWay) -> bool {
         .is_some_and(|v| v != "no")
 }
 
-/// Endpoints shared by 2+ rail-bridge ways — used to suppress per-way ramps mid-bridge.
+// Mirrors generate_railways' dispatch so the internal-endpoint set only counts rendered bridges.
+fn renders_as_rail_bridge(way: &ProcessedWay) -> bool {
+    let Some(railway_type) = way.tags.get("railway") else {
+        return false;
+    };
+    if way.nodes.len() < 2 || !is_rail_bridge(way) {
+        return false;
+    }
+    let is_subway = railway_type == "subway"
+        || way.tags.get("subway").map(|v| v == "yes").unwrap_or(false);
+    if is_subway {
+        return false;
+    }
+    if ["proposed", "abandoned", "construction", "razed", "turntable"]
+        .contains(&railway_type.as_str())
+    {
+        return false;
+    }
+    if way.tags.get("tunnel").map(|v| v.as_str()) == Some("yes") {
+        return false;
+    }
+    true
+}
+
+/// Endpoints shared by 2+ rendered rail-bridge ways — used to suppress per-way ramps mid-bridge.
 pub fn collect_rail_bridge_internal_endpoints(
     elements: &[ProcessedElement],
 ) -> RailBridgeInternalEndpoints {
@@ -111,7 +135,7 @@ pub fn collect_rail_bridge_internal_endpoints(
         let ProcessedElement::Way(w) = elem else {
             continue;
         };
-        if !w.tags.contains_key("railway") || w.nodes.len() < 2 || !is_rail_bridge(w) {
+        if !renders_as_rail_bridge(w) {
             continue;
         }
         let s = &w.nodes[0];
@@ -201,21 +225,6 @@ fn generate_rail_bridge(
         return;
     }
 
-    let mut max_y = i32::MIN;
-    let mut min_y = i32::MAX;
-    for node in &way.nodes {
-        let y = editor.get_ground_level(node.x, node.z);
-        max_y = max_y.max(y);
-        min_y = min_y.min(y);
-    }
-    let dip = max_y - min_y;
-    // Flat span: lift by clearance so the structure is visible. Canyon span: deck at terrain_max.
-    let deck_y = if dip < RAIL_BRIDGE_DIP_THRESHOLD {
-        max_y + RAIL_BRIDGE_FLAT_CLEARANCE
-    } else {
-        max_y
-    };
-
     let mut all_points: Vec<(i32, i32)> = Vec::new();
     for window in way.nodes.windows(2) {
         let bp = bresenham_line(window[0].x, 0, window[0].z, window[1].x, 0, window[1].z);
@@ -229,6 +238,23 @@ fn generate_rail_bridge(
     if all_points.is_empty() {
         return;
     }
+
+    // Sample terrain at every centerline cell, not just OSM nodes, so a hill mid-span
+    // still clears the deck.
+    let mut max_y = i32::MIN;
+    let mut min_y = i32::MAX;
+    for &(bx, bz) in &all_points {
+        let y = editor.get_ground_level(bx, bz);
+        max_y = max_y.max(y);
+        min_y = min_y.min(y);
+    }
+    let dip = max_y - min_y;
+    // Flat span: lift by clearance so the structure is visible. Canyon span: deck at terrain_max.
+    let deck_y = if dip < RAIL_BRIDGE_DIP_THRESHOLD {
+        max_y + RAIL_BRIDGE_FLAT_CLEARANCE
+    } else {
+        max_y
+    };
 
     let total = all_points.len();
     let last_idx = total - 1;


### PR DESCRIPTION
Two coupled fixes for visible-but-unsupported decks introduced after the bridge PR:

1. bridges.rs: drop the had_unlabelled -> max_layer = 1 fallback in the per-group clearance calc. Unlabelled bridge ways now contribute 0 to the clearance, so a pure-unlabelled flat group renders at terrain instead of getting an unwanted +6 lift. Unlabelled ways unioned with an explicit layer=N way still inherit N's lift via max_layer; effective_layer (used for endpoint-based unioning) still defaults to 1, so unioning behaviour is preserved.

2. railways.rs: replace the layer-based rail lift with a real bridge pipeline. generate_railways now dispatches: - subway -> existing tunnel shell - tunnel=yes -> skip - bridge=yes -> generate_rail_bridge - else -> generate_at_grade_rail generate_rail_bridge picks deck_y from terrain samples (max + 4 for flat spans, max for canyon spans), computes per-cell deck Ys with linear ramps from start_ground / end_ground over clamp(0.25 * total, 8..=30) blocks, and places a stone-brick foundation at y-1, gravel / oak-log sleepers at y, rail at y+1, and periodic stone-brick pillars from terrain up to y-2 every 8 blocks. Internal endpoints (shared by 2+ rail-bridge ways) suppress per-way ramping so multi-way bridges don't dip in the middle - the shared set is built once via collect_rail_bridge_internal_endpoints and threaded through data_processing.