### PR TITLE
Suppress outlines of building relations whose members are sub-relations

### DIFF
--- a/src/bedrock_block_map.rs
+++ b/src/bedrock_block_map.rs
@@ -370,6 +370,10 @@ pub fn to_bedrock_block(block: Block) -> BedrockBlock {
             "concretePowder",
             vec![("color", BedrockBlockStateValue::String("gray".to_string()))],
         ),
+        "brown_concrete_powder" => BedrockBlock::with_states(
+            "concretePowder",
+            vec![("color", BedrockBlockStateValue::String("brown".to_string()))],
+        ),
         "light_gray_concrete" => BedrockBlock::with_states(
             "concrete",
             vec![(
@@ -1412,6 +1416,17 @@ mod tests {
         assert!(matches!(
             bedrock.states.get("color"),
             Some(BedrockBlockStateValue::String(s)) if s == "gray"
+        ));
+    }
+
+    #[test]
+    fn test_brown_concrete_powder_bedrock_mapping() {
+        use crate::block_definitions::BROWN_CONCRETE_POWDER;
+        let bedrock = to_bedrock_block(BROWN_CONCRETE_POWDER);
+        assert_eq!(bedrock.name, "minecraft:concretePowder");
+        assert!(matches!(
+            bedrock.states.get("color"),
+            Some(BedrockBlockStateValue::String(s)) if s == "brown"
         ));
     }
 

--- a/src/block_definitions.rs
+++ b/src/block_definitions.rs
@@ -328,7 +328,7 @@ impl Block {
             229 => "daylight_detector",
             230 => "cherry_log",
             231 => "cherry_leaves",
-            232 => "purple_stained_glass",
+            232 => "brown_concrete_powder",
             233 => "orange_stained_glass",
             234 => "magenta_stained_glass",
             235 => "potted_poppy",
@@ -1030,6 +1030,7 @@ pub const POTTED_DANDELION: Block = Block::new(247);
 pub const POTTED_BLUE_ORCHID: Block = Block::new(248);
 
 pub const GRAY_CONCRETE_POWDER: Block = Block::new(252);
+pub const BROWN_CONCRETE_POWDER: Block = Block::new(232);
 pub const CYAN_TERRACOTTA: Block = Block::new(253);
 pub const BLACK_WOOL: Block = Block::new(254);
 pub const LIGHT_GRAY_WALL_BANNER: Block = Block::new(255);
@@ -1075,6 +1076,7 @@ pub fn get_stair_block_for_material(material: Block) -> Block {
         MUD_BRICKS => MUD_BRICK_STAIRS,
         MUD => MUD_BRICK_STAIRS,
         BROWN_CONCRETE => MUD_BRICK_STAIRS,
+        BROWN_CONCRETE_POWDER => MUD_BRICK_STAIRS,
         BROWN_TERRACOTTA => MUD_BRICK_STAIRS,
         GRAY_TERRACOTTA => MUD_BRICK_STAIRS,
         LIGHT_GRAY_TERRACOTTA => MUD_BRICK_STAIRS,
@@ -1139,7 +1141,7 @@ pub fn get_stair_block_for_material(material: Block) -> Block {
 pub fn get_slab_block_for_material(material: Block) -> Block {
     match material {
         STONE_BRICKS | CHISELED_STONE_BRICKS | CRACKED_STONE_BRICKS => STONE_BRICK_SLAB,
-        BRICK | BROWN_TERRACOTTA => BRICK_SLAB,
+        BRICK | BROWN_TERRACOTTA | BROWN_CONCRETE_POWDER => BRICK_SLAB,
         MUD_BRICKS | WHITE_TERRACOTTA | GRAY_TERRACOTTA | LIGHT_BLUE_TERRACOTTA => MUD_BRICK_SLAB,
         OAK_PLANKS | OAK_LOG | SPRUCE_PLANKS | DARK_OAK_PLANKS => OAK_SLAB,
         QUARTZ_BLOCK | QUARTZ_BRICKS | WHITE_CONCRETE => QUARTZ_SLAB_TOP,
@@ -1162,7 +1164,9 @@ pub fn get_wall_piece_for_material(material: Block) -> Block {
         | SMOOTH_STONE
         | POLISHED_DEEPSLATE
         | DEEPSLATE_BRICKS => STONE_BRICK_WALL,
-        BRICK | BROWN_TERRACOTTA | MUD_BRICKS | WHITE_TERRACOTTA => BRICK_WALL,
+        BRICK | BROWN_TERRACOTTA | BROWN_CONCRETE_POWDER | MUD_BRICKS | WHITE_TERRACOTTA => {
+            BRICK_WALL
+        }
         ANDESITE | GRAY_CONCRETE | LIGHT_GRAY_CONCRETE => ANDESITE_WALL,
         _ => COBBLESTONE_WALL,
     }

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -6,7 +6,7 @@ use crate::floodfill_cache::FloodFillCache;
 use crate::ground::Ground;
 use crate::ground_generation;
 use crate::map_renderer;
-use crate::osm_parser::{ProcessedElement, ProcessedMemberRole};
+use crate::osm_parser::{OutlineSuppression, ProcessedElement};
 use crate::progress::{emit_gui_progress_update, emit_map_preview_ready, emit_show_in_folder};
 #[cfg(feature = "gui")]
 use crate::telemetry::{send_log, LogLevel};
@@ -34,6 +34,7 @@ pub fn generate_world_with_options(
     ground: Ground,
     args: &Args,
     options: GenerationOptions,
+    outline_suppression: OutlineSuppression,
 ) -> Result<PathBuf, String> {
     let output_path = options.path.clone();
     let world_format = options.format;
@@ -108,33 +109,6 @@ pub fn generate_world_with_options(
     let pb_batch_size: u64 = (elements_count as u64 / desired_updates).max(1);
     let mut element_counter: u64 = 0;
 
-    // Pre-scan: detect building relation outlines that should be suppressed.
-    // Only applies to type=building relations (NOT type=multipolygon).
-    // When a type=building relation has "part" members, the outline way should not
-    // render as a standalone building, the individual parts render instead.
-    let suppressed_building_outlines: HashSet<u64> = {
-        let mut outlines = HashSet::new();
-        for element in &elements {
-            if let ProcessedElement::Relation(rel) = element {
-                let is_building_type = rel.tags.get("type").map(|t| t.as_str()) == Some("building");
-                if is_building_type {
-                    let has_parts = rel
-                        .members
-                        .iter()
-                        .any(|m| m.role == ProcessedMemberRole::Part);
-                    if has_parts {
-                        for member in &rel.members {
-                            if member.role == ProcessedMemberRole::Outer {
-                                outlines.insert(member.way.id);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        outlines
-    };
-
     // Pre-scan 3DMR-tagged elements first; 3DMR wins over Wikidata on conflict.
     let three_dmr_prescan = if args.use_3d {
         Some(crate::models_3d::three_dmr::prescan(
@@ -172,6 +146,7 @@ pub fn generate_world_with_options(
         let suppression_key = (element.kind(), element.id());
         if three_dmr_suppressed.contains(&suppression_key)
             || wikidata_suppressed.contains(&suppression_key)
+            || outline_suppression.contains(&suppression_key)
         {
             continue;
         }
@@ -202,19 +177,15 @@ pub fn generate_world_with_options(
         match &element {
             ProcessedElement::Way(way) => {
                 if way.tags.contains_key("building") || way.tags.contains_key("building:part") {
-                    // Skip building outlines that are suppressed by building relations with parts.
-                    // The individual building:part ways will render instead.
-                    if !suppressed_building_outlines.contains(&way.id) {
-                        buildings::generate_buildings(
-                            &mut editor,
-                            way,
-                            args,
-                            None,
-                            None,
-                            &flood_fill_cache,
-                            &building_passages,
-                        );
-                    }
+                    buildings::generate_buildings(
+                        &mut editor,
+                        way,
+                        args,
+                        None,
+                        None,
+                        &flood_fill_cache,
+                        &building_passages,
+                    );
                 } else if way.tags.contains_key("highway") {
                     highways::generate_highways(
                         &mut editor,

--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -2155,9 +2155,9 @@ fn substitute_pool_only(block: Block) -> &'static [Block] {
         BLACK_TERRACOTTA => &[NETHER_BRICK],
         RED_NETHER_BRICKS => &[NETHER_BRICK],
 
-        // Mud / brown terracotta
-        MUD_BRICKS => &[BROWN_TERRACOTTA, BROWN_CONCRETE],
-        BROWN_TERRACOTTA => &[MUD_BRICKS, BROWN_CONCRETE],
+        // Brown family
+        BROWN_TERRACOTTA => &[BROWN_CONCRETE_POWDER, BROWN_CONCRETE],
+        BROWN_CONCRETE => &[BROWN_CONCRETE_POWDER, BROWN_TERRACOTTA],
 
         // Off-white / quartz
         QUARTZ_BLOCK => &[QUARTZ_BRICKS, SMOOTH_QUARTZ],

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1086,6 +1086,7 @@ fn gui_start_generation(
                     ground,
                     &args,
                     generation_options.clone(),
+                    osm_parser::OutlineSuppression::new(),
                 );
                 if let Some(g) = cleanup_guard.as_mut() {
                     g.disarm();
@@ -1111,7 +1112,7 @@ fn gui_start_generation(
             // Run data fetch and world generation (standard mode: objects + terrain, or objects only)
             match retrieve_data::fetch_data_from_overpass(args.bbox, args.debug, "requests", None) {
                 Ok(raw_data) => {
-                    let (mut parsed_elements, mut xzbbox) =
+                    let (mut parsed_elements, mut xzbbox, outline_suppression) =
                         osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug);
 
                     // Fetch supplementary building data from Overture Maps
@@ -1171,6 +1172,7 @@ fn gui_start_generation(
                         ground,
                         &args,
                         generation_options.clone(),
+                        outline_suppression,
                     );
                     if let Some(g) = cleanup_guard.as_mut() {
                         g.disarm();

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,7 @@ fn run_cli() {
     let mut ground = ground::generate_ground_data(&args);
 
     // Parse raw data
-    let (mut parsed_elements, mut xzbbox) =
+    let (mut parsed_elements, mut xzbbox, outline_suppression) =
         osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug);
 
     // Fetch supplementary building data from Overture Maps
@@ -299,6 +299,7 @@ fn run_cli() {
         ground,
         &args,
         generation_options,
+        outline_suppression,
     ) {
         Ok(_) => {
             if args.bedrock {

--- a/src/osm_parser.rs
+++ b/src/osm_parser.rs
@@ -5,7 +5,7 @@ use crate::coordinate_system::transformation::CoordTransformer;
 use crate::progress::emit_gui_progress_update;
 use colored::Colorize;
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 // Tags Arnis never reads. Filtered at parse time to save memory.
@@ -228,12 +228,14 @@ impl ProcessedElement {
     }
 }
 
+pub type OutlineSuppression = HashSet<(&'static str, u64)>;
+
 pub fn parse_osm_data(
     osm_data: OsmData,
     bbox: LLBBox,
     scale: f64,
     debug: bool,
-) -> (Vec<ProcessedElement>, XZBBox) {
+) -> (Vec<ProcessedElement>, XZBBox, OutlineSuppression) {
     println!("{} Parsing data...", "[2/7]".bold());
     println!("Bounding box: {bbox:?}");
     emit_gui_progress_update(5.0, "Parsing data...");
@@ -252,6 +254,8 @@ pub fn parse_osm_data(
         println!("Scale factor X: {}", coord_transformer.scale_factor_x());
         println!("Scale factor Z: {}", coord_transformer.scale_factor_z());
     }
+
+    let outline_suppression = compute_outline_suppression(&data.relations);
 
     let mut nodes_map: HashMap<u64, ProcessedNode> = HashMap::new();
     let mut ways_map: HashMap<u64, Arc<ProcessedWay>> = HashMap::new();
@@ -354,7 +358,9 @@ pub fn parse_osm_data(
             .iter()
             .filter_map(|mem: &OsmMember| {
                 if mem.r#type != "way" {
-                    eprintln!("WARN: Unknown relation member type \"{}\"", mem.r#type);
+                    if mem.r#type != "relation" && mem.r#type != "node" {
+                        eprintln!("WARN: Unknown relation member type \"{}\"", mem.r#type);
+                    }
                     return None;
                 }
 
@@ -425,7 +431,37 @@ pub fn parse_osm_data(
     drop(nodes_map);
     drop(ways_map);
 
-    (processed_elements, xzbbox)
+    (processed_elements, xzbbox, outline_suppression)
+}
+
+fn compute_outline_suppression(relations: &[OsmElement]) -> OutlineSuppression {
+    let mut suppressed: OutlineSuppression = HashSet::new();
+    for rel in relations {
+        let Some(tags) = &rel.tags else { continue };
+        if tags.get("type").map(|t| t.as_str()) != Some("building") {
+            continue;
+        }
+        let has_parts = rel
+            .members
+            .iter()
+            .any(|m| m.role.trim().eq_ignore_ascii_case("part"));
+        if !has_parts {
+            continue;
+        }
+        for m in &rel.members {
+            let r = m.role.trim();
+            if !(r.eq_ignore_ascii_case("outline") || r.eq_ignore_ascii_case("outer")) {
+                continue;
+            }
+            let kind: &'static str = match m.r#type.as_str() {
+                "way" => "way",
+                "relation" => "relation",
+                _ => continue,
+            };
+            suppressed.insert((kind, m.r#ref));
+        }
+    }
+    suppressed
 }
 
 /// Returns true if tags indicate a water element handled by water_areas.rs.

--- a/src/test_utilities.rs
+++ b/src/test_utilities.rs
@@ -11,7 +11,8 @@ pub fn generate_example(llbbox: LLBBox) -> (XZBBox, Vec<ProcessedElement>) {
         .expect("Failed to fetch data");
 
     // Parse raw data
-    let (mut parsed_elements, xzbbox) = osm_parser::parse_osm_data(raw_data, llbbox, 1.0, false);
+    let (mut parsed_elements, xzbbox, _outline_suppression) =
+        osm_parser::parse_osm_data(raw_data, llbbox, 1.0, false);
     parsed_elements
         .sort_by_key(|element: &osm_parser::ProcessedElement| osm_parser::get_priority(element));
 


### PR DESCRIPTION
OSM type=building relations like St. Basil's Cathedral (3224486) reference their outline and parts as nested sub-relations rather than ways. The parser silently dropped every relation-typed member, so the parent relation ended up with no parsed members and the existing outline-suppression pre-scan in data_processing never fired. The outline rendered as a separate cathedral building on top of the parts.

Compute the outline suppression set in the parser from raw OSM data, keyed by (kind, id) so it covers both way- and relation-typed outline members. Apply it alongside the existing 3DMR/Wikidata suppression in data_processing. The previous way-only pre-scan is removed as redundant.

Also silence WARN spam for the expected relation/node member types; only genuinely unknown types still warn.