### PR TITLE
Filter ignored OSM tags at parse time to reduce memory

### DIFF
--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -99,11 +99,29 @@ jobs:
           fi
 
           baseline_mem=935
+          mem_diff=$((peak_mem - baseline_mem))
+          mem_abs_diff=${mem_diff#-}
           mem_annotation=""
-          if [ "$peak_mem" -gt 2000 ]; then
-            mem_diff=$((peak_mem - baseline_mem))
+          if [ "$mem_abs_diff" -gt 30 ]; then
             mem_percent=$((mem_diff * 100 / baseline_mem))
-            mem_annotation=" (↗ ${mem_percent}% more)"
+            mem_abs_percent=${mem_percent#-}
+            if [ "$mem_diff" -gt 0 ]; then
+              mem_annotation=" (↗ ${mem_abs_percent}% more)"
+            else
+              mem_annotation=" (↘ ${mem_abs_percent}% less)"
+            fi
+          fi
+
+          if [ "$mem_diff" -lt -100 ]; then
+            mem_verdict="✅ This PR **drastically reduces peak memory**."
+          elif [ "$mem_diff" -lt -30 ]; then
+            mem_verdict="🌱 This PR **reduces peak memory**."
+          elif [ "$mem_abs_diff" -le 30 ]; then
+            mem_verdict="🟢 Peak memory is unchanged."
+          elif [ "$mem_diff" -le 200 ]; then
+            mem_verdict="⚠️ This PR **increases peak memory**."
+          else
+            mem_verdict="🚨 This PR **drastically increases peak memory**."
           fi
 
           benchmark_time=$(date -u "+%Y-%m-%d %H:%M:%S UTC")
@@ -116,11 +134,12 @@ jobs:
             fi
             echo "🧠 Peak memory usage: **${peak_mem} MB**${mem_annotation}"
             echo ""
-            echo "📈 Compared against baseline: **${baseline_time}s**"
-            echo "🧮 Delta: **${diff}s**"
+            echo "📈 Compared against baseline: **${baseline_time}s** time, **${baseline_mem} MB** memory"
+            echo "🧮 Delta: **${diff}s** time, **${mem_diff} MB** memory"
             echo "🔢 Commit: [\`${GITHUB_SHA:0:7}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"
             echo ""
             echo "${verdict}"
+            echo "${mem_verdict}"
             echo ""
             echo "📅 **Last benchmark:** ${benchmark_time}"
             echo ""

--- a/src/osm_parser.rs
+++ b/src/osm_parser.rs
@@ -280,11 +280,8 @@ pub fn parse_osm_data(
 
             // Only add tagged nodes to processed_elements if they're within or near the bbox
             // This significantly improves performance by filtering out distant nodes
-            if !element.tags.as_ref().map(|t| t.is_empty()).unwrap_or(true) {
-                // Node has tags, check if it's in the bbox (with some margin)
-                if xzbbox.contains(&xzpoint) {
-                    processed_elements.push(ProcessedElement::Node(processed));
-                }
+            if !processed.tags.is_empty() && xzbbox.contains(&xzpoint) {
+                processed_elements.push(ProcessedElement::Node(processed));
             }
         }
     }

--- a/src/osm_parser.rs
+++ b/src/osm_parser.rs
@@ -8,6 +8,67 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+// Tags Arnis never reads. Filtered at parse time to save memory.
+const IGNORED_TAGS: &[&str] = &[
+    "created_by",
+    "note",
+    "fixme",
+    "FIXME",
+    "todo",
+    "TODO",
+    "wikipedia",
+    "wikidata",
+    "wikimedia_commons",
+    "import_uuid",
+    "import",
+    "old_name",
+    "loc_name",
+    "official_name",
+    "alt_name",
+    "operator",
+    "phone",
+    "fax",
+    "email",
+    "url",
+    "website",
+    "opening_hours",
+    "description",
+    "attribution",
+    "start_date",
+    "check_date",
+    "survey:date",
+    "ref:bag",
+    "ref:bygningsnr",
+];
+
+// Tag-key prefixes Arnis never reads (localized names, addresses, regional import refs).
+const IGNORED_PREFIXES: &[&str] = &[
+    "addr:",
+    "source",
+    "name:",
+    "alt_name:",
+    "contact:",
+    "is_in:",
+    "operator:",
+    "tiger:",
+    "NHD:",
+    "lacounty:",
+    "nysgissam:",
+    "ref:ruian:",
+    "building:ruian:",
+    "osak:",
+    "gnis:",
+    "yh:",
+    "check_date:",
+];
+
+fn filter_tags(mut tags: HashMap<String, String>) -> HashMap<String, String> {
+    tags.retain(|k, _| {
+        !IGNORED_TAGS.contains(&k.as_str()) && !IGNORED_PREFIXES.iter().any(|p| k.starts_with(p))
+    });
+    tags
+}
+
 // Raw data from OSM
 
 #[derive(Debug, Deserialize)]
@@ -210,7 +271,7 @@ pub fn parse_osm_data(
 
             let processed: ProcessedNode = ProcessedNode {
                 id: element.id,
-                tags: element.tags.clone().unwrap_or_default(),
+                tags: filter_tags(element.tags.clone().unwrap_or_default()),
                 x: xzpoint.x,
                 z: xzpoint.z,
             };
@@ -240,7 +301,7 @@ pub fn parse_osm_data(
         }
 
         // Clip the way to bbox to reduce node count dramatically
-        let tags = element.tags.clone().unwrap_or_default();
+        let tags = filter_tags(element.tags.clone().unwrap_or_default());
 
         // Store unclipped way for relation assembly (clipping happens after ring merging)
         let way = Arc::new(ProcessedWay {
@@ -358,7 +419,7 @@ pub fn parse_osm_data(
             processed_elements.push(ProcessedElement::Relation(ProcessedRelation {
                 id: element.id,
                 members,
-                tags: tags.clone(),
+                tags: filter_tags(tags.clone()),
             }));
         }
     }

--- a/src/osm_parser.rs
+++ b/src/osm_parser.rs
@@ -271,7 +271,7 @@ pub fn parse_osm_data(
 
             let processed: ProcessedNode = ProcessedNode {
                 id: element.id,
-                tags: filter_tags(element.tags.clone().unwrap_or_default()),
+                tags: filter_tags(element.tags.unwrap_or_default()),
                 x: xzpoint.x,
                 z: xzpoint.z,
             };
@@ -298,7 +298,7 @@ pub fn parse_osm_data(
         }
 
         // Clip the way to bbox to reduce node count dramatically
-        let tags = filter_tags(element.tags.clone().unwrap_or_default());
+        let tags = filter_tags(element.tags.unwrap_or_default());
 
         // Store unclipped way for relation assembly (clipping happens after ring merging)
         let way = Arc::new(ProcessedWay {


### PR DESCRIPTION
Drop tags Arnis never reads (created_by, wiki*, addr:*, source*, name:*, tiger:*, NHD:*, regional import refs, etc.) when constructing ProcessedNode/Way/Relation. Audited against all tags.get/contains_key sites in src/ to confirm no read keys conflict.