### PR TITLE
Fetch type=building relations from Overpass (fixes #1011)

### DIFF
--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -152,6 +152,7 @@ pub fn fetch_data_from_overpass(
     (
         nwr["building"];
         nwr["building:part"];
+        relation["type"="building"];
         nwr["highway"];
         nwr["landuse"]["landuse"!="salt_pond"];
         nwr["natural"]["natural"!="coastline"]["natural"!="bay"]["natural"!="strait"];


### PR DESCRIPTION
The Overpass query was nwr["building"] / nwr["building:part"], matching elements that have a building tag key. Empire State Building's parent relation 2098969 has only {name, type=building} - no building=* tag - so it was never fetched. The outline-suppression code added in the previous commit on this branch had no relation to walk, the outline way rendered standalone at its full height, and the entire structure appeared as a giant rectangular blob with the setback parts hidden inside.

Add relation["type"="building"] to the query. Brings ESB-style parents into Arnis's data, where compute_outline_suppression picks them up automatically via the existing code path.