### PR TITLE
Make cherry trees rarer and fix iron roof stair color

### DIFF
--- a/src/block_definitions.rs
+++ b/src/block_definitions.rs
@@ -1123,7 +1123,7 @@ pub fn get_stair_block_for_material(material: Block) -> Block {
         SPRUCE_LOG => SPRUCE_STAIRS,
 
         // Misc
-        IRON_BLOCK => POLISHED_BLACKSTONE_BRICK_STAIRS,
+        IRON_BLOCK => POLISHED_DIORITE_STAIRS,
         NETHERITE_BLOCK => POLISHED_BLACKSTONE_BRICK_STAIRS,
         HAY_BALE => OAK_STAIRS,
         GRAVEL => COBBLESTONE_STAIRS,

--- a/src/element_processing/tree.rs
+++ b/src/element_processing/tree.rs
@@ -214,16 +214,16 @@ impl Tree<'_> {
         // The element_id of 0 is used as a salt for tree-specific randomness
         let mut rng = coord_rng(x, z, 0);
 
-        let tree_type = match rng.random_range(1..=13) {
-            1..=3 => TreeType::Oak,
-            4..=5 => TreeType::Spruce,
-            6..=7 => TreeType::Birch,
-            8 => TreeType::DarkOak,
-            9 => TreeType::Jungle,
-            10 => TreeType::Acacia,
-            11 => TreeType::Cherry,
-            12 => TreeType::TallOak,
-            13 => TreeType::Pine,
+        let tree_type = match rng.random_range(1..=50) {
+            1..=13 => TreeType::Oak,
+            14..=21 => TreeType::Spruce,
+            22..=29 => TreeType::Birch,
+            30..=33 => TreeType::DarkOak,
+            34..=37 => TreeType::Jungle,
+            38..=41 => TreeType::Acacia,
+            42 => TreeType::Cherry,
+            43..=46 => TreeType::TallOak,
+            47..=50 => TreeType::Pine,
             _ => unreachable!(),
         };
 


### PR DESCRIPTION
Cherry trees drop from 1/13 (~7.7%) to 1/50 (~2%); other species keep their original proportions. Iron-block roofs (roof:material=metal and related) now pair with polished diorite stairs instead of polished blackstone brick stairs, matching the silvery roof color.