### PR TITLE
Extract CI Linux setup into a composite action

### DIFF
--- a/.github/actions/setup-arnis-linux/action.yml
+++ b/.github/actions/setup-arnis-linux/action.yml
@@ -1,0 +1,34 @@
+name: Set up Arnis Linux build environment
+description: Install Rust toolchain, optionally install GTK/WebKit GUI libs, restore cargo cache. Caller must check out the repo first.
+
+inputs:
+  rust-components:
+    description: Extra rustup components (e.g. "clippy,rustfmt")
+    required: false
+    default: ""
+  gui-deps:
+    description: Install GTK/WebKit system libs needed by the gui feature
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@v1
+      with:
+        toolchain: stable
+        components: ${{ inputs.rust-components }}
+
+    - name: Install Linux GUI dependencies
+      if: inputs.gui-deps == 'true'
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install -y software-properties-common
+        sudo add-apt-repository universe
+        echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+        sudo apt update
+        sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
+        echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
+
+    - uses: Swatinem/rust-cache@v2

--- a/.github/actions/setup-arnis-linux/action.yml
+++ b/.github/actions/setup-arnis-linux/action.yml
@@ -1,13 +1,21 @@
-name: Set up Arnis Linux build environment
-description: Install Rust toolchain, optionally install GTK/WebKit GUI libs, restore cargo cache. Caller must check out the repo first.
+name: Set up Arnis build environment
+description: Install Rust toolchain, optionally install GTK/WebKit GUI libs (Linux only), restore cargo cache. Caller must check out the repo first.
 
 inputs:
   rust-components:
     description: Extra rustup components (e.g. "clippy,rustfmt")
     required: false
     default: ""
+  rust-targets:
+    description: Extra rustup targets (e.g. "x86_64-pc-windows-msvc")
+    required: false
+    default: ""
   gui-deps:
-    description: Install GTK/WebKit system libs needed by the gui feature
+    description: Install GTK/WebKit system libs needed by the gui feature (Linux only)
+    required: false
+    default: "true"
+  cache:
+    description: Restore the Swatinem/rust-cache for cargo registry + target
     required: false
     default: "true"
 
@@ -18,9 +26,10 @@ runs:
       with:
         toolchain: stable
         components: ${{ inputs.rust-components }}
+        targets: ${{ inputs.rust-targets }}
 
     - name: Install Linux GUI dependencies
-      if: inputs.gui-deps == 'true'
+      if: runner.os == 'Linux' && inputs.gui-deps == 'true'
       shell: bash
       run: |
         sudo apt update
@@ -31,4 +40,5 @@ runs:
         sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
         echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
 
-    - uses: Swatinem/rust-cache@v2
+    - if: inputs.cache == 'true'
+      uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,58 +17,25 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-arnis-linux
+        with:
+          rust-components: clippy,rustfmt
 
-    - name: Set up Rust
-      uses: dtolnay/rust-toolchain@v1
-      with:
-        toolchain: stable
-        components: clippy, rustfmt
+      - name: Check formatting
+        run: cargo fmt -- --check
 
-    - name: Install Linux dependencies
-      run: |
-        sudo apt update
-        sudo apt install -y software-properties-common
-        sudo add-apt-repository universe
-        echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
-        sudo apt update
-        sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
-        echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
-
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Check formatting
-      run: cargo fmt -- --check
-
-    - name: Check clippy lints
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Check clippy lints
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-arnis-linux
 
-    - name: Set up Rust
-      uses: dtolnay/rust-toolchain@v1
-      with:
-        toolchain: stable
+      - name: Build (all targets, all features)
+        run: cargo build --all-targets --all-features --release
 
-    - name: Install Linux dependencies
-      run: |
-        sudo apt update
-        sudo apt install -y software-properties-common
-        sudo add-apt-repository universe
-        echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
-        sudo apt update
-        sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
-        echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
-
-    - uses: Swatinem/rust-cache@v2
-
-    - name: Build (all targets, all features)
-      run: cargo build --all-targets --all-features --release
-
-    - name: Run unit tests
-      run: cargo test --all-targets --all-features
+      - name: Run unit tests
+        run: cargo test --all-targets --all-features

--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -19,15 +19,10 @@ jobs:
        contains(github.event.comment.body, 'retrigger-benchmark'))
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@v1
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-arnis-linux
         with:
-          toolchain: stable
-
-      - uses: Swatinem/rust-cache@v2
+          gui-deps: "false"
 
       - name: Create dummy Minecraft world directory
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,25 +29,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
+    - uses: actions/checkout@v6
 
-    - name: Set up Rust
-      uses: dtolnay/rust-toolchain@v1
+    - uses: ./.github/actions/setup-arnis-linux
       with:
-        toolchain: stable
-        targets: ${{ matrix.target }}
-
-    - name: Install Linux dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt update
-        sudo apt install -y software-properties-common
-        sudo add-apt-repository universe
-        echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
-        sudo apt update
-        sudo apt install -y libgtk-3-dev build-essential pkg-config libglib2.0-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev
-        echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
+        rust-targets: ${{ matrix.target }}
+        # Cold rebuild for release reproducibility.
+        cache: "false"
 
     - name: Install dependencies
       run: cargo fetch

--- a/src/elevation/providers/fixed_tile.rs
+++ b/src/elevation/providers/fixed_tile.rs
@@ -61,10 +61,10 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::path::{Path, PathBuf};
 
-/// Pixels per tile edge. 512 matches the Tellus reference mod and the
-/// classic slippy-map conventions; small enough that a tile usually
-/// sits within a single LiDAR flight, large enough that total tile
-/// counts stay reasonable for city-scale bboxes.
+/// Pixels per tile edge. 512 matches classic slippy-map conventions;
+/// small enough that a tile usually sits within a single LiDAR flight,
+/// large enough that total tile counts stay reasonable for city-scale
+/// bboxes.
 pub(super) const TILE_PIXELS: usize = 512;
 
 /// Half-extent of the Web Mercator world in meters (EPSG:3857).

--- a/src/elevation/providers/usgs_3dep.rs
+++ b/src/elevation/providers/usgs_3dep.rs
@@ -8,8 +8,7 @@
 //! relative* sub-requests disagree at their boundaries by 10–500 m.
 //! Anchoring every request to a fixed global tile grid means two users
 //! over the same area hit the same tile URLs, the same cached bytes,
-//! and the same data — the way Tellus's `Usgs3depElevationSource` and
-//! the standard slippy-map pattern already do.
+//! and the same data — matching the standard slippy-map pattern.
 //!
 //! All the heavy lifting lives in [`super::fixed_tile`]; this module
 //! contributes the USGS-specific pieces:
@@ -26,9 +25,7 @@ use super::fixed_tile::{
 };
 
 /// USGS 3DEP's published zoom levels, each covering a fixed
-/// meters-per-pixel. The values match the Tellus reference
-/// implementation so disk-cache entries stay compatible across
-/// projects that happen to share a cache root.
+/// meters-per-pixel.
 // Visibility: `pub(super)` because the shared `FixedTileProvider` trait
 // (in `super::fixed_tile`) exposes this as its associated `Level` type —
 // anything `impl`ing a `pub(super)` trait has to keep that associated


### PR DESCRIPTION
Lint, build and benchmark workflows each duplicated the apt install block plus rust toolchain + cache setup. Moving them into .github/actions/setup-arnis-linux lets each caller invoke them with one line and a single source of truth for the GTK/WebKit deps.

The `gui-deps` input keeps the benchmark job's existing optimisation of skipping apt install when building with --no-default-features.