### PR TITLE
Feat/osm water and bridge shoreline

### DIFF
--- a/src/element_processing/bridge_styles.rs
+++ b/src/element_processing/bridge_styles.rs
@@ -402,9 +402,9 @@ fn place_arch_spandrel_cell(
     }
     for fy in arch_under_y..=fill_top {
         if use_absolute_y {
-            editor.set_block_absolute(STONE_BRICKS, set_x, fy, set_z, None, None);
+            editor.set_block_absolute(STONE_BRICKS, set_x, fy, set_z, None, Some(&[WATER]));
         } else {
-            editor.set_block(STONE_BRICKS, set_x, fy, set_z, None, None);
+            editor.set_block(STONE_BRICKS, set_x, fy, set_z, None, Some(&[WATER]));
         }
     }
 }

--- a/src/element_processing/bridges.rs
+++ b/src/element_processing/bridges.rs
@@ -560,7 +560,7 @@ impl BridgeSurfaceMap {
     }
 }
 
-fn is_bridge_way(way: &ProcessedWay) -> bool {
+pub(crate) fn is_bridge_way(way: &ProcessedWay) -> bool {
     if way.tags.get("indoor").map(|s| s.as_str()) == Some("yes") {
         return false;
     }

--- a/src/elevation/mod.rs
+++ b/src/elevation/mod.rs
@@ -177,26 +177,26 @@ pub fn fetch_elevation_data(
     // Safety net: fill any remaining NaN from tile gaps or partial provider coverage
     fill_nan_values(&mut height_grid);
 
-    // Land-cover-aware repair (targets urban LiDAR/DSM classification
-    // errors and coastal tile-boundary artifacts; leaves natural terrain
-    // untouched).
+    // Land-cover-aware repair: built-up Gaussian smoothing targets urban
+    // LiDAR/DSM classification errors, coastal pull-down flattens the
+    // shoreline cliff across all land classes.
     //
-    // Both scales are expressed in *meters* and converted to grid cells
-    // via the actual meters-per-cell for this bbox/grid, so the smoothing
-    // covers the same physical scale regardless of world size or provider
-    // resolution.
+    // Both scales are in meters and converted to grid cells via the actual
+    // meters-per-cell, so the smoothing covers the same physical scale
+    // regardless of world size or provider resolution.
     //
     // σ = 30 m for the built-up Gaussian: wide enough that a typical
     // 20 m-wide DSM artifact (tunnel portal, overpass, parking deck) is
-    // reduced to a residual the user can't distinguish from one Minecraft
-    // block. Hilly cities (SF, Pittsburgh) still keep their macro shape —
-    // the kernel falls off long before a real urban slope does. On coarse
+    // reduced to a residual indistinguishable from one Minecraft block.
+    // Hilly cities (SF, Pittsburgh) still keep their macro shape — the
+    // kernel falls off long before a real urban slope does. On coarse
     // providers (AWS fallback when σ < 1.5 cells) the Gaussian pass is
     // skipped internally.
     //
-    // 25 m coastal pull range: reaches far enough to cover DSM-captured
-    // piers/warehouses at the shoreline, short enough to leave the actual
-    // inland city alone.
+    // 25 m coastal pull range: short enough to leave the inland interior
+    // alone, long enough that a 7-10 m urban embankment (Munich Isar,
+    // Vienna Donaukanal) becomes a slope-tier-free ramp instead of a
+    // cliff with stepped stone walls.
     const BUILT_UP_SIGMA_M: f64 = 30.0;
     const COASTAL_PULL_M: f64 = 25.0;
     let (bbox_height_m, bbox_width_m) = geo_distance(bbox.min(), bbox.max());

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -198,20 +198,17 @@ pub fn apply_land_cover_repair(
         land_cover.refresh_water_blend_grid();
     }
 
-    if coastal_pull_distance_cells > 0 {
-        pull_coastal_builtup_toward_water(
-            heights,
-            &land_cover.grid,
-            &is_water_surface,
-            coastal_pull_distance_cells,
-        );
-    }
+    // Smooth must run before the pull — otherwise the Gaussian blends pulled
+    // cells back up toward surrounding city built-up.
     smooth_built_up_gaussian(
         heights,
         &land_cover.grid,
         &is_water_surface,
         built_up_sigma_cells,
     );
+    if coastal_pull_distance_cells > 0 {
+        pull_coastal_land_toward_water(heights, &is_water_surface, coastal_pull_distance_cells);
+    }
 }
 
 /// Flatten the water surface of each connected `LC_WATER` component and
@@ -726,28 +723,11 @@ fn reclassify_non_surface_water_cells(
     n
 }
 
-/// Pull built-up cells near water down toward the local water surface.
-///
-/// DSMs (AWS Terrain Tiles, Copernicus DSM, SRTM) include buildings and
-/// waterfront structures in the elevation. In Minecraft that appears as a
-/// flat strip of "city" sitting ~10–30 m above the water it's right next to
-/// — a cliff at the shoreline. A plain Gaussian blur can't fix this
-/// cleanly: with water included in the source it creates a broad ramp
-/// instead of a cliff; with water excluded it keeps the cliff.
-///
-/// This pass walks outward from every water cell (4-connected multi-source
-/// BFS bounded at `max_distance`) and, for each built-up cell inside that
-/// distance, lerps its elevation toward the nearest water cell's surface
-/// level with a **linear distance falloff**:
-///
-///     weight = (max_distance − distance) / max_distance
-///     new    = (1 − weight) · original + weight · water_level
-///
-/// Net effect: a controlled, known-width ramp from water up to the city
-/// interior that replaces the uncontrolled Gaussian-induced ramp.
-fn pull_coastal_builtup_toward_water(
+/// Linearly pull every land cell within `max_distance` of a water-surface
+/// cell toward that surface, except cells sitting more than
+/// `MAX_PULL_DROP_M` above local water (preserved as real cliffs).
+fn pull_coastal_land_toward_water(
     heights: &mut [Vec<f64>],
-    lc_grid: &[Vec<u8>],
     is_water_surface: &[Vec<bool>],
     max_distance: u32,
 ) {
@@ -756,6 +736,9 @@ fn pull_coastal_builtup_toward_water(
     }
     let h = heights.len();
     let w = heights[0].len();
+
+    // Cells above this threshold are treated as real cliffs and not pulled.
+    const MAX_PULL_DROP_M: f64 = 15.0;
 
     // Multi-source BFS: seed with confirmed water-surface cells (not just
     // LC_WATER, so a canyon-wall cell misclassified as water doesn't
@@ -769,9 +752,6 @@ fn pull_coastal_builtup_toward_water(
         for x in 0..w {
             if is_water_surface[y][x] {
                 dist[y][x] = 0;
-                // Heights at water-surface cells have been flattened to the
-                // component water level, so this is the target we pull
-                // coastal built-up cells toward.
                 water_level[y][x] = heights[y][x];
                 queue.push_back((x, y));
             }
@@ -800,14 +780,11 @@ fn pull_coastal_builtup_toward_water(
         }
     }
 
-    // Apply the linear pull-down to built-up cells in range.
     let mut affected = 0usize;
+    let mut skipped_cliff = 0usize;
     let denom = max_distance as f64;
     for y in 0..h {
         for x in 0..w {
-            if lc_grid[y][x] != LC_BUILT_UP {
-                continue;
-            }
             let d = dist[y][x];
             if d == 0 || d > max_distance {
                 continue;
@@ -817,18 +794,20 @@ fn pull_coastal_builtup_toward_water(
             if !wl.is_finite() || !orig.is_finite() {
                 continue;
             }
-            // Linear falloff: weight ≈ 1 at d=1 (right next to water),
-            // weight → 0 as d → max_distance.
+            if orig - wl > MAX_PULL_DROP_M {
+                skipped_cliff += 1;
+                continue;
+            }
             let weight = ((max_distance - d) as f64 / denom).clamp(0.0, 1.0);
             heights[y][x] = orig * (1.0 - weight) + wl * weight;
             affected += 1;
         }
     }
 
-    if affected > 0 {
+    if affected > 0 || skipped_cliff > 0 {
         eprintln!(
-            "Land cover repair: pulled {} coastal built-up cells toward water (within {} cells)",
-            affected, max_distance
+            "Land cover repair: pulled {} coastal land cells toward water (within {} cells); kept {} cells above {} m as real cliffs",
+            affected, max_distance, skipped_cliff, MAX_PULL_DROP_M
         );
     }
 }

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -198,8 +198,7 @@ pub fn apply_land_cover_repair(
         land_cover.refresh_water_blend_grid();
     }
 
-    // Smooth must run before the pull — otherwise the Gaussian blends pulled
-    // cells back up toward surrounding city built-up.
+    // Smooth before pull; otherwise the Gaussian raises pulled cells back up.
     smooth_built_up_gaussian(
         heights,
         &land_cover.grid,
@@ -723,9 +722,7 @@ fn reclassify_non_surface_water_cells(
     n
 }
 
-/// Linearly pull every land cell within `max_distance` of a water-surface
-/// cell toward that surface, except cells sitting more than
-/// `MAX_PULL_DROP_M` above local water (preserved as real cliffs).
+// Linearly pull land cells within max_distance toward the local water surface; skip > MAX_PULL_DROP_M above water (real cliffs).
 fn pull_coastal_land_toward_water(
     heights: &mut [Vec<f64>],
     is_water_surface: &[Vec<bool>],

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -1,8 +1,12 @@
 use crate::args::Args;
-use crate::coordinate_system::{cartesian::XZPoint, geographic::LLBBox};
+use crate::coordinate_system::{
+    cartesian::{XZBBox, XZPoint},
+    geographic::LLBBox,
+};
 use crate::elevation::compute_grid_dims;
 use crate::elevation_data::{fetch_elevation_data, ElevationData};
 use crate::land_cover::{self, LandCoverData};
+use crate::osm_parser::ProcessedElement;
 use crate::progress::emit_gui_progress_update;
 #[cfg(feature = "gui")]
 use crate::telemetry::{send_log, LogLevel};
@@ -118,6 +122,46 @@ impl Ground {
     #[inline(always)]
     pub fn has_land_cover(&self) -> bool {
         self.land_cover.is_some()
+    }
+
+    /// Force LC_WATER for every cell inside an OSM water polygon or waterway.
+    pub fn apply_osm_water_override(&mut self, elements: &[ProcessedElement], xzbbox: &XZBBox) {
+        let Some(lc) = self.land_cover.as_mut() else {
+            return;
+        };
+        let Some(data) = self.elevation_data.as_ref() else {
+            return;
+        };
+        crate::land_cover_osm_water_override::apply_osm_water_override(
+            lc,
+            data.world_width,
+            data.world_height,
+            elements,
+            xzbbox,
+        );
+    }
+
+    /// Reclassify cells under OSM-tagged bridges to the surrounding class.
+    pub fn apply_bridge_land_cover_repair(
+        &mut self,
+        elements: &[ProcessedElement],
+        xzbbox: &XZBBox,
+        scale: f64,
+    ) {
+        let Some(lc) = self.land_cover.as_mut() else {
+            return;
+        };
+        let Some(data) = self.elevation_data.as_ref() else {
+            return;
+        };
+        crate::land_cover_bridge_repair::apply_bridge_land_cover_repair(
+            lc,
+            data.world_width,
+            data.world_height,
+            elements,
+            xzbbox,
+            scale,
+        );
     }
 
     /// Returns the ESA WorldCover land cover class at the given coordinates.
@@ -399,6 +443,44 @@ impl Ground {
             && orig_z <= mask.orig_max_z as f64 + EPSILON
     }
 
+    pub fn save_land_cover_debug_image(&self, filename: &str) {
+        let Some(ref lc) = self.land_cover else {
+            return;
+        };
+        if lc.height == 0 || lc.width == 0 {
+            return;
+        }
+        let mut img: image::ImageBuffer<Rgb<u8>, Vec<u8>> =
+            RgbImage::new(lc.width as u32, lc.height as u32);
+        for (y, row) in lc.grid.iter().enumerate() {
+            for (x, &class) in row.iter().enumerate() {
+                let color = match class {
+                    land_cover::LC_TREE_COVER => Rgb([0x00, 0x6e, 0x00]),
+                    land_cover::LC_SHRUBLAND => Rgb([0xff, 0xbb, 0x22]),
+                    land_cover::LC_GRASSLAND => Rgb([0xff, 0xff, 0x4c]),
+                    land_cover::LC_CROPLAND => Rgb([0xf0, 0x96, 0xff]),
+                    land_cover::LC_BUILT_UP => Rgb([0xfa, 0x00, 0x00]),
+                    land_cover::LC_BARE => Rgb([0xb4, 0xb4, 0xb4]),
+                    land_cover::LC_SNOW_ICE => Rgb([0xf0, 0xf0, 0xf0]),
+                    land_cover::LC_WATER => Rgb([0x00, 0x64, 0xc8]),
+                    land_cover::LC_WETLAND => Rgb([0x00, 0x96, 0xa0]),
+                    land_cover::LC_MANGROVES => Rgb([0x00, 0xcf, 0x75]),
+                    land_cover::LC_MOSS => Rgb([0xfa, 0xe6, 0xa0]),
+                    _ => Rgb([0x00, 0x00, 0x00]),
+                };
+                img.put_pixel(x as u32, y as u32, color);
+            }
+        }
+        let filename: String = if !filename.ends_with(".png") {
+            format!("{filename}.png")
+        } else {
+            filename.to_string()
+        };
+        if let Err(e) = img.save(&filename) {
+            eprintln!("Failed to save land cover debug image: {e}");
+        }
+    }
+
     fn save_debug_image(&self, filename: &str) {
         let heights = &self
             .elevation_data
@@ -470,6 +552,7 @@ pub fn generate_ground_data(args: &Args) -> Ground {
         );
         if args.debug {
             ground.save_debug_image("elevation_debug");
+            ground.save_land_cover_debug_image("landcover_debug");
         }
         return ground;
     }

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -134,6 +134,7 @@ impl Ground {
         };
         crate::land_cover_osm_water_override::apply_osm_water_override(
             lc,
+            &data.heights,
             data.world_width,
             data.world_height,
             elements,

--- a/src/ground_generation.rs
+++ b/src/ground_generation.rs
@@ -535,30 +535,27 @@ pub fn generate_ground_layer(
                             let (surface_block, under_block) = if surface_block != WATER
                                 && slope <= 3
                             {
-                                // Transition-zone blocks that noise decided are "not
-                                // water" get sand via water_blend > 0.01 (at least one
-                                // surrounding grid cell is water).  For blocks fully
-                                // outside the blend zone, fall back to neighbor check.
+                                // Sand only at the immediate 1-cell ring around LC_WATER
+                                // (plus near_placed_water below for OSM-rendered water).
                                 let near_esa_water = has_land_cover
                                     && !is_esa_water
-                                    && (water_blend > 0.01
-                                        || [
-                                            (-1i32, 0i32),
-                                            (1, 0),
-                                            (0, -1),
-                                            (0, 1),
-                                            (-1, -1),
-                                            (-1, 1),
-                                            (1, -1),
-                                            (1, 1),
-                                        ]
-                                        .iter()
-                                        .any(|(dx, dz)| {
-                                            ground.cover_class(XZPoint::new(
-                                                x + dx - xzbbox.min_x(),
-                                                z + dz - xzbbox.min_z(),
-                                            )) == land_cover::LC_WATER
-                                        }));
+                                    && [
+                                        (-1i32, 0i32),
+                                        (1, 0),
+                                        (0, -1),
+                                        (0, 1),
+                                        (-1, -1),
+                                        (-1, 1),
+                                        (1, -1),
+                                        (1, 1),
+                                    ]
+                                    .iter()
+                                    .any(|(dx, dz)| {
+                                        ground.cover_class(XZPoint::new(
+                                            x + dx - xzbbox.min_x(),
+                                            z + dz - xzbbox.min_z(),
+                                        )) == land_cover::LC_WATER
+                                    });
 
                                 // Also check placed water blocks (OSM rivers, etc.)
                                 let near_placed_water = [(-1i32, 0i32), (1, 0), (0, -1), (0, 1)]

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1110,6 +1110,10 @@ fn gui_start_generation(
 
                     let mut ground = ground::generate_ground_data(&args);
 
+                    // OSM water override first, then bridge repair.
+                    ground.apply_osm_water_override(&parsed_elements, &xzbbox);
+                    ground.apply_bridge_land_cover_repair(&parsed_elements, &xzbbox, args.scale);
+
                     // Transform map (parsed_elements). Operations are defined in a json file
                     map_transformation::transform_map(
                         &mut parsed_elements,

--- a/src/land_cover_bridge_repair.rs
+++ b/src/land_cover_bridge_repair.rs
@@ -1,0 +1,289 @@
+//! Reclassify ESA built-up cells under OSM bridges to the nearest non-bridge
+//! class via BFS, preferring water so river-bridge footprints become LC_WATER.
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, VecDeque};
+
+use crate::bresenham::bresenham_line;
+use crate::coordinate_system::cartesian::XZBBox;
+use crate::element_processing::bridges::is_bridge_way;
+use crate::element_processing::highways::highway_block_range;
+use crate::land_cover::{compute_water_distance, LandCoverData, LC_BUILT_UP, LC_WATER};
+use crate::osm_parser::{ProcessedElement, ProcessedWay};
+
+const MAX_BFS_RINGS: usize = 64;
+const DEFAULT_RAIL_HALF_WIDTH: i32 = 1;
+const DEFAULT_GENERIC_HALF_WIDTH: i32 = 1;
+// Margin past `highway_block_range` so the stamp covers the full ESA bridge
+// shadow (deck + parapets), not just the OSM lane centreline.
+const BRIDGE_STAMP_MARGIN_CELLS: i32 = 8;
+const NEIGHBOURS: [(i32, i32); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
+
+pub fn apply_bridge_land_cover_repair(
+    land_cover: &mut LandCoverData,
+    world_width: usize,
+    world_height: usize,
+    elements: &[ProcessedElement],
+    xzbbox: &XZBBox,
+    scale: f64,
+) {
+    let width = land_cover.width;
+    let height = land_cover.height;
+    if width < 2 || height < 2 || world_width < 2 || world_height < 2 {
+        return;
+    }
+    if !elements
+        .iter()
+        .any(|e| matches!(e, ProcessedElement::Way(w) if is_bridge_way(w)))
+    {
+        return;
+    }
+
+    let scale_to_grid_x = (width as f64 - 1.0) / (world_width as f64 - 1.0);
+    let scale_to_grid_z = (height as f64 - 1.0) / (world_height as f64 - 1.0);
+    let min_x = xzbbox.min_x();
+    let min_z = xzbbox.min_z();
+
+    let n = width * height;
+    let mut bridge_mask: Vec<u64> = vec![0; n.div_ceil(64)];
+    let mut bridge_indices: Vec<u32> = Vec::new();
+
+    for elem in elements {
+        let ProcessedElement::Way(way) = elem else {
+            continue;
+        };
+        if !is_bridge_way(way) || way.nodes.len() < 2 {
+            continue;
+        }
+
+        let block_range_world = bridge_block_range_world(way, scale) + BRIDGE_STAMP_MARGIN_CELLS;
+        let range_x = ((block_range_world as f64 * scale_to_grid_x).ceil() as i32).max(1);
+        let range_z = ((block_range_world as f64 * scale_to_grid_z).ceil() as i32).max(1);
+
+        let mut prev: Option<(i32, i32)> = None;
+        for node in &way.nodes {
+            let curr = world_to_grid(
+                node.x - min_x,
+                node.z - min_z,
+                scale_to_grid_x,
+                scale_to_grid_z,
+            );
+            if let Some((px, pz)) = prev {
+                for (gx, _, gz) in bresenham_line(px, 0, pz, curr.0, 0, curr.1) {
+                    stamp_square(
+                        &mut bridge_mask,
+                        &mut bridge_indices,
+                        &land_cover.grid,
+                        gx,
+                        gz,
+                        range_x,
+                        range_z,
+                        width,
+                        height,
+                    );
+                }
+            }
+            prev = Some(curr);
+        }
+    }
+
+    if bridge_indices.is_empty() {
+        return;
+    }
+
+    let width_i32 = width as i32;
+    let height_i32 = height as i32;
+
+    let mut assigned: HashMap<u32, u8> = HashMap::with_capacity(bridge_indices.len());
+    let mut current: VecDeque<(u32, u8)> = VecDeque::new();
+    // Pass 1: seed water-adjacent bridge cells first so water propagates
+    // ahead of any other class through the BFS queue.
+    for &b_idx in &bridge_indices {
+        let bi = b_idx as usize;
+        let x = (bi % width) as i32;
+        let z = (bi / width) as i32;
+        for (dx, dz) in NEIGHBOURS {
+            let nx = x + dx;
+            let nz = z + dz;
+            if nx < 0 || nz < 0 || nx >= width_i32 || nz >= height_i32 {
+                continue;
+            }
+            let nidx = nz as usize * width + nx as usize;
+            if get_bit(&bridge_mask, nidx) {
+                continue;
+            }
+            if land_cover.grid[nz as usize][nx as usize] == LC_WATER {
+                assigned.insert(b_idx, LC_WATER);
+                current.push_back((b_idx, LC_WATER));
+                break;
+            }
+        }
+    }
+    // Pass 2: fall back to the first non-water non-bridge neighbour.
+    for &b_idx in &bridge_indices {
+        if assigned.contains_key(&b_idx) {
+            continue;
+        }
+        let bi = b_idx as usize;
+        let x = (bi % width) as i32;
+        let z = (bi / width) as i32;
+        for (dx, dz) in NEIGHBOURS {
+            let nx = x + dx;
+            let nz = z + dz;
+            if nx < 0 || nz < 0 || nx >= width_i32 || nz >= height_i32 {
+                continue;
+            }
+            let nidx = nz as usize * width + nx as usize;
+            if get_bit(&bridge_mask, nidx) {
+                continue;
+            }
+            let cls = land_cover.grid[nz as usize][nx as usize];
+            if cls == 0 || cls == LC_WATER {
+                continue;
+            }
+            assigned.insert(b_idx, cls);
+            current.push_back((b_idx, cls));
+            break;
+        }
+    }
+
+    let mut next: VecDeque<(u32, u8)> = VecDeque::new();
+    let mut depth = 1usize;
+    while !current.is_empty() && depth < MAX_BFS_RINGS {
+        while let Some((idx, cls)) = current.pop_front() {
+            let bi = idx as usize;
+            let x = (bi % width) as i32;
+            let z = (bi / width) as i32;
+            for (dx, dz) in NEIGHBOURS {
+                let nx = x + dx;
+                let nz = z + dz;
+                if nx < 0 || nz < 0 || nx >= width_i32 || nz >= height_i32 {
+                    continue;
+                }
+                let nidx_usize = nz as usize * width + nx as usize;
+                if !get_bit(&bridge_mask, nidx_usize) {
+                    continue;
+                }
+                let nidx = nidx_usize as u32;
+                if let Entry::Vacant(e) = assigned.entry(nidx) {
+                    e.insert(cls);
+                    next.push_back((nidx, cls));
+                }
+            }
+        }
+        std::mem::swap(&mut current, &mut next);
+        depth += 1;
+    }
+
+    let mut water_changed = false;
+    for &b_idx in &bridge_indices {
+        let Some(&new_class) = assigned.get(&b_idx) else {
+            continue;
+        };
+        let bi = b_idx as usize;
+        let x = bi % width;
+        let z = bi / width;
+        let old_class = land_cover.grid[z][x];
+        if new_class == old_class {
+            continue;
+        }
+        land_cover.grid[z][x] = new_class;
+        if (old_class == LC_WATER) != (new_class == LC_WATER) {
+            water_changed = true;
+        }
+    }
+
+    let to_water = bridge_indices
+        .iter()
+        .filter(|&&b| {
+            let bi = b as usize;
+            assigned.contains_key(&b) && land_cover.grid[bi / width][bi % width] == LC_WATER
+        })
+        .count();
+    eprintln!(
+        "Bridge LC repair: {} cells reclassified ({} to water)",
+        bridge_indices.len(),
+        to_water,
+    );
+
+    if water_changed {
+        land_cover.water_distance = compute_water_distance(&land_cover.grid, width, height);
+        land_cover.refresh_water_blend_grid();
+    }
+}
+
+fn bridge_block_range_world(way: &ProcessedWay, scale: f64) -> i32 {
+    if let Some(highway_type) = way.tags.get("highway") {
+        return highway_block_range(highway_type, &way.tags, scale);
+    }
+    if way.tags.contains_key("railway") {
+        let tracks = way
+            .tags
+            .get("tracks")
+            .and_then(|v| v.parse::<i32>().ok())
+            .unwrap_or(1)
+            .max(1);
+        let raw = DEFAULT_RAIL_HALF_WIDTH + (tracks - 1).max(0);
+        return scaled_block_range(raw, scale);
+    }
+    scaled_block_range(DEFAULT_GENERIC_HALF_WIDTH, scale)
+}
+
+fn scaled_block_range(raw: i32, scale: f64) -> i32 {
+    if scale < 1.0 {
+        (((raw as f64) * scale).floor() as i32).max(1)
+    } else {
+        raw
+    }
+}
+
+fn world_to_grid(rel_x: i32, rel_z: i32, scale_x: f64, scale_z: f64) -> (i32, i32) {
+    let gx = (rel_x.max(0) as f64 * scale_x).round() as i32;
+    let gz = (rel_z.max(0) as f64 * scale_z).round() as i32;
+    (gx, gz)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn stamp_square(
+    mask: &mut [u64],
+    bridge_indices: &mut Vec<u32>,
+    grid: &[Vec<u8>],
+    cx: i32,
+    cz: i32,
+    range_x: i32,
+    range_z: i32,
+    width: usize,
+    height: usize,
+) {
+    let width_i32 = width as i32;
+    let height_i32 = height as i32;
+    let lo_x = (cx - range_x).max(0);
+    let hi_x = (cx + range_x).min(width_i32 - 1);
+    let lo_z = (cz - range_z).max(0);
+    let hi_z = (cz + range_z).min(height_i32 - 1);
+    if lo_x > hi_x || lo_z > hi_z {
+        return;
+    }
+    for z in lo_z..=hi_z {
+        let zu = z as usize;
+        let row_start = zu * width;
+        for x in lo_x..=hi_x {
+            // Only stamp built-up cells so genuine water/forest cells caught
+            // by the stamp margin keep their class.
+            if grid[zu][x as usize] != LC_BUILT_UP {
+                continue;
+            }
+            let idx = row_start + x as usize;
+            let word = idx >> 6;
+            let bit_mask = 1u64 << (idx & 63);
+            if (mask[word] & bit_mask) == 0 {
+                mask[word] |= bit_mask;
+                bridge_indices.push(idx as u32);
+            }
+        }
+    }
+}
+
+#[inline(always)]
+fn get_bit(mask: &[u64], idx: usize) -> bool {
+    (mask[idx >> 6] >> (idx & 63)) & 1 != 0
+}

--- a/src/land_cover_bridge_repair.rs
+++ b/src/land_cover_bridge_repair.rs
@@ -173,6 +173,8 @@ pub fn apply_bridge_land_cover_repair(
     }
 
     let mut water_changed = false;
+    let mut mutated = 0usize;
+    let mut to_water = 0usize;
     for &b_idx in &bridge_indices {
         let Some(&new_class) = assigned.get(&b_idx) else {
             continue;
@@ -185,22 +187,18 @@ pub fn apply_bridge_land_cover_repair(
             continue;
         }
         land_cover.grid[z][x] = new_class;
+        mutated += 1;
+        if new_class == LC_WATER {
+            to_water += 1;
+        }
         if (old_class == LC_WATER) != (new_class == LC_WATER) {
             water_changed = true;
         }
     }
 
-    let to_water = bridge_indices
-        .iter()
-        .filter(|&&b| {
-            let bi = b as usize;
-            assigned.contains_key(&b) && land_cover.grid[bi / width][bi % width] == LC_WATER
-        })
-        .count();
     eprintln!(
         "Bridge LC repair: {} cells reclassified ({} to water)",
-        bridge_indices.len(),
-        to_water,
+        mutated, to_water,
     );
 
     if water_changed {

--- a/src/land_cover_bridge_repair.rs
+++ b/src/land_cover_bridge_repair.rs
@@ -13,8 +13,7 @@ use crate::osm_parser::{ProcessedElement, ProcessedWay};
 const MAX_BFS_RINGS: usize = 64;
 const DEFAULT_RAIL_HALF_WIDTH: i32 = 1;
 const DEFAULT_GENERIC_HALF_WIDTH: i32 = 1;
-// Margin past `highway_block_range` so the stamp covers the full ESA bridge
-// shadow (deck + parapets), not just the OSM lane centreline.
+// Margin past highway_block_range to cover deck + parapets, not just the lane centreline.
 const BRIDGE_STAMP_MARGIN_CELLS: i32 = 8;
 const NEIGHBOURS: [(i32, i32); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
 
@@ -95,8 +94,7 @@ pub fn apply_bridge_land_cover_repair(
 
     let mut assigned: HashMap<u32, u8> = HashMap::with_capacity(bridge_indices.len());
     let mut current: VecDeque<(u32, u8)> = VecDeque::new();
-    // Pass 1: seed water-adjacent bridge cells first so water propagates
-    // ahead of any other class through the BFS queue.
+    // Pass 1: seed water-adjacent bridge cells first so water propagates first.
     for &b_idx in &bridge_indices {
         let bi = b_idx as usize;
         let x = (bi % width) as i32;
@@ -267,8 +265,7 @@ fn stamp_square(
         let zu = z as usize;
         let row_start = zu * width;
         for x in lo_x..=hi_x {
-            // Only stamp built-up cells so genuine water/forest cells caught
-            // by the stamp margin keep their class.
+            // Only stamp built-up cells; the margin must not clobber real water/forest.
             if grid[zu][x as usize] != LC_BUILT_UP {
                 continue;
             }

--- a/src/land_cover_osm_water_override.rs
+++ b/src/land_cover_osm_water_override.rs
@@ -1,6 +1,6 @@
 //! Force LC_WATER inside OSM water polygons and waterways so OSM defines
 //! the shoreline, overriding ESA's noisy 10 m classification.
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use crate::bresenham::bresenham_line;
 use crate::coordinate_system::cartesian::XZBBox;
@@ -9,8 +9,22 @@ use crate::osm_parser::{
     ProcessedElement, ProcessedMemberRole, ProcessedNode, ProcessedRelation, ProcessedWay,
 };
 
+const ELEVATION_TOLERANCE_BLOCKS: f32 = 1.5;
+// Min area for a non-water component to count as a real land mass.
+const PROTECTED_LAND_AREA_M2: f64 = 4000.0;
+const MIN_PROTECTED_LAND_CELLS: usize = 100;
+// Aspect ratio above which a component is treated as bridge-like (not protected).
+const LINEAR_ASPECT_RATIO: f64 = 3.0;
+
+struct WaterContext {
+    nearest_y: Vec<Vec<f32>>,
+    protected_mask: Vec<u64>,
+    width: usize,
+}
+
 pub fn apply_osm_water_override(
     land_cover: &mut LandCoverData,
+    heights: &[Vec<f32>],
     world_width: usize,
     world_height: usize,
     elements: &[ProcessedElement],
@@ -28,6 +42,15 @@ pub fn apply_osm_water_override(
     let max_x = xzbbox.max_x();
     let max_z = xzbbox.max_z();
 
+    let context = build_water_context(
+        &land_cover.grid,
+        heights,
+        width,
+        height,
+        scale_to_grid_x,
+        scale_to_grid_z,
+    );
+
     let mut changed: usize = 0;
     for elem in elements {
         match elem {
@@ -38,6 +61,8 @@ pub fn apply_osm_water_override(
                         &mut land_cover.grid,
                         &[outer.as_slice()],
                         &[],
+                        heights,
+                        context.as_ref(),
                         min_x,
                         min_z,
                         max_x,
@@ -54,6 +79,8 @@ pub fn apply_osm_water_override(
                         &mut land_cover.grid,
                         &way.nodes,
                         half_width,
+                        heights,
+                        context.as_ref(),
                         min_x,
                         min_z,
                         max_x,
@@ -92,6 +119,8 @@ pub fn apply_osm_water_override(
                     &mut land_cover.grid,
                     &outers_refs,
                     &inners_refs,
+                    heights,
+                    context.as_ref(),
                     min_x,
                     min_z,
                     max_x,
@@ -160,6 +189,8 @@ fn fill_polygon_scanline(
     grid: &mut [Vec<u8>],
     outers: &[&[(i32, i32)]],
     inners: &[&[(i32, i32)]],
+    heights: &[Vec<f32>],
+    context: Option<&WaterContext>,
     min_x_world: i32,
     min_z_world: i32,
     max_x_world: i32,
@@ -258,6 +289,9 @@ fn fill_polygon_scanline(
                         continue;
                     }
                 }
+                if !passes_water_guard(heights, context, gx, gz) {
+                    continue;
+                }
                 if row[gx] != LC_WATER {
                     row[gx] = LC_WATER;
                     count += 1;
@@ -303,6 +337,8 @@ fn rasterize_line(
     grid: &mut [Vec<u8>],
     nodes: &[ProcessedNode],
     half_width: i32,
+    heights: &[Vec<f32>],
+    context: Option<&WaterContext>,
     min_x_world: i32,
     min_z_world: i32,
     max_x_world: i32,
@@ -351,6 +387,9 @@ fn rasterize_line(
                     }
                     let gx_u = gx as usize;
                     let gz_u = gz as usize;
+                    if !passes_water_guard(heights, context, gx_u, gz_u) {
+                        continue;
+                    }
                     if grid[gz_u][gx_u] != LC_WATER {
                         grid[gz_u][gx_u] = LC_WATER;
                         count += 1;
@@ -360,4 +399,222 @@ fn rasterize_line(
         }
     }
     count
+}
+
+// Returns None when there are no ESA water cells, disabling the guard.
+fn build_water_context(
+    grid: &[Vec<u8>],
+    heights: &[Vec<f32>],
+    width: usize,
+    height: usize,
+    scale_to_grid_x: f64,
+    scale_to_grid_z: f64,
+) -> Option<WaterContext> {
+    if width < 2 || height < 2 {
+        return None;
+    }
+    if heights.len() < height || heights.first().map_or(0, |r| r.len()) < width {
+        return None;
+    }
+    if grid.len() < height || grid.first().map_or(0, |r| r.len()) < width {
+        return None;
+    }
+    let has_seeds = grid
+        .iter()
+        .take(height)
+        .any(|row| row.iter().take(width).any(|&c| c == LC_WATER));
+    if !has_seeds {
+        return None;
+    }
+
+    let cells_per_meter_sq = scale_to_grid_x * scale_to_grid_z;
+    let raw = (PROTECTED_LAND_AREA_M2 * cells_per_meter_sq).round() as usize;
+    let small_threshold_cells = raw.max(MIN_PROTECTED_LAND_CELLS);
+
+    let protected_mask = build_protected_land_bitset(
+        grid,
+        width,
+        height,
+        small_threshold_cells,
+        LINEAR_ASPECT_RATIO,
+    );
+    let nearest_y = compute_nearest_water_y(grid, heights, width, height);
+
+    Some(WaterContext {
+        nearest_y,
+        protected_mask,
+        width,
+    })
+}
+
+// Marks cells in 4-connected non-water components that are large AND compact.
+fn build_protected_land_bitset(
+    grid: &[Vec<u8>],
+    width: usize,
+    height: usize,
+    small_threshold_cells: usize,
+    linear_aspect_ratio: f64,
+) -> Vec<u64> {
+    let n = width * height;
+    let mut visited: Vec<u64> = vec![0; n.div_ceil(64)];
+    let mut protected: Vec<u64> = vec![0; n.div_ceil(64)];
+    let mut stack: Vec<u32> = Vec::new();
+    let mut component_cells: Vec<u32> = Vec::new();
+    let width_i32 = width as i32;
+    let height_i32 = height as i32;
+
+    for start_z in 0..height {
+        for start_x in 0..width {
+            if grid[start_z][start_x] == LC_WATER {
+                continue;
+            }
+            let start_idx = start_z * width + start_x;
+            if get_bit(&visited, start_idx) {
+                continue;
+            }
+
+            component_cells.clear();
+            stack.clear();
+            stack.push(start_idx as u32);
+            set_bit(&mut visited, start_idx);
+
+            let mut min_x = start_x;
+            let mut max_x = start_x;
+            let mut min_z = start_z;
+            let mut max_z = start_z;
+
+            while let Some(curr) = stack.pop() {
+                let curr_u = curr as usize;
+                let cx = (curr_u % width) as i32;
+                let cz = (curr_u / width) as i32;
+                component_cells.push(curr);
+                let cxu = cx as usize;
+                let czu = cz as usize;
+                if cxu < min_x {
+                    min_x = cxu;
+                }
+                if cxu > max_x {
+                    max_x = cxu;
+                }
+                if czu < min_z {
+                    min_z = czu;
+                }
+                if czu > max_z {
+                    max_z = czu;
+                }
+                for (dx, dz) in [(-1i32, 0i32), (1, 0), (0, -1), (0, 1)] {
+                    let nx = cx + dx;
+                    let nz = cz + dz;
+                    if nx < 0 || nz < 0 || nx >= width_i32 || nz >= height_i32 {
+                        continue;
+                    }
+                    let nxu = nx as usize;
+                    let nzu = nz as usize;
+                    if grid[nzu][nxu] == LC_WATER {
+                        continue;
+                    }
+                    let n_idx = nzu * width + nxu;
+                    if get_bit(&visited, n_idx) {
+                        continue;
+                    }
+                    set_bit(&mut visited, n_idx);
+                    stack.push(n_idx as u32);
+                }
+            }
+
+            let bbox_w = max_x - min_x + 1;
+            let bbox_h = max_z - min_z + 1;
+            let long_axis = bbox_w.max(bbox_h);
+            let short_axis = bbox_w.min(bbox_h).max(1);
+            let aspect = long_axis as f64 / short_axis as f64;
+            let is_compact = aspect <= linear_aspect_ratio;
+            let is_large = component_cells.len() >= small_threshold_cells;
+
+            if is_large && is_compact {
+                for &c in &component_cells {
+                    set_bit(&mut protected, c as usize);
+                }
+            }
+        }
+    }
+
+    protected
+}
+
+// Multi-source BFS: each cell gets the terrain Y of its nearest LC_WATER seed.
+fn compute_nearest_water_y(
+    grid: &[Vec<u8>],
+    heights: &[Vec<f32>],
+    width: usize,
+    height: usize,
+) -> Vec<Vec<f32>> {
+    let mut result: Vec<Vec<f32>> = vec![vec![f32::NAN; width]; height];
+    let mut queue: VecDeque<(u32, u32)> = VecDeque::new();
+    for z in 0..height {
+        let row = &grid[z];
+        let h_row = &heights[z];
+        for x in 0..width {
+            if row[x] == LC_WATER {
+                let h = h_row[x];
+                if h.is_finite() {
+                    result[z][x] = h;
+                    queue.push_back((x as u32, z as u32));
+                }
+            }
+        }
+    }
+    if queue.is_empty() {
+        return result;
+    }
+    let width_i32 = width as i32;
+    let height_i32 = height as i32;
+    while let Some((x, z)) = queue.pop_front() {
+        let cell_y = result[z as usize][x as usize];
+        for (dx, dz) in [(-1i32, 0i32), (1, 0), (0, -1), (0, 1)] {
+            let nx = x as i32 + dx;
+            let nz = z as i32 + dz;
+            if nx < 0 || nz < 0 || nx >= width_i32 || nz >= height_i32 {
+                continue;
+            }
+            let nxu = nx as usize;
+            let nzu = nz as usize;
+            if result[nzu][nxu].is_nan() {
+                result[nzu][nxu] = cell_y;
+                queue.push_back((nx as u32, nz as u32));
+            }
+        }
+    }
+    result
+}
+
+#[inline]
+fn passes_water_guard(
+    heights: &[Vec<f32>],
+    context: Option<&WaterContext>,
+    gx: usize,
+    gz: usize,
+) -> bool {
+    let Some(c) = context else {
+        return true;
+    };
+    let idx = gz * c.width + gx;
+    if get_bit(&c.protected_mask, idx) {
+        return false;
+    }
+    let cell_y = heights[gz][gx];
+    let water_y = c.nearest_y[gz][gx];
+    if !cell_y.is_finite() || !water_y.is_finite() {
+        return true;
+    }
+    cell_y <= water_y + ELEVATION_TOLERANCE_BLOCKS
+}
+
+#[inline(always)]
+fn get_bit(mask: &[u64], idx: usize) -> bool {
+    (mask[idx >> 6] >> (idx & 63)) & 1 != 0
+}
+
+#[inline(always)]
+fn set_bit(mask: &mut [u64], idx: usize) {
+    mask[idx >> 6] |= 1u64 << (idx & 63);
 }

--- a/src/land_cover_osm_water_override.rs
+++ b/src/land_cover_osm_water_override.rs
@@ -10,14 +10,14 @@ use crate::osm_parser::{
 };
 
 const ELEVATION_TOLERANCE_BLOCKS: f32 = 1.5;
-// Min area for a non-water component to count as a real land mass.
 const PROTECTED_LAND_AREA_M2: f64 = 4000.0;
 const MIN_PROTECTED_LAND_CELLS: usize = 100;
-// Aspect ratio above which a component is treated as bridge-like (not protected).
 const LINEAR_ASPECT_RATIO: f64 = 3.0;
+// Above this grid size the nearest-water f32 grid is dropped to cap memory.
+const MAX_CELLS_FOR_ELEV_GUARD: usize = 100 * 1024 * 1024;
 
 struct WaterContext {
-    nearest_y: Vec<Vec<f32>>,
+    nearest_y: Option<Vec<Vec<f32>>>,
     protected_mask: Vec<u64>,
     width: usize,
 }
@@ -56,6 +56,9 @@ pub fn apply_osm_water_override(
         match elem {
             ProcessedElement::Way(way) => {
                 if is_water_polygon_way(way) {
+                    if !is_ring_closed(&way.nodes) {
+                        continue;
+                    }
                     let outer: Vec<(i32, i32)> = way.nodes.iter().map(|n| (n.x, n.z)).collect();
                     changed += fill_polygon_scanline(
                         &mut land_cover.grid,
@@ -96,23 +99,34 @@ pub fn apply_osm_water_override(
                 if !is_water_relation(rel) {
                     continue;
                 }
-                let mut outers: Vec<Vec<(i32, i32)>> = Vec::new();
-                let mut inners: Vec<Vec<(i32, i32)>> = Vec::new();
+                let mut outer_nodes: Vec<Vec<ProcessedNode>> = Vec::new();
+                let mut inner_nodes: Vec<Vec<ProcessedNode>> = Vec::new();
                 for member in &rel.members {
-                    let nodes: Vec<(i32, i32)> =
-                        member.way.nodes.iter().map(|n| (n.x, n.z)).collect();
-                    if nodes.len() < 3 {
+                    if member.way.nodes.len() < 2 {
                         continue;
                     }
                     match member.role {
-                        ProcessedMemberRole::Outer => outers.push(nodes),
-                        ProcessedMemberRole::Inner => inners.push(nodes),
+                        ProcessedMemberRole::Outer => outer_nodes.push(member.way.nodes.clone()),
+                        ProcessedMemberRole::Inner => inner_nodes.push(member.way.nodes.clone()),
                         _ => {}
                     }
                 }
-                if outers.is_empty() {
+                // Members are often fragments; stitch into closed rings.
+                crate::element_processing::merge_way_segments(&mut outer_nodes);
+                crate::element_processing::merge_way_segments(&mut inner_nodes);
+                outer_nodes.retain(|ring| is_ring_closed(ring));
+                inner_nodes.retain(|ring| is_ring_closed(ring));
+                if outer_nodes.is_empty() {
                     continue;
                 }
+                let outers: Vec<Vec<(i32, i32)>> = outer_nodes
+                    .iter()
+                    .map(|ring| ring.iter().map(|n| (n.x, n.z)).collect())
+                    .collect();
+                let inners: Vec<Vec<(i32, i32)>> = inner_nodes
+                    .iter()
+                    .map(|ring| ring.iter().map(|n| (n.x, n.z)).collect())
+                    .collect();
                 let outers_refs: Vec<&[(i32, i32)]> = outers.iter().map(|v| v.as_slice()).collect();
                 let inners_refs: Vec<&[(i32, i32)]> = inners.iter().map(|v| v.as_slice()).collect();
                 changed += fill_polygon_scanline(
@@ -149,10 +163,7 @@ fn is_water_polygon_way(way: &ProcessedWay) -> bool {
     if way.nodes.len() < 3 {
         return false;
     }
-    let tags = &way.tags;
-    matches!(tags.get("natural").map(|s| s.as_str()), Some("water"))
-        || tags.contains_key("water")
-        || matches!(tags.get("landuse").map(|s| s.as_str()), Some("reservoir"))
+    has_water_polygon_tags(&way.tags)
 }
 
 fn is_water_relation(rel: &ProcessedRelation) -> bool {
@@ -160,7 +171,33 @@ fn is_water_relation(rel: &ProcessedRelation) -> bool {
     matches!(
         tags.get("natural").map(|s| s.as_str()),
         Some("water" | "bay")
-    ) || tags.contains_key("water")
+    ) || has_explicit_water_tag(tags)
+}
+
+fn has_water_polygon_tags(tags: &HashMap<String, String>) -> bool {
+    matches!(tags.get("natural").map(|s| s.as_str()), Some("water"))
+        || has_explicit_water_tag(tags)
+        || matches!(tags.get("landuse").map(|s| s.as_str()), Some("reservoir"))
+}
+
+// `water=no` and similar negatives must not count as water.
+fn has_explicit_water_tag(tags: &HashMap<String, String>) -> bool {
+    tags.get("water")
+        .is_some_and(|v| !matches!(v.as_str(), "no" | "0" | "false"))
+}
+
+fn is_ring_closed(nodes: &[ProcessedNode]) -> bool {
+    if nodes.len() < 3 {
+        return false;
+    }
+    let first = &nodes[0];
+    let last = nodes.last().unwrap();
+    if first.id == last.id {
+        return true;
+    }
+    let dx = (first.x - last.x).abs();
+    let dz = (first.z - last.z).abs();
+    dx <= 1 && dz <= 1
 }
 
 fn get_waterway_width(waterway_type: &str, tags: &HashMap<String, String>) -> i32 {
@@ -438,7 +475,11 @@ fn build_water_context(
         small_threshold_cells,
         LINEAR_ASPECT_RATIO,
     );
-    let nearest_y = compute_nearest_water_y(grid, heights, width, height);
+    let nearest_y = if width.saturating_mul(height) <= MAX_CELLS_FOR_ELEV_GUARD {
+        Some(compute_nearest_water_y(grid, heights, width, height))
+    } else {
+        None
+    };
 
     Some(WaterContext {
         nearest_y,
@@ -447,7 +488,7 @@ fn build_water_context(
     })
 }
 
-// Marks cells in 4-connected non-water components that are large AND compact.
+// Two-pass: classify components without storing cells, then re-walk protected seeds.
 fn build_protected_land_bitset(
     grid: &[Vec<u8>],
     width: usize,
@@ -456,38 +497,38 @@ fn build_protected_land_bitset(
     linear_aspect_ratio: f64,
 ) -> Vec<u64> {
     let n = width * height;
-    let mut visited: Vec<u64> = vec![0; n.div_ceil(64)];
-    let mut protected: Vec<u64> = vec![0; n.div_ceil(64)];
+    let mut mask: Vec<u64> = vec![0; n.div_ceil(64)];
     let mut stack: Vec<u32> = Vec::new();
-    let mut component_cells: Vec<u32> = Vec::new();
+    let mut protected_seeds: Vec<u32> = Vec::new();
     let width_i32 = width as i32;
     let height_i32 = height as i32;
 
+    // Pass 1: classify each component, remember protected seeds.
     for start_z in 0..height {
         for start_x in 0..width {
             if grid[start_z][start_x] == LC_WATER {
                 continue;
             }
             let start_idx = start_z * width + start_x;
-            if get_bit(&visited, start_idx) {
+            if get_bit(&mask, start_idx) {
                 continue;
             }
 
-            component_cells.clear();
             stack.clear();
             stack.push(start_idx as u32);
-            set_bit(&mut visited, start_idx);
+            set_bit(&mut mask, start_idx);
 
             let mut min_x = start_x;
             let mut max_x = start_x;
             let mut min_z = start_z;
             let mut max_z = start_z;
+            let mut size: usize = 0;
 
             while let Some(curr) = stack.pop() {
                 let curr_u = curr as usize;
                 let cx = (curr_u % width) as i32;
                 let cz = (curr_u / width) as i32;
-                component_cells.push(curr);
+                size += 1;
                 let cxu = cx as usize;
                 let czu = cz as usize;
                 if cxu < min_x {
@@ -514,10 +555,10 @@ fn build_protected_land_bitset(
                         continue;
                     }
                     let n_idx = nzu * width + nxu;
-                    if get_bit(&visited, n_idx) {
+                    if get_bit(&mask, n_idx) {
                         continue;
                     }
-                    set_bit(&mut visited, n_idx);
+                    set_bit(&mut mask, n_idx);
                     stack.push(n_idx as u32);
                 }
             }
@@ -528,17 +569,49 @@ fn build_protected_land_bitset(
             let short_axis = bbox_w.min(bbox_h).max(1);
             let aspect = long_axis as f64 / short_axis as f64;
             let is_compact = aspect <= linear_aspect_ratio;
-            let is_large = component_cells.len() >= small_threshold_cells;
-
+            let is_large = size >= small_threshold_cells;
             if is_large && is_compact {
-                for &c in &component_cells {
-                    set_bit(&mut protected, c as usize);
-                }
+                protected_seeds.push(start_idx as u32);
             }
         }
     }
 
-    protected
+    // Pass 2: reuse the bitset to mark cells reachable from protected seeds.
+    mask.fill(0);
+    for seed in protected_seeds {
+        let seed_u = seed as usize;
+        if get_bit(&mask, seed_u) {
+            continue;
+        }
+        stack.clear();
+        stack.push(seed);
+        set_bit(&mut mask, seed_u);
+        while let Some(curr) = stack.pop() {
+            let curr_u = curr as usize;
+            let cx = (curr_u % width) as i32;
+            let cz = (curr_u / width) as i32;
+            for (dx, dz) in [(-1i32, 0i32), (1, 0), (0, -1), (0, 1)] {
+                let nx = cx + dx;
+                let nz = cz + dz;
+                if nx < 0 || nz < 0 || nx >= width_i32 || nz >= height_i32 {
+                    continue;
+                }
+                let nxu = nx as usize;
+                let nzu = nz as usize;
+                if grid[nzu][nxu] == LC_WATER {
+                    continue;
+                }
+                let n_idx = nzu * width + nxu;
+                if get_bit(&mask, n_idx) {
+                    continue;
+                }
+                set_bit(&mut mask, n_idx);
+                stack.push(n_idx as u32);
+            }
+        }
+    }
+
+    mask
 }
 
 // Multi-source BFS: each cell gets the terrain Y of its nearest LC_WATER seed.
@@ -601,8 +674,11 @@ fn passes_water_guard(
     if get_bit(&c.protected_mask, idx) {
         return false;
     }
+    let Some(nearest_y) = c.nearest_y.as_deref() else {
+        return true;
+    };
     let cell_y = heights[gz][gx];
-    let water_y = c.nearest_y[gz][gx];
+    let water_y = nearest_y[gz][gx];
     if !cell_y.is_finite() || !water_y.is_finite() {
         return true;
     }

--- a/src/land_cover_osm_water_override.rs
+++ b/src/land_cover_osm_water_override.rs
@@ -1,0 +1,363 @@
+//! Force LC_WATER inside OSM water polygons and waterways so OSM defines
+//! the shoreline, overriding ESA's noisy 10 m classification.
+use std::collections::HashMap;
+
+use crate::bresenham::bresenham_line;
+use crate::coordinate_system::cartesian::XZBBox;
+use crate::land_cover::{compute_water_distance, LandCoverData, LC_WATER};
+use crate::osm_parser::{
+    ProcessedElement, ProcessedMemberRole, ProcessedNode, ProcessedRelation, ProcessedWay,
+};
+
+pub fn apply_osm_water_override(
+    land_cover: &mut LandCoverData,
+    world_width: usize,
+    world_height: usize,
+    elements: &[ProcessedElement],
+    xzbbox: &XZBBox,
+) {
+    let width = land_cover.width;
+    let height = land_cover.height;
+    if width < 2 || height < 2 || world_width < 2 || world_height < 2 {
+        return;
+    }
+    let scale_to_grid_x = (width as f64 - 1.0) / (world_width as f64 - 1.0);
+    let scale_to_grid_z = (height as f64 - 1.0) / (world_height as f64 - 1.0);
+    let min_x = xzbbox.min_x();
+    let min_z = xzbbox.min_z();
+    let max_x = xzbbox.max_x();
+    let max_z = xzbbox.max_z();
+
+    let mut changed: usize = 0;
+    for elem in elements {
+        match elem {
+            ProcessedElement::Way(way) => {
+                if is_water_polygon_way(way) {
+                    let outer: Vec<(i32, i32)> = way.nodes.iter().map(|n| (n.x, n.z)).collect();
+                    changed += fill_polygon_scanline(
+                        &mut land_cover.grid,
+                        &[outer.as_slice()],
+                        &[],
+                        min_x,
+                        min_z,
+                        max_x,
+                        max_z,
+                        width,
+                        height,
+                        scale_to_grid_x,
+                        scale_to_grid_z,
+                    );
+                } else if let Some(waterway_type) = way.tags.get("waterway") {
+                    let waterway_width = get_waterway_width(waterway_type, &way.tags);
+                    let half_width = waterway_width / 2;
+                    changed += rasterize_line(
+                        &mut land_cover.grid,
+                        &way.nodes,
+                        half_width,
+                        min_x,
+                        min_z,
+                        max_x,
+                        max_z,
+                        width,
+                        height,
+                        scale_to_grid_x,
+                        scale_to_grid_z,
+                    );
+                }
+            }
+            ProcessedElement::Relation(rel) => {
+                if !is_water_relation(rel) {
+                    continue;
+                }
+                let mut outers: Vec<Vec<(i32, i32)>> = Vec::new();
+                let mut inners: Vec<Vec<(i32, i32)>> = Vec::new();
+                for member in &rel.members {
+                    let nodes: Vec<(i32, i32)> =
+                        member.way.nodes.iter().map(|n| (n.x, n.z)).collect();
+                    if nodes.len() < 3 {
+                        continue;
+                    }
+                    match member.role {
+                        ProcessedMemberRole::Outer => outers.push(nodes),
+                        ProcessedMemberRole::Inner => inners.push(nodes),
+                        _ => {}
+                    }
+                }
+                if outers.is_empty() {
+                    continue;
+                }
+                let outers_refs: Vec<&[(i32, i32)]> = outers.iter().map(|v| v.as_slice()).collect();
+                let inners_refs: Vec<&[(i32, i32)]> = inners.iter().map(|v| v.as_slice()).collect();
+                changed += fill_polygon_scanline(
+                    &mut land_cover.grid,
+                    &outers_refs,
+                    &inners_refs,
+                    min_x,
+                    min_z,
+                    max_x,
+                    max_z,
+                    width,
+                    height,
+                    scale_to_grid_x,
+                    scale_to_grid_z,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    if changed > 0 {
+        eprintln!(
+            "OSM water override: reclassified {} cells to LC_WATER inside OSM water polygons/lines",
+            changed
+        );
+        land_cover.water_distance = compute_water_distance(&land_cover.grid, width, height);
+        land_cover.refresh_water_blend_grid();
+    }
+}
+
+fn is_water_polygon_way(way: &ProcessedWay) -> bool {
+    if way.nodes.len() < 3 {
+        return false;
+    }
+    let tags = &way.tags;
+    matches!(tags.get("natural").map(|s| s.as_str()), Some("water"))
+        || tags.contains_key("water")
+        || matches!(tags.get("landuse").map(|s| s.as_str()), Some("reservoir"))
+}
+
+fn is_water_relation(rel: &ProcessedRelation) -> bool {
+    let tags = &rel.tags;
+    matches!(
+        tags.get("natural").map(|s| s.as_str()),
+        Some("water" | "bay")
+    ) || tags.contains_key("water")
+}
+
+fn get_waterway_width(waterway_type: &str, tags: &HashMap<String, String>) -> i32 {
+    if let Some(w) = tags.get("width").and_then(|s| {
+        s.parse::<f32>()
+            .ok()
+            .or_else(|| s.parse::<i32>().ok().map(|i| i as f32))
+    }) {
+        return w.round() as i32;
+    }
+    match waterway_type {
+        "river" => 8,
+        "canal" => 6,
+        "stream" => 3,
+        "fairway" => 12,
+        "flowline" => 2,
+        "brook" => 2,
+        "ditch" => 2,
+        "drain" => 1,
+        _ => 4,
+    }
+}
+
+#[allow(clippy::too_many_arguments, clippy::needless_range_loop)]
+fn fill_polygon_scanline(
+    grid: &mut [Vec<u8>],
+    outers: &[&[(i32, i32)]],
+    inners: &[&[(i32, i32)]],
+    min_x_world: i32,
+    min_z_world: i32,
+    max_x_world: i32,
+    max_z_world: i32,
+    width: usize,
+    height: usize,
+    scale_to_grid_x: f64,
+    scale_to_grid_z: f64,
+) -> usize {
+    if outers.is_empty() || width < 2 || height < 2 {
+        return 0;
+    }
+
+    let mut p_min_z = i32::MAX;
+    let mut p_max_z = i32::MIN;
+    for ring in outers {
+        for &(_, z) in *ring {
+            p_min_z = p_min_z.min(z);
+            p_max_z = p_max_z.max(z);
+        }
+    }
+    if p_min_z == i32::MAX {
+        return 0;
+    }
+    if p_max_z < min_z_world || p_min_z > max_z_world {
+        return 0;
+    }
+
+    let scale_inv_z = if scale_to_grid_z > 0.0 {
+        1.0 / scale_to_grid_z
+    } else {
+        return 0;
+    };
+    let scale_inv_x = if scale_to_grid_x > 0.0 {
+        1.0 / scale_to_grid_x
+    } else {
+        return 0;
+    };
+
+    // Iterate grid rows intersected with the polygon's z range only.
+    let p_min_gz = ((p_min_z - min_z_world).max(0) as f64 * scale_to_grid_z).floor() as i32;
+    let p_max_gz = ((p_max_z - min_z_world).max(0) as f64 * scale_to_grid_z).ceil() as i32;
+    let gz_start = p_min_gz.max(0) as usize;
+    let gz_end = (p_max_gz.min(height as i32 - 1)).max(0) as usize;
+
+    let mut outer_x_world: Vec<f64> = Vec::new();
+    let mut inner_x_world: Vec<f64> = Vec::new();
+    let mut count = 0;
+
+    for gz in gz_start..=gz_end {
+        let world_z = gz as f64 * scale_inv_z + min_z_world as f64;
+
+        outer_x_world.clear();
+        for ring in outers {
+            edge_crossings_at_z(ring, world_z, &mut outer_x_world);
+        }
+        if outer_x_world.len() < 2 {
+            continue;
+        }
+        outer_x_world.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        inner_x_world.clear();
+        for ring in inners {
+            edge_crossings_at_z(ring, world_z, &mut inner_x_world);
+        }
+        if !inner_x_world.is_empty() {
+            inner_x_world.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        }
+
+        let row = &mut grid[gz];
+        let mut i = 0;
+        while i + 1 < outer_x_world.len() {
+            let wx_start = outer_x_world[i];
+            let wx_end = outer_x_world[i + 1];
+            i += 2;
+
+            let wx_start_clipped = wx_start.max(min_x_world as f64);
+            let wx_end_clipped = wx_end.min(max_x_world as f64);
+            if wx_start_clipped > wx_end_clipped {
+                continue;
+            }
+
+            let gx_start =
+                ((wx_start_clipped - min_x_world as f64) * scale_to_grid_x).ceil() as i32;
+            let gx_end = ((wx_end_clipped - min_x_world as f64) * scale_to_grid_x).floor() as i32;
+            let gx_start = gx_start.max(0) as usize;
+            let gx_end = (gx_end.min(width as i32 - 1)).max(0) as usize;
+            if gx_start > gx_end {
+                continue;
+            }
+
+            for gx in gx_start..=gx_end {
+                if !inner_x_world.is_empty() {
+                    let wx = gx as f64 * scale_inv_x + min_x_world as f64;
+                    if point_in_sorted_ranges(wx, &inner_x_world) {
+                        continue;
+                    }
+                }
+                if row[gx] != LC_WATER {
+                    row[gx] = LC_WATER;
+                    count += 1;
+                }
+            }
+        }
+    }
+    count
+}
+
+fn edge_crossings_at_z(ring: &[(i32, i32)], z: f64, out: &mut Vec<f64>) {
+    let n = ring.len();
+    if n < 3 {
+        return;
+    }
+    let mut j = n - 1;
+    for i in 0..n {
+        let zi = ring[i].1 as f64;
+        let zj = ring[j].1 as f64;
+        if (zi > z) != (zj > z) {
+            let xi = ring[i].0 as f64;
+            let xj = ring[j].0 as f64;
+            let t = (z - zi) / (zj - zi);
+            out.push(xi + (xj - xi) * t);
+        }
+        j = i;
+    }
+}
+
+fn point_in_sorted_ranges(x: f64, sorted: &[f64]) -> bool {
+    let mut i = 0;
+    while i + 1 < sorted.len() {
+        if x > sorted[i] && x < sorted[i + 1] {
+            return true;
+        }
+        i += 2;
+    }
+    false
+}
+
+#[allow(clippy::too_many_arguments)]
+fn rasterize_line(
+    grid: &mut [Vec<u8>],
+    nodes: &[ProcessedNode],
+    half_width: i32,
+    min_x_world: i32,
+    min_z_world: i32,
+    max_x_world: i32,
+    max_z_world: i32,
+    width: usize,
+    height: usize,
+    scale_to_grid_x: f64,
+    scale_to_grid_z: f64,
+) -> usize {
+    if nodes.len() < 2 || half_width < 0 {
+        return 0;
+    }
+    let width_i32 = width as i32;
+    let height_i32 = height as i32;
+    let margin = half_width.max(0);
+    let mut count = 0;
+    for pair in nodes.windows(2) {
+        let (x1, z1) = (pair[0].x, pair[0].z);
+        let (x2, z2) = (pair[1].x, pair[1].z);
+        // Skip segments whose bbox+margin doesn't intersect the world bbox.
+        let seg_min_x = x1.min(x2) - margin;
+        let seg_max_x = x1.max(x2) + margin;
+        let seg_min_z = z1.min(z2) - margin;
+        let seg_max_z = z1.max(z2) + margin;
+        if seg_max_x < min_x_world
+            || seg_min_x > max_x_world
+            || seg_max_z < min_z_world
+            || seg_min_z > max_z_world
+        {
+            continue;
+        }
+        for (bx, _, bz) in bresenham_line(x1, 0, z1, x2, 0, z2) {
+            for dx in -half_width..=half_width {
+                for dz in -half_width..=half_width {
+                    let wx = bx + dx;
+                    let wz = bz + dz;
+                    let rel_x = wx - min_x_world;
+                    let rel_z = wz - min_z_world;
+                    if rel_x < 0 || rel_z < 0 {
+                        continue;
+                    }
+                    let gx = (rel_x as f64 * scale_to_grid_x).round() as i32;
+                    let gz = (rel_z as f64 * scale_to_grid_z).round() as i32;
+                    if gx < 0 || gz < 0 || gx >= width_i32 || gz >= height_i32 {
+                        continue;
+                    }
+                    let gx_u = gx as usize;
+                    let gz_u = gz as usize;
+                    if grid[gz_u][gx_u] != LC_WATER {
+                        grid[gz_u][gx_u] = LC_WATER;
+                        count += 1;
+                    }
+                }
+            }
+        }
+    }
+    count
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ mod floodfill_cache;
 mod ground;
 mod ground_generation;
 mod land_cover;
+mod land_cover_bridge_repair;
+mod land_cover_osm_water_override;
 mod map_renderer;
 mod map_transformation;
 mod osm_parser;
@@ -192,6 +194,16 @@ fn run_cli() {
 
     parsed_elements
         .sort_by_key(|element: &osm_parser::ProcessedElement| osm_parser::get_priority(element));
+
+    // OSM water override first, then bridge repair handles remaining bridge-shadow cells.
+    ground.apply_osm_water_override(&parsed_elements, &xzbbox);
+    if args.debug {
+        ground.save_land_cover_debug_image("landcover_debug_post_osm_water");
+    }
+    ground.apply_bridge_land_cover_repair(&parsed_elements, &xzbbox, args.scale);
+    if args.debug {
+        ground.save_land_cover_debug_image("landcover_debug_post_bridge_repair");
+    }
 
     // Write the parsed OSM data to a file for inspection
     if args.debug {


### PR DESCRIPTION
# River shoreline + bridge cleanup

Two long-standing visual artifacts around water in Arnis-generated worlds:

1. **Bridges over rivers came out as stone bricks "plopped" inside the river.**
   ESA WorldCover sees a bridge from above and (correctly!) classifies it as
   built-up. ESA doesn't know that there's a river *under* the bridge, so the
   river was getting interrupted by the bridge's footprint.

2. **Shorelines next to built-up areas had a stone-block "cliff" at the
   water's edge.** DSM elevation data includes buildings and waterfront
   structures in its heights, so the shore was popping up ~10–30 m above the
   water it was sitting next to.

This PR addresses both. Tested on Munich (Isar), Heidelberg (Neckar), NYC
(Hudson), Grand Canyon (Colorado River), and Arnis (Schlei).

## What changed

**OSM water override (new module: `land_cover_osm_water_override.rs`).** OSM
has authoritative water polygons — `natural=water`, `water=*`,
`landuse=reservoir`, plus `waterway=*` lines for rivers/canals/streams. We
now use these to overrule ESA's noisy 10 m classification inside the polygon
footprint, fixing the bridge "plop" and small ESA misclassifications inside
rivers.

The override walks the grid via a scanline polygon fill (iterates *grid
rows*, not the polygon's world bbox — so NYC's Hudson, the Colorado River,
and similar huge polygons run in ~1 s instead of timing out).

Inside each water polygon, two guards decide what to actually flood:

- **Elevation guard** — cells more than ~1.5 blocks above the local water
  surface (BFS from the nearest ESA water cell) stay as land. Catches
  bluffs/banks that fall inside a loosely-drawn polygon.
- **Protected-land mask** — connected components of ESA non-water cells
  that are both *large* (≥ 4000 m²) AND *compact* (aspect ratio ≤ 3) are
  treated as real land masses and never get flooded.

The protected-land mask is what makes the Arnis case (Schlei OSM
multipolygon literally sweeps over the entire peninsula because nobody
marked it as an inner ring) work cleanly. It generalises:

- **Peninsulas / islands missing their inner ring** — preserved (compact +
  large → protected).
- **Bridges over wide rivers** — bridges end up in the same component as
  the surrounding city (they touch at the bridge endpoints), so they're
  protected here too. `bridge_land_cover_repair` (below) reclassifies them
  to water in a separate pass, so the river still appears continuous.
- **Free-floating built-up patches in a river** — small components,
  flooded.
