### PR TITLE
Saturate Ground::slope subtraction

### DIFF
--- a/src/ground.rs
+++ b/src/ground.rs
@@ -221,7 +221,9 @@ impl Ground {
 
         let max_val = east.max(west).max(north).max(south);
         let min_val = east.min(west).min(north).min(south);
-        max_val - min_val
+        // Saturate: pathological CLI input (e.g. very negative ground_level)
+        // can push max - min past i32::MAX.
+        max_val.saturating_sub(min_val)
     }
 
     /// Returns the ground level at the given coordinates


### PR DESCRIPTION
`max_val - min_val` overflows when both come from `level()` returning values at the extremes of `[ground_level, upper_clamp]` — pathological CLI ground_level near i32::MIN can push the difference past i32::MAX and panic. Switch to saturating_sub; the slope consumers compare against small thresholds anyway, so saturating to i32::MAX is fine.