### PR TITLE
Add experimental Luanti/Mineclonia world export (continues #808)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "rayon",
  "reqwest",
  "rfd",
+ "rusqlite",
  "rusty-leveldb",
  "semver",
  "serde",
@@ -236,6 +237,7 @@ dependencies = [
  "vek",
  "windows 0.62.2",
  "zip",
+ "zstd",
 ]
 
 [[package]]
@@ -1713,6 +1715,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastanvil"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2471,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heapless"
@@ -3258,6 +3281,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4755,6 +4789,20 @@ checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
 dependencies = [
  "heapless",
  "num-traits",
+ "smallvec",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
  "smallvec",
 ]
 
@@ -6555,6 +6603,12 @@ name = "varint-rs"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f54a172d0620933a27a4360d3db3e2ae0dd6cceae9730751a036bbf182c4b23"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vek"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ nbtx = { git = "https://github.com/bedrock-crustaceans/nbtx", optional = true }
 vek = { version = "0.17", optional = true }
 zip = { version = "0.6", default-features = false, features = ["deflate"], optional = true }
 rusty-leveldb = { version = "3", optional = true }
+rusqlite = { version = "0.33", features = ["bundled"] }
+zstd = "0.13"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.0", features = ["Win32_System_Console"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ overflow-checks = true
 
 [features]
 default = ["gui"]
-gui = ["tauri", "tauri-plugin-log", "tauri-plugin-shell", "tokio", "rfd", "tauri-build", "bedrock"]
-bedrock = ["bedrockrs_level", "bedrockrs_shared", "nbtx", "zip", "byteorder", "vek", "rusty-leveldb"]
+gui = ["tauri", "tauri-plugin-log", "tauri-plugin-shell", "tokio", "rfd", "tauri-build"]
 
 [build-dependencies]
 tauri-build = {version = "2", optional = true}
@@ -23,7 +22,7 @@ tauri-build = {version = "2", optional = true}
 [dependencies]
 base64 = "0.22.1"
 bytes = "1"
-byteorder = { version = "1.5", optional = true }
+byteorder = "1.5"
 clap = { version = "4.6.0", features = ["derive", "env"] }
 colored = "3.0.0"
 dda-voxelize = { git = "https://github.com/MIERUNE/dda-voxelize-rs", rev = "1e0844a873262f13b19a709e188a3df22a6fbf97" }
@@ -55,12 +54,12 @@ tauri-plugin-log = { version = "2.6.0", optional = true }
 tauri-plugin-shell = { version = "2", optional = true }
 tiff = "0.11"
 tokio = { version = "1.48.0", features = ["full"], optional = true }
-bedrockrs_level = { git = "https://github.com/bedrock-crustaceans/bedrock-rs", rev = "7ef268b", package = "bedrockrs_level", optional = true }
-bedrockrs_shared = { git = "https://github.com/bedrock-crustaceans/bedrock-rs", rev = "7ef268b", package = "bedrockrs_shared", optional = true }
-nbtx = { git = "https://github.com/bedrock-crustaceans/nbtx", optional = true }
-vek = { version = "0.17", optional = true }
-zip = { version = "0.6", default-features = false, features = ["deflate"], optional = true }
-rusty-leveldb = { version = "3", optional = true }
+bedrockrs_level = { git = "https://github.com/bedrock-crustaceans/bedrock-rs", rev = "7ef268b", package = "bedrockrs_level" }
+bedrockrs_shared = { git = "https://github.com/bedrock-crustaceans/bedrock-rs", rev = "7ef268b", package = "bedrockrs_shared" }
+nbtx = { git = "https://github.com/bedrock-crustaceans/nbtx" }
+vek = "0.17"
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
+rusty-leveldb = "3"
 rusqlite = { version = "0.33", features = ["bundled"] }
 zstd = "0.13"
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.[^3]
 
+The Luanti block-name mapping in `src/luanti_block_map.rs` is derived from [MC2MT](https://github.com/rollerozxa/MC2MT) by rollerozxa and is licensed under the GNU Lesser General Public License v2.1 or later. The full attribution and license header are preserved in that file.
+
 Download Arnis only from the official source https://arnismc.com or https://github.com/louis-e/arnis/. Every other website providing a download and claiming to be affiliated with the project is unofficial and may be malicious.
 
 The logo was made by @nxfx21.

--- a/src/args.rs
+++ b/src/args.rs
@@ -28,6 +28,10 @@ pub struct Args {
     #[arg(long)]
     pub bedrock: bool,
 
+    /// Generate a Luanti/Minetest world (map.sqlite) instead of Java Edition
+    #[arg(long)]
+    pub luanti: bool,
+
     /// Downloader method (requests/curl/wget) (optional)
     #[arg(long, default_value = "requests")]
     pub downloader: String,
@@ -106,8 +110,22 @@ pub struct Args {
 /// For Java Edition: `--path` is required. If the directory doesn't exist, it will be created.
 /// For Bedrock Edition (`--bedrock`): `--path` is optional (defaults to Desktop output).
 pub fn validate_args(args: &Args) -> Result<(), String> {
+    if args.bedrock && args.luanti {
+        return Err("Cannot use --bedrock and --luanti together.".to_string());
+    }
+
     if args.bedrock {
         // Bedrock: path is optional; if provided, it must be an existing directory
+        if let Some(ref path) = args.path {
+            if !path.exists() {
+                return Err(format!("Path does not exist: {}", path.display()));
+            }
+            if !path.is_dir() {
+                return Err(format!("Path is not a directory: {}", path.display()));
+            }
+        }
+    } else if args.luanti {
+        // Luanti: path optional, defaults to OS Luanti worlds dir
         if let Some(ref path) = args.path {
             if !path.exists() {
                 return Err(format!("Path does not exist: {}", path.display()));

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -24,6 +24,8 @@ pub struct GenerationOptions {
     pub format: WorldFormat,
     pub level_name: Option<String>,
     pub spawn_point: Option<(i32, i32)>,
+    pub luanti_game: Option<crate::luanti_block_map::LuantiGame>,
+    pub ground_level: i32,
 }
 
 /// Generate world with explicit format options (used by GUI for Bedrock support)
@@ -41,15 +43,29 @@ pub fn generate_world_with_options(
     let generation_start = args.benchmark.then(std::time::Instant::now);
 
     // Create editor with appropriate format
-    let mut editor: WorldEditor = WorldEditor::new_with_format_and_name(
-        options.path,
-        &xzbbox,
-        llbbox,
-        options.format,
-        options.level_name.clone(),
-        options.spawn_point,
-        args.disable_height_limit,
-    );
+    let mut editor: WorldEditor = if options.format == WorldFormat::LuantiWorld {
+        WorldEditor::new_luanti(
+            options.path,
+            &xzbbox,
+            llbbox,
+            options
+                .luanti_game
+                .unwrap_or(crate::luanti_block_map::LuantiGame::Mineclonia),
+            options.level_name.clone(),
+            options.spawn_point,
+            options.ground_level,
+        )
+    } else {
+        WorldEditor::new_with_format_and_name(
+            options.path,
+            &xzbbox,
+            llbbox,
+            options.format,
+            options.level_name.clone(),
+            options.spawn_point,
+            args.disable_height_limit,
+        )
+    };
     let ground = Arc::new(ground);
 
     println!("{} Processing data...", "[4/7]".bold());

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -864,7 +864,7 @@ fn gui_start_generation(
     // For new Java worlds, set the spawn point in level.dat
     // Only update player position for Java worlds - Bedrock worlds don't have a pre-existing
     // level.dat to modify (the spawn point will be set when the .mcworld is created)
-    if is_new_world && world_format != "bedrock" {
+    if is_new_world && world_format != "bedrock" && !world_format.starts_with("luanti") {
         let prep_result: Result<(), String> = (|| -> Result<(), String> {
             let llbbox = LLBBox::from_str(&bbox_text)
                 .map_err(|e| format!("Failed to parse bounding box: {e}"))?;
@@ -917,8 +917,17 @@ fn gui_start_generation(
             let world_path = PathBuf::from(&selected_world);
 
             // Determine world format from UI selection first (needed for session lock decision)
+
+            let luanti_game = if world_format.starts_with("luanti") {
+                Some(crate::luanti_block_map::LuantiGame::Mineclonia)
+            } else {
+                None
+            };
+
             let world_format = if world_format == "bedrock" {
                 WorldFormat::BedrockMcWorld
+            } else if world_format.starts_with("luanti") {
+                WorldFormat::LuantiWorld
             } else {
                 WorldFormat::JavaAnvil
             };
@@ -1002,6 +1011,24 @@ fn gui_start_generation(
                     progress::emit_world_name_update(&lvl_name);
                     (output_path, Some(lvl_name))
                 }
+                WorldFormat::LuantiWorld => {
+                    let worlds_dir = crate::world_utils::get_luanti_worlds_directory();
+                    let _ = std::fs::create_dir_all(&worlds_dir);
+                    let mut counter = 1;
+                    let world_name = loop {
+                        let candidate = format!("Arnis Luanti World {counter}");
+                        if !worlds_dir.join(&candidate).exists() {
+                            break candidate;
+                        }
+                        counter += 1;
+                    };
+                    let luanti_path = worlds_dir.join(&world_name);
+                    println!(
+                        "Creating Luanti world at: {}",
+                        luanti_path.display().to_string().bright_white().bold()
+                    );
+                    (luanti_path, Some(world_name))
+                }
             };
 
             // Calculate MC spawn coordinates from lat/lng if spawn point was provided
@@ -1035,6 +1062,8 @@ fn gui_start_generation(
                 format: world_format,
                 level_name,
                 spawn_point: mc_spawn_point,
+                luanti_game,
+                ground_level,
             };
 
             // Create an Args instance with the chosen bounding box
@@ -1049,6 +1078,7 @@ fn gui_start_generation(
                     world_path
                 }),
                 bedrock: world_format == WorldFormat::BedrockMcWorld,
+                luanti: world_format == WorldFormat::LuantiWorld,
                 downloader: "requests".to_string(),
                 scale: world_scale,
                 ground_level,

--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -656,6 +656,10 @@ button:hover {
   accent-color: #fecc44;
 }
 
+#enable-luanti-toggle {
+  accent-color: #fecc44;
+}
+
 #telemetry-toggle {
   accent-color: #fecc44;
 }

--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -310,7 +310,7 @@ button:hover {
   border-radius: 0 0 0 8px;
 }
 
-.format-toggle-btn:last-child {
+.format-toggle-btn.format-toggle-btn--rightmost {
   border-radius: 0 0 8px 0;
   border-left: 1px solid rgba(255, 255, 255, 0.15);
 }

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -203,8 +203,8 @@
         <!-- Enable Luanti (experimental) -->
         <div class="settings-row">
           <label for="enable-luanti-toggle">
-            <span data-localize="enable_luanti">Luanti (experimental)</span>
-            <span class="tooltip-icon" data-tooltip="Show Luanti (Mineclonia) as an output format. Experimental, block mappings and lighting may be imperfect.">?</span>
+            <span>Luanti (experimental)</span>
+            <span class="tooltip-icon" data-tooltip="Show Luanti (Mineclonia) as an output format. Experimental: block mappings and lighting may be imperfect.">?</span>
           </label>
           <div class="settings-control">
             <input type="checkbox" id="enable-luanti-toggle" name="enable-luanti-toggle">

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -47,6 +47,9 @@
                 <button type="button" id="format-bedrock" class="format-toggle-btn" onclick="setWorldFormat('bedrock')">
                   Bedrock
                 </button>
+                <button type="button" id="format-luanti" class="format-toggle-btn" onclick="setWorldFormat('luanti')" style="display: none;">
+                  Luanti
+                </button>
               </div>
             </div>
             <span id="bbox-selection-info" class="bbox-selection-text" data-localize="select_area_prompt">Select an area on the map using the tools.</span>
@@ -104,28 +107,6 @@
           </div>
         </div>
 
-        <!-- Interior Toggle Button -->
-        <div class="settings-row">
-          <label for="interior-toggle">
-            <span data-localize="interior">Interior Generation</span>
-            <span class="tooltip-icon" data-tooltip="Generate interior details inside buildings (experimental)">?</span>
-          </label>
-          <div class="settings-control">
-            <input type="checkbox" id="interior-toggle" name="interior-toggle">
-          </div>
-        </div>
-
-        <!-- Fill ground Toggle Button -->
-        <div class="settings-row">
-          <label for="fillground-toggle">
-            <span data-localize="fillground">Fill Ground</span>
-            <span class="tooltip-icon" data-tooltip="Fill the ground below the surface">?</span>
-          </label>
-          <div class="settings-control">
-            <input type="checkbox" id="fillground-toggle" name="fillground-toggle">
-          </div>
-        </div>
-
         <!-- Land Cover Toggle Button -->
         <div class="settings-row">
           <label for="land-cover-toggle">
@@ -145,6 +126,28 @@
           </label>
           <div class="settings-control">
             <input type="checkbox" id="use-3d-toggle" name="use-3d-toggle" checked>
+          </div>
+        </div>
+
+        <!-- Interior Toggle Button -->
+        <div class="settings-row">
+          <label for="interior-toggle">
+            <span data-localize="interior">Interior Generation</span>
+            <span class="tooltip-icon" data-tooltip="Generate interior details inside buildings (experimental)">?</span>
+          </label>
+          <div class="settings-control">
+            <input type="checkbox" id="interior-toggle" name="interior-toggle">
+          </div>
+        </div>
+
+        <!-- Fill ground Toggle Button -->
+        <div class="settings-row">
+          <label for="fillground-toggle">
+            <span data-localize="fillground">Fill Ground</span>
+            <span class="tooltip-icon" data-tooltip="Fill the ground below the surface">?</span>
+          </label>
+          <div class="settings-control">
+            <input type="checkbox" id="fillground-toggle" name="fillground-toggle">
           </div>
         </div>
 
@@ -194,6 +197,17 @@
           <div class="settings-control rotation-control">
             <input type="number" id="rotation-angle-input" min="-90" max="90" step="0.01" value="0">
             <span class="rotation-unit">&deg;</span>
+          </div>
+        </div>
+
+        <!-- Enable Luanti (experimental) -->
+        <div class="settings-row">
+          <label for="enable-luanti-toggle">
+            <span data-localize="enable_luanti">Luanti (experimental)</span>
+            <span class="tooltip-icon" data-tooltip="Show Luanti (Mineclonia) as an output format. Experimental, block mappings and lighting may be imperfect.">?</span>
+          </label>
+          <div class="settings-control">
+            <input type="checkbox" id="enable-luanti-toggle" name="enable-luanti-toggle">
           </div>
         </div>
 

--- a/src/gui/js/license.js
+++ b/src/gui/js/license.js
@@ -51,6 +51,18 @@ Land cover classification data provided by the <a href="https://esa-worldcover.o
 Bedrock Edition world format support uses the <a href="https://github.com/bedrock-crustaceans/bedrock-rs" style="color: inherit;" target="_blank">bedrock-rs</a> library, licensed under the Apache License 2.0.
 <br><br>
 
+<b>MC2MT:</b><br>
+The Luanti block mapping (<code>src/luanti_block_map.rs</code>) is derived from <a href="https://github.com/rollerozxa/MC2MT" style="color: inherit;" target="_blank">MC2MT</a> by rollerozxa. Licensed under <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html" style="color: inherit;" target="_blank">LGPL-2.1-or-later</a>.
+<br><br>
+
+<b>Mineclonia:</b><br>
+Generated Luanti worlds use the <a href="https://content.luanti.org/packages/Mineclonia/mineclonia/" style="color: inherit;" target="_blank">Mineclonia</a> game pack for Luanti. Mineclonia is independent of and not associated with Mojang or Microsoft.
+<br><br>
+
+<b>Luanti (formerly Minetest):</b><br>
+Luanti world export targets the <a href="https://www.luanti.org" style="color: inherit;" target="_blank">Luanti</a> engine, licensed under <a href="https://github.com/luanti-org/luanti/blob/master/LICENSE.txt" style="color: inherit;" target="_blank">LGPL-2.1+</a>.
+<br><br>
+
 <p><b>Third-Party JavaScript Libraries:</b></p>
 <p>The map picker bundles the following libraries:</p>
 

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -543,7 +543,7 @@ function initSettings() {
   });
   window.updateRotation = updateRotation;
 
-  // World format toggle (Java/Bedrock)
+  // World format toggle (Java/Bedrock/Luanti)
   initWorldFormatToggle();
 
   // Save path setting
@@ -676,31 +676,68 @@ function initSettings() {
   window.closeLicense = closeLicense;
 }
 
-// World format selection (Java/Bedrock)
+// World format selection (Java/Bedrock/Luanti)
 let selectedWorldFormat = 'java'; // Default to Java
 
+const VALID_FORMATS = ['java', 'bedrock', 'luanti'];
+
 function initWorldFormatToggle() {
-  // Load saved format preference
+  initLuantiExperimentalToggle();
+
   const savedFormat = localStorage.getItem('arnis-world-format');
-  if (savedFormat && (savedFormat === 'java' || savedFormat === 'bedrock')) {
+  if (savedFormat && VALID_FORMATS.includes(savedFormat)) {
     selectedWorldFormat = savedFormat;
   }
-  
-  // Apply the saved selection to UI
+  if (selectedWorldFormat === 'luanti' && !isLuantiEnabled()) {
+    selectedWorldFormat = 'java';
+  }
+
   updateFormatToggleUI(selectedWorldFormat);
 }
 
+function isLuantiEnabled() {
+  return localStorage.getItem('arnis-luanti-enabled') === 'true';
+}
+
+function initLuantiExperimentalToggle() {
+  const toggle = document.getElementById('enable-luanti-toggle');
+  const luantiBtn = document.getElementById('format-luanti');
+  if (!toggle || !luantiBtn) return;
+
+  const enabled = isLuantiEnabled();
+  toggle.checked = enabled;
+  luantiBtn.style.display = enabled ? '' : 'none';
+
+  toggle.addEventListener('change', () => {
+    const on = toggle.checked;
+    localStorage.setItem('arnis-luanti-enabled', on ? 'true' : 'false');
+    luantiBtn.style.display = on ? '' : 'none';
+    if (!on && selectedWorldFormat === 'luanti') {
+      setWorldFormat('java');
+    }
+  });
+}
+
 function setWorldFormat(format) {
-  if (format !== 'java' && format !== 'bedrock') return;
-  
+  if (!VALID_FORMATS.includes(format)) return;
+  if (format === 'luanti' && !isLuantiEnabled()) return;
+
   selectedWorldFormat = format;
   localStorage.setItem('arnis-world-format', format);
   updateFormatToggleUI(format);
 }
 
+function getEffectiveWorldFormat() {
+  if (selectedWorldFormat === 'luanti') {
+    return 'luanti_mineclonia';
+  }
+  return selectedWorldFormat;
+}
+
 function updateFormatToggleUI(format) {
   const javaBtn = document.getElementById('format-java');
   const bedrockBtn = document.getElementById('format-bedrock');
+  const luantiBtn = document.getElementById('format-luanti');
 
   const heightLimitToggle = document.getElementById('disable-height-limit-toggle');
 
@@ -710,13 +747,18 @@ function updateFormatToggleUI(format) {
     heightLimitToggle.parentElement.closest('.settings-row').style.opacity = '1';
   }
 
+  javaBtn.classList.remove('format-active');
+  bedrockBtn.classList.remove('format-active');
+  if (luantiBtn) luantiBtn.classList.remove('format-active');
+
   if (format === 'java') {
     javaBtn.classList.add('format-active');
-    bedrockBtn.classList.remove('format-active');
-  } else {
-    javaBtn.classList.remove('format-active');
+  } else if (format === 'bedrock') {
     bedrockBtn.classList.add('format-active');
     // Clear world path for bedrock (auto-generated)
+    worldPath = "";
+  } else if (format === 'luanti') {
+    if (luantiBtn) luantiBtn.classList.add('format-active');
     worldPath = "";
   }
 }
@@ -1359,7 +1401,7 @@ async function startGeneration() {
         isNewWorld: true,
         spawnPoint: spawnPoint,
         telemetryConsent: telemetryConsent || false,
-        worldFormat: selectedWorldFormat,
+        worldFormat: getEffectiveWorldFormat(),
         rotationAngle: rotationAngle
     });
 

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -702,16 +702,25 @@ function isLuantiEnabled() {
 function initLuantiExperimentalToggle() {
   const toggle = document.getElementById('enable-luanti-toggle');
   const luantiBtn = document.getElementById('format-luanti');
+  const bedrockBtn = document.getElementById('format-bedrock');
   if (!toggle || !luantiBtn) return;
+
+  const applyRightmost = (enabled) => {
+    luantiBtn.style.display = enabled ? '' : 'none';
+    luantiBtn.classList.toggle('format-toggle-btn--rightmost', enabled);
+    if (bedrockBtn) {
+      bedrockBtn.classList.toggle('format-toggle-btn--rightmost', !enabled);
+    }
+  };
 
   const enabled = isLuantiEnabled();
   toggle.checked = enabled;
-  luantiBtn.style.display = enabled ? '' : 'none';
+  applyRightmost(enabled);
 
   toggle.addEventListener('change', () => {
     const on = toggle.checked;
     localStorage.setItem('arnis-luanti-enabled', on ? 'true' : 'false');
-    luantiBtn.style.display = on ? '' : 'none';
+    applyRightmost(on);
     if (!on && selectedWorldFormat === 'luanti') {
       setWorldFormat('java');
     }

--- a/src/luanti_block_map.rs
+++ b/src/luanti_block_map.rs
@@ -1,0 +1,397 @@
+use crate::block_definitions::Block;
+use fastnbt::Value;
+
+/* * This file contains data converted from MC2MT.
+ * Original C++ Source Copyright (C) 2016 rollerozxa
+ * * Converted to Rust and modified by 3rd3 in 2026.
+ * * This file is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+/// Supported Luanti game pack
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LuantiGame {
+    /// Mineclonia — Minecraft-like game for Luanti
+    Mineclonia,
+}
+
+impl LuantiGame {
+    #[allow(dead_code)]
+    pub fn from_str(s: &str) -> Result<Self, String> {
+        match s {
+            "mineclonia" => Ok(Self::Mineclonia),
+            _ => Err(format!(
+                "Unknown Luanti game: '{}'. Supported: mineclonia",
+                s
+            )),
+        }
+    }
+
+    /// Returns the gameid string for world.mt
+    pub fn game_id(&self) -> &'static str {
+        match self {
+            Self::Mineclonia => "mineclonia",
+        }
+    }
+}
+
+/// A Luanti node with its name and param2 value
+pub struct LuantiNode {
+    pub name: &'static str,
+    pub param2: u8,
+}
+
+// ---------------------------------------------------------------------------
+// MC2MT-style conversion functions
+// ---------------------------------------------------------------------------
+// Ported from MC2MT's conversions.h (C macros → Rust functions).
+// Each function resolves block properties into a LuantiNode with both
+// the correct node name AND the correct facedir/wallmounted param2.
+
+/// MC facing direction → Luanti facedir (with Z-axis flip applied).
+///
+/// Minecraft:  Z+ = South, Z- = North
+/// Luanti:     Z+ = North, Z- = South
+///
+/// Facedir mapping:
+///   "north" (-Z_mc = +Z_lt) → 0
+///   "east"  (+X)             → 1
+///   "south" (+Z_mc = -Z_lt) → 2
+///   "west"  (-X)             → 3
+fn facing_to_facedir(facing: &str) -> u8 {
+    match facing {
+        "north" => 0,
+        "east" => 1,
+        "south" => 2,
+        "west" => 3,
+        _ => 0,
+    }
+}
+
+/// Read a string property from an optional NBT compound.
+fn prop_str<'a>(props: Option<&'a Value>, key: &str) -> Option<&'a str> {
+    match props {
+        Some(Value::Compound(map)) => match map.get(key) {
+            Some(Value::String(s)) => Some(s.as_str()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Check if a string property equals a specific value.
+fn prop_eq(props: Option<&Value>, key: &str, val: &str) -> bool {
+    prop_str(props, key) == Some(val)
+}
+
+/// MC2MT `CONV_TRAPDOOR` equivalent.
+///
+/// Resolves facing × open × half properties into (node_name, facedir param2).
+///
+/// MC2MT expands CONV_TRAPDOOR(id, mcn, mtn) into 16 CONV_DP entries:
+///   data 0–3   (closed, bottom) → mtn,       param2 = facedir
+///   data 4–7   (open,   bottom) → mtn_open,  param2 = facedir
+///   data 8–11  (closed, top)    → mtn,       param2 = facedir + 20
+///   data 12–15 (open,   top)    → mtn_open,  param2 = facedir + 20
+fn conv_trapdoor(props: Option<&Value>, closed: &'static str, open: &'static str) -> LuantiNode {
+    let facing = prop_str(props, "facing").unwrap_or("north");
+    let is_open = prop_eq(props, "open", "true");
+    let is_top = prop_eq(props, "half", "top");
+    let base = facing_to_facedir(facing);
+    let param2 = if is_top { base + 20 } else { base };
+    let name = if is_open { open } else { closed };
+    LuantiNode { name, param2 }
+}
+
+/// MC2MT `CONV_STAIR` equivalent.
+///
+/// MC2MT expands CONV_STAIR(id, mcn, mtn) into 8 CONV_DP entries:
+///   data 0–3 (bottom) → mtn, param2 = facedir
+///   data 4–7 (top)    → mtn, param2 = facedir + 20
+fn conv_stair(props: Option<&Value>, name: &'static str) -> LuantiNode {
+    let facing = prop_str(props, "facing").unwrap_or("north");
+    let is_top = prop_eq(props, "half", "top");
+    let base = facing_to_facedir(facing);
+    let param2 = if is_top { base + 20 } else { base };
+    LuantiNode { name, param2 }
+}
+
+/// MC2MT `CONV_SLAB` equivalent.
+///
+/// MC2MT expands CONV_SLAB(id, mcn, dbottom, dtop, mtn) into 2 entries:
+///   bottom → mtn,        param2 = 0
+///   top    → mtn "_top", param2 = 0
+#[allow(dead_code)]
+fn conv_slab(props: Option<&Value>, bottom: &'static str, top: &'static str) -> LuantiNode {
+    let name = if prop_eq(props, "type", "top") {
+        top
+    } else {
+        bottom
+    };
+    LuantiNode { name, param2: 0 }
+}
+
+/// Maps an Arnis Block to a Luanti node for the given game pack.
+///
+/// Directional blocks (stairs, trapdoors, etc.) use the optional `props`
+/// (Minecraft NBT block properties) to compute the correct `param2` value.
+pub fn to_luanti_node(block: Block, game: LuantiGame, props: Option<&Value>) -> LuantiNode {
+    match game {
+        LuantiGame::Mineclonia => to_mineclonia_node(block, props),
+    }
+}
+
+fn to_mineclonia_node(block: Block, props: Option<&Value>) -> LuantiNode {
+    let name = match block.id() {
+        1 => "air",
+        2 => "mcl_core:andesite",
+        3 => "mcl_trees:leaves_birch",
+        4 => "mcl_trees:tree_birch",
+        5 => "mcl_colorblocks:concrete_black",
+        6 => "mcl_blackstone:blackstone",
+        7 => "mcl_flowers:blue_orchid",
+        8 => "mcl_colorblocks:hardened_clay_blue",
+        9 => "mcl_core:brick_block",
+        10 => "mcl_cauldrons:cauldron",
+        11 => "mcl_core:stonebrickcarved",
+        12 => "mcl_walls:cobble",
+        13 => "mcl_core:cobble",
+        14 => "mcl_blackstone:blackstone_brick_polished",
+        15 => "mcl_core:stonebrickcracked",
+        16 => "mesecons_walllever:wall_lever_off", // LEVER
+        17 => return conv_stair(props, "mcl_stairs:stair_cobble"), // COBBLESTONE_STAIRS
+        18 => "mcl_colorblocks:concrete_cyan",
+        19 => "mcl_trees:wood_dark_oak",
+        20 => "mcl_deepslate:deepslate_bricks",
+        21 => "mcl_core:diorite",
+        22 => "mcl_core:dirt",
+        23 => "mcl_end:end_bricks",
+        24 => "mcl_farming:soil_wet",
+        25 => "mcl_core:glass",
+        26 => "mcl_nether:glowstone",
+        27 => "mcl_core:granite",
+        28 => "mcl_core:dirt_with_grass",
+        29 => "mcl_flowers:tallgrass",
+        30 => "mcl_core:gravel",
+        31 => "mcl_colorblocks:concrete_grey",
+        32 => "mcl_colorblocks:hardened_clay_grey",
+        33 => "mcl_colorblocks:hardened_clay_green",
+        34 => "mcl_wool:green",
+        35 => "mcl_farming:hay_block",
+        36 => "xpanes:bar_flat",
+        37 => "mcl_core:ironblock",
+        38 => return conv_stair(props, "mcl_copper:waxed_cut_stair"), // WAXED_CUT_COPPER_STAIRS
+        39 => "mcl_core:ladder",
+        40 => "mcl_colorblocks:concrete_light_blue",
+        41 => "mcl_colorblocks:hardened_clay_light_blue",
+        42 => "mcl_colorblocks:concrete_silver",
+        43 => "mcl_lush_caves:moss",
+        44 => "mcl_core:mossycobble",
+        45 => "mcl_mud:mud_bricks",
+        46 => "mcl_nether:nether_brick",
+        47 => "mcl_nether:netheriteblock",
+        48 => "mcl_fences:fence",
+        49 => "mcl_trees:leaves_oak",
+        50 => "mcl_trees:tree_oak",
+        51 => "mcl_trees:wood_oak",
+        52 => "mcl_stairs:slab_oak",
+        53 => "mcl_colorblocks:hardened_clay_orange",
+        54 => "mcl_core:podzol",
+        55 => "mcl_core:andesite_smooth",
+        56 => return conv_stair(props, "mcl_stairs:stair_stonebrickmossy"), // MOSSY_STONE_BRICK_STAIRS
+        57 => "mcl_nether:quartz_block",
+        58 => "mcl_blackstone:blackstone_polished",
+        59 => "mcl_deepslate:deepslate_polished",
+        60 => "mcl_core:diorite_smooth",
+        61 => "mcl_core:granite_smooth",
+        62 => return conv_stair(props, "mcl_stairs:stair_mossycobble"), // MOSSY_COBBLESTONE_STAIRS
+        63 => return conv_stair(props, "mcl_stairs:stair_deepslate_bricks"), // DEEPSLATE_BRICK_STAIRS
+        64 => return conv_stair(props, "mcl_stairs:stair_deepslate_polished"), // POLISHED_DEEPSLATE_STAIRS
+        65 => "mcl_nether:quartz_block",
+        66 => "mcl_minecarts:rail",
+        67 => "mcl_flowers:poppy",
+        68 => "mcl_nether:red_nether_brick",
+        69 => "mcl_colorblocks:hardened_clay_red",
+        70 => "mcl_wool:red",
+        71 => "mcl_core:sand",
+        72 => "mcl_core:sandstone",
+        73 => "mcl_bamboo:scaffolding",
+        74 => "mcl_nether:quartz_smooth",
+        75 => return conv_stair(props, "mcl_stairs:stair_spruce"), // SPRUCE_STAIRS
+        76 => "mcl_core:sandstonesmooth2",
+        77 => "mcl_stairs:slab_stone_double",
+        78 => "mcl_sponges:sponge",
+        79 => "mcl_trees:tree_spruce",
+        80 => "mcl_trees:wood_spruce",
+        81 => "mcl_stairs:slab_stone",
+        82 => "mcl_stairs:slab_stonebrick",
+        83 => "mcl_core:stonebrick",
+        84 => "mcl_core:stone",
+        85 => "mcl_colorblocks:hardened_clay",
+        86 => return conv_stair(props, "mcl_stairs:stair_dark_oak"), // DARK_OAK_STAIRS
+        87 => "mcl_core:water_source",
+        88 => "mcl_colorblocks:concrete_white",
+        89 => "mcl_flowers:azure_bluet",
+        90 => "mcl_core:glass_white",
+        91 => "mcl_colorblocks:hardened_clay_white",
+        92 => "mcl_wool:white",
+        93 => "mcl_colorblocks:concrete_yellow",
+        94 => "mcl_flowers:dandelion",
+        95 => "mcl_wool:yellow",
+        96 => "mcl_colorblocks:concrete_lime",
+        97 => return conv_stair(props, "mcl_stairs:stair_red_nether_brick"), // RED_NETHER_BRICK_STAIRS
+        98 => "mcl_colorblocks:concrete_blue",
+        99 => "mcl_colorblocks:concrete_purple",
+        100 => "mcl_colorblocks:concrete_red",
+        101 => "mcl_colorblocks:concrete_magenta",
+        102 => return conv_stair(props, "mcl_copper:waxed_oxidized_cut_stair"), // WAXED_OXIDIZED_CUT_COPPER_STAIRS
+        103 => "mcl_copper:block_oxidized", // WAXED_OXIDIZED_COPPER (waxed variant approximated as oxidized)
+        104 => "mcl_colorblocks:hardened_clay_yellow",
+        105 => "mcl_farming:carrot_7",
+        106 => "mcl_doors:dark_oak_door_b_1",
+        107 => "mcl_doors:dark_oak_door_t_1",
+        108 => "mcl_farming:potato_4",
+        109 => "mcl_farming:wheat_7",
+        110 => "mcl_core:bedrock",
+        111 => "mcl_core:snowblock",
+        112 => return conv_stair(props, "mcl_stairs:stair_andesite"), // ANDESITE_STAIRS
+        113 => "mcl_signs:wall_sign",
+        114 => "mcl_walls:andesite",
+        115 => "mcl_walls:stonebrick",
+        116..=125 => "mcl_minecarts:rail",
+        126 => "mcl_core:coarse_dirt",
+        127 => "mcl_core:stone_with_iron",
+        128 => "mcl_core:stone_with_coal",
+        129 => "mcl_core:stone_with_gold",
+        130 => "mcl_copper:stone_with_copper",
+        131 => "mcl_core:clay",
+        132 => "mcl_core:grass_path",
+        133 => return conv_stair(props, "mcl_copper:waxed_exposed_cut_stair"), // WAXED_EXPOSED_CUT_COPPER_STAIRS
+        134 => "mcl_core:packed_ice",
+        135 => "mcl_mud:mud",
+        136 => "mcl_core:deadbush",
+        137 => "mcl_flowers:double_grass",
+        138 => "mcl_flowers:double_grass_top",
+        139 => "mcl_crafting_table:crafting_table",
+        140 => "mcl_furnaces:furnace",
+        141 => "mcl_wool:white_carpet",
+        142 => "mcl_books:bookshelf",
+        143 => "mcl_trees:wood_oak",
+        144 => return conv_stair(props, "mcl_stairs:stair_oak"),
+        145 => "mcl_banners:hanging_banner_white", // WHITE_WALL_BANNER
+        146 => "mcl_banners:hanging_banner_blue",  // BLUE_WALL_BANNER
+        147 => "mcl_banners:hanging_banner_black", // BLACK_WALL_BANNER
+        148 => "mcl_banners:hanging_banner_red",   // RED_WALL_BANNER
+        149 => "mcl_banners:hanging_banner_green", // GREEN_WALL_BANNER
+        150 => "mcl_core:stonebrickmossy",         // MOSSY_STONE_BRICKS
+        151 => "mcl_deepslate:deepslate",          // DEEPSLATE
+        152 => "mcl_deepslate:tuff",               // TUFF
+        153 => "mcl_deepslate:deepslate_cobbled",  // COBBLED_DEEPSLATE
+        154 => "mcl_cauldrons:cauldron_3",         // WATER_CAULDRON (filled)
+        155 => "mcl_chests:chest",
+        156 => "mcl_wool:red_carpet",
+        157 => "mcl_anvils:anvil",
+        158 => "mcl_noteblock:noteblock",
+        159 => "mcl_doors:wooden_door_b_1",
+        160 => "mcl_brewing:stand_000",
+        161..=168 => "mcl_beds:bed_red_bottom",
+        169 => "mcl_core:glass_grey",
+        170 => "mcl_core:glass_silver",
+        171 => "mcl_core:glass_brown",
+        172 => "mcl_core:glass",
+        173 | 236 | 237 | 238 | 239 => {
+            return conv_trapdoor(props, "mcl_doors:trapdoor", "mcl_doors:trapdoor_open")
+        }
+        174 => "mcl_colorblocks:concrete_brown",
+        175 => "mcl_colorblocks:hardened_clay_black",
+        176 => "mcl_colorblocks:hardened_clay_brown",
+        177 => return conv_stair(props, "mcl_stairs:stair_stonebrick"),
+        178 => return conv_stair(props, "mcl_stairs:stair_mud_brick"),
+        179 => return conv_stair(props, "mcl_stairs:stair_blackstone_brick_polished"),
+        180 => return conv_stair(props, "mcl_stairs:stair_brick_block"),
+        181 => return conv_stair(props, "mcl_stairs:stair_granite_smooth"),
+        182 => return conv_stair(props, "mcl_stairs:stair_end_bricks"),
+        183 => return conv_stair(props, "mcl_stairs:stair_diorite_smooth"),
+        184 => return conv_stair(props, "mcl_stairs:stair_sandstone"),
+        185 => return conv_stair(props, "mcl_stairs:stair_quartzblock"),
+        186 => return conv_stair(props, "mcl_stairs:stair_andesite_smooth"),
+        187 => return conv_stair(props, "mcl_stairs:stair_nether_brick"),
+        188 => "mcl_barrels:barrel_closed",
+        189 => "mcl_flowers:fern",
+        190 => "mcl_core:cobweb",
+        191..=194 => "mcl_books:bookshelf",
+        195 => "mcl_copper:block", // WAXED_COPPER_BLOCK
+        196 => "mcl_anvils:anvil_damage_2",
+        197 => "mcl_flowers:double_fern",
+        198 => "mcl_flowers:double_fern_top",
+        199 => "mcl_copper:block_exposed", // WAXED_EXPOSED_COPPER
+        200 => "mcl_end:end_rod",
+        201 => "mcl_lightning_rods:rod",
+        202 => "mcl_core:goldblock",
+        203 => "mcl_ocean:sea_lantern",
+        204 => "mcl_copper:block_chiseled_exposed", // WAXED_EXPOSED_CHISELED_COPPER
+        205 => "mcl_wool:orange",
+        206 => "mcl_wool:blue",
+        207 => "mcl_colorblocks:concrete_green",
+        208 => "mcl_walls:brick",
+        209 => "mcl_redstone_torch:redstoneblock",
+        210..=211 => "mcl_lanterns:chain",
+        212 => "mcl_doors:spruce_door_b_1",
+        213 => "mcl_doors:spruce_door_t_1",
+        214 => "mcl_stairs:slab_stone_double",
+        215 => "mcl_copper:block_cut_exposed", // WAXED_EXPOSED_CUT_COPPER
+        216 => "mcl_colorblocks:hardened_clay_silver",
+        217 => "mcl_stairs:slab_oak",
+        218 => "mcl_doors:wooden_door_b_1",
+        219 => "mcl_trees:tree_dark_oak",
+        220 => "mcl_trees:leaves_dark_oak",
+        221 => "mcl_trees:tree_jungle",
+        222 => "mcl_trees:leaves_jungle",
+        223 => "mcl_trees:tree_acacia",
+        224 => "mcl_trees:leaves_acacia",
+        225 => "mcl_trees:leaves_spruce",
+        226 => "mcl_core:glass_cyan",
+        227 => "mcl_core:glass_blue",
+        228 => "mcl_core:glass_light_blue",
+        229 => "mcl_daylight_detector:daylight_detector",
+        230 => "mcl_cherry_blossom:cherrytree", // CHERRY_LOG (Mineclonia may not have cherry yet)
+        231 => "mcl_cherry_blossom:leaves",     // CHERRY_LEAVES (fallback if cherry missing)
+        232 => "mcl_colorblocks:concrete_powder_brown", // BROWN_CONCRETE_POWDER
+        235 => "mcl_flowers:poppy",
+        240 => "mcl_stairs:slab_quartzblock",
+        241 => {
+            return conv_trapdoor(
+                props,
+                "mcl_doors:dark_oak_trapdoor",
+                "mcl_doors:dark_oak_trapdoor_open",
+            )
+        }
+        242 => {
+            return conv_trapdoor(
+                props,
+                "mcl_doors:spruce_trapdoor",
+                "mcl_doors:spruce_trapdoor_open",
+            )
+        }
+        243 => {
+            return conv_trapdoor(
+                props,
+                "mcl_doors:birch_trapdoor",
+                "mcl_doors:birch_trapdoor_open",
+            )
+        }
+        244 => "mcl_stairs:slab_mud_brick",
+        245 => "mcl_stairs:slab_brick_block",
+        246 => "mcl_flowers:tulip_red",
+        247 => "mcl_flowers:dandelion",
+        248 => "mcl_flowers:blue_orchid",
+        252 => "mcl_colorblocks:concrete_powder_grey", // GRAY_CONCRETE_POWDER
+        253 => "mcl_colorblocks:hardened_clay_cyan",   // CYAN_TERRACOTTA
+        254 => "mcl_wool:black",                       // BLACK_WOOL
+        255 => "mcl_banners:hanging_banner_silver",    // LIGHT_GRAY_WALL_BANNER
+        _ => "mcl_core:stone",
+    };
+    LuantiNode { name, param2: 0 }
+}

--- a/src/luanti_block_map.rs
+++ b/src/luanti_block_map.rs
@@ -18,17 +18,6 @@ pub enum LuantiGame {
 }
 
 impl LuantiGame {
-    #[allow(dead_code)]
-    pub fn from_str(s: &str) -> Result<Self, String> {
-        match s {
-            "mineclonia" => Ok(Self::Mineclonia),
-            _ => Err(format!(
-                "Unknown Luanti game: '{}'. Supported: mineclonia",
-                s
-            )),
-        }
-    }
-
     /// Returns the gameid string for world.mt
     pub fn game_id(&self) -> &'static str {
         match self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod args;
-#[cfg(feature = "bedrock")]
 mod bedrock_block_map;
 mod block_definitions;
 mod bresenham;
@@ -97,15 +96,6 @@ fn run_cli() {
     // Validate arguments (path requirements differ between Java and Bedrock)
     if let Err(e) = args::validate_args(&args) {
         eprintln!("{}: {}", "Error".red().bold(), e);
-        std::process::exit(1);
-    }
-
-    // Early guard: --bedrock requires the bedrock cargo feature
-    if args.bedrock && !cfg!(feature = "bedrock") {
-        eprintln!(
-            "{}: The --bedrock flag requires the 'bedrock' feature. Rebuild with: cargo build --features bedrock",
-            "Error".red().bold()
-        );
         std::process::exit(1);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod ground_generation;
 mod land_cover;
 mod land_cover_bridge_repair;
 mod land_cover_osm_water_override;
+mod luanti_block_map;
 mod map_renderer;
 mod map_transformation;
 mod models_3d;
@@ -111,6 +112,8 @@ fn run_cli() {
     // Determine world format and output path
     let world_format = if args.bedrock {
         world_editor::WorldFormat::BedrockMcWorld
+    } else if args.luanti {
+        world_editor::WorldFormat::LuantiWorld
     } else {
         world_editor::WorldFormat::JavaAnvil
     };
@@ -124,6 +127,26 @@ fn run_cli() {
             .unwrap_or_else(world_utils::get_bedrock_output_directory);
         let (output_path, lvl_name) = world_utils::build_bedrock_output(&args.bbox, output_dir);
         (output_path, Some(lvl_name))
+    } else if args.luanti {
+        let base_dir = args
+            .path
+            .clone()
+            .unwrap_or_else(world_utils::get_luanti_worlds_directory);
+        let _ = std::fs::create_dir_all(&base_dir);
+        let mut counter = 1;
+        let world_name = loop {
+            let candidate = format!("Arnis Luanti World {counter}");
+            if !base_dir.join(&candidate).exists() {
+                break candidate;
+            }
+            counter += 1;
+        };
+        let world_path = base_dir.join(&world_name);
+        println!(
+            "Creating Luanti world at: {}",
+            world_path.display().to_string().bright_white().bold()
+        );
+        (world_path, Some(world_name))
     } else {
         // Java: create a new world in the provided output directory
         let base_dir = args.path.clone().unwrap();
@@ -284,11 +307,19 @@ fn run_cli() {
     });
 
     // Build generation options
+    let luanti_game = if args.luanti {
+        Some(luanti_block_map::LuantiGame::Mineclonia)
+    } else {
+        None
+    };
+
     let generation_options = data_processing::GenerationOptions {
         path: generation_path.clone(),
         format: world_format,
         level_name,
         spawn_point,
+        luanti_game,
+        ground_level: args.ground_level,
     };
 
     // Generate world

--- a/src/world_editor/luanti.rs
+++ b/src/world_editor/luanti.rs
@@ -3,7 +3,7 @@ use crate::coordinate_system::cartesian::XZBBox;
 use crate::coordinate_system::geographic::LLBBox;
 use crate::luanti_block_map::{to_luanti_node, LuantiGame};
 use crate::progress::emit_gui_progress_update;
-use crate::world_editor::common::WorldToModify;
+use crate::world_editor::common::{WorldToModify, MIN_Y};
 use colored::Colorize;
 use fastnbt::Value;
 use rayon::prelude::*;
@@ -167,17 +167,10 @@ fn serialize_mapblock(
 }
 
 /// Find a spawn position that is outdoors on solid ground.
-/// Spirals outward from (center_x, center_z) looking for a column where
-/// there is solid ground (not trees/leaves) with air above.
-fn find_safe_spawn(
-    world: &WorldToModify,
-    center_x: i32,
-    center_z: i32,
-    ground_level: i32,
-) -> (i32, i32, i32) {
+/// Trees, leaves and other plants that shouldn't be a spawn surface.
+fn non_ground_blocks() -> [crate::block_definitions::Block; 12] {
     use crate::block_definitions::*;
-    // Blocks to avoid spawning on (trees, leaves, vegetation)
-    let non_ground = [
+    [
         OAK_LOG,
         OAK_LEAVES,
         BIRCH_LOG,
@@ -190,30 +183,34 @@ fn find_safe_spawn(
         ACACIA_LEAVES,
         SPRUCE_LOG,
         SPRUCE_LEAVES,
-    ];
+    ]
+}
 
-    // Scan range: from ground_level up to ground_level + 400 to cover elevation
+/// Spirals outward from (center_x, center_z) looking for a column where
+/// there is solid ground (not trees/leaves) with air above.
+fn find_safe_spawn(
+    world: &WorldToModify,
+    center_x: i32,
+    center_z: i32,
+    ground_level: i32,
+) -> (i32, i32, i32) {
+    use crate::block_definitions::*;
+    let non_ground = non_ground_blocks();
     let y_max = ground_level + 400;
     for radius in 0i32..=40 {
         for dx in -radius..=radius {
             for dz in -radius..=radius {
                 if dx.abs() != radius && dz.abs() != radius {
-                    continue; // only check perimeter
+                    continue;
                 }
                 let x = center_x + dx;
                 let z = center_z + dz;
-                // Scan from top down to find the highest solid block
                 for y in (ground_level..=y_max).rev() {
                     let block = world.get_block(x, y, z);
                     if let Some(b) = block {
-                        if b == AIR {
+                        if b == AIR || non_ground.contains(&b) {
                             continue;
                         }
-                        // Skip tree/leaf blocks — keep scanning down
-                        if non_ground.contains(&b) {
-                            continue;
-                        }
-                        // Found solid ground — check air above
                         let above1 = world.get_block(x, y + 1, z);
                         let above2 = world.get_block(x, y + 2, z);
                         if (above1.is_none()
@@ -225,17 +222,17 @@ fn find_safe_spawn(
                         {
                             return (x, y + 1, z);
                         }
-                        break; // solid non-tree block but enclosed, try next column
+                        break;
                     }
                 }
             }
         }
     }
-    // Fallback: center, above ground
     (center_x, ground_level + 3, center_z)
 }
 
 /// Single-column spawn-Y lookup used when an explicit spawn (x, z) is given.
+/// Scans a wide vertical range so columns below ground_level (e.g. ocean) still resolve.
 fn find_spawn_y_at_column(
     world: &WorldToModify,
     x: i32,
@@ -243,21 +240,10 @@ fn find_spawn_y_at_column(
     ground_level: i32,
 ) -> (i32, i32, i32) {
     use crate::block_definitions::*;
-    let non_ground = [
-        OAK_LOG,
-        OAK_LEAVES,
-        BIRCH_LOG,
-        BIRCH_LEAVES,
-        DARK_OAK_LOG,
-        DARK_OAK_LEAVES,
-        JUNGLE_LOG,
-        JUNGLE_LEAVES,
-        ACACIA_LOG,
-        ACACIA_LEAVES,
-        SPRUCE_LOG,
-        SPRUCE_LEAVES,
-    ];
-    for y in (ground_level..=ground_level + 400).rev() {
+    let non_ground = non_ground_blocks();
+    let y_min = (ground_level - 100).max(MIN_Y);
+    let y_max = ground_level + 400;
+    for y in (y_min..=y_max).rev() {
         if let Some(b) = world.get_block(x, y, z) {
             if b == AIR || non_ground.contains(&b) {
                 continue;
@@ -429,6 +415,11 @@ fn write_worldmod(
         "-- (overrides game-specific spawn handlers like Mineclonia's)"
     )?;
     writeln!(f, "minetest.register_on_joinplayer(function(player)")?;
+    writeln!(f, "    local name = player:get_player_name()")?;
+    writeln!(f, "    local privs = minetest.get_player_privs(name)")?;
+    writeln!(f, "    privs.fast = true")?;
+    writeln!(f, "    privs.fly = true")?;
+    writeln!(f, "    minetest.set_player_privs(name, privs)")?;
     writeln!(f, "    minetest.after(0.5, function()")?;
     writeln!(f, "        if player:is_player() then")?;
     writeln!(f, "            player:set_pos(SPAWN)")?;
@@ -443,17 +434,6 @@ fn write_worldmod(
     writeln!(f, "        end")?;
     writeln!(f, "    end)")?;
     writeln!(f, "    return true")?;
-    writeln!(f, "end)")?;
-    writeln!(f)?;
-
-    // Grant fast and fly privileges to all joining players
-    writeln!(f, "-- Grant fast and fly privileges")?;
-    writeln!(f, "minetest.register_on_joinplayer(function(player)")?;
-    writeln!(f, "    local name = player:get_player_name()")?;
-    writeln!(f, "    local privs = minetest.get_player_privs(name)")?;
-    writeln!(f, "    privs.fast = true")?;
-    writeln!(f, "    privs.fly = true")?;
-    writeln!(f, "    minetest.set_player_privs(name, privs)")?;
     writeln!(f, "end)")?;
     writeln!(f)?;
 

--- a/src/world_editor/luanti.rs
+++ b/src/world_editor/luanti.rs
@@ -233,6 +233,7 @@ fn find_safe_spawn(
 
 /// Single-column spawn-Y lookup used when an explicit spawn (x, z) is given.
 /// Scans a wide vertical range so columns below ground_level (e.g. ocean) still resolve.
+/// Requires 2 blocks of air clearance above to avoid spawning embedded in a wall/roof.
 fn find_spawn_y_at_column(
     world: &WorldToModify,
     x: i32,
@@ -243,12 +244,17 @@ fn find_spawn_y_at_column(
     let non_ground = non_ground_blocks();
     let y_min = (ground_level - 100).max(MIN_Y);
     let y_max = ground_level + 400;
+    let clear = |b: Option<crate::block_definitions::Block>| -> bool {
+        b.is_none() || b == Some(AIR) || non_ground.contains(&b.unwrap())
+    };
     for y in (y_min..=y_max).rev() {
         if let Some(b) = world.get_block(x, y, z) {
             if b == AIR || non_ground.contains(&b) {
                 continue;
             }
-            return (x, y + 1, z);
+            if clear(world.get_block(x, y + 1, z)) && clear(world.get_block(x, y + 2, z)) {
+                return (x, y + 1, z);
+            }
         }
     }
     (x, ground_level + 3, z)

--- a/src/world_editor/luanti.rs
+++ b/src/world_editor/luanti.rs
@@ -40,7 +40,7 @@ fn serialize_mapblock(
     block_z: i32,
     section: &crate::world_editor::common::SectionToModify,
     game: LuantiGame,
-) -> (i64, Vec<u8>) {
+) -> std::io::Result<(i64, Vec<u8>)> {
     // Build name-ID mapping: collect unique node names in this mapblock
     let mut name_to_local_id: std::collections::HashMap<&'static str, u16> =
         std::collections::HashMap::new();
@@ -157,17 +157,13 @@ fn serialize_mapblock(
     buf.push(10); // data length per timer (2 + 4 + 4)
     buf.extend_from_slice(&0u16.to_be_bytes()); // count = 0
 
-    // Compress the entire buffer with zstd
-    let compressed =
-        zstd::bulk::compress(&buf, 3).expect("zstd compression failed for mapblock data");
-
-    // Final blob: version byte + compressed data
+    let compressed = zstd::bulk::compress(&buf, 3)?;
     let mut blob = Vec::with_capacity(1 + compressed.len());
     blob.push(MAP_FORMAT_VERSION);
     blob.extend_from_slice(&compressed);
 
     let pos = encode_block_pos(block_x, block_y, block_z);
-    (pos, blob)
+    Ok((pos, blob))
 }
 
 /// Find a spawn position that is outdoors on solid ground.
@@ -239,6 +235,39 @@ fn find_safe_spawn(
     (center_x, ground_level + 3, center_z)
 }
 
+/// Single-column spawn-Y lookup used when an explicit spawn (x, z) is given.
+fn find_spawn_y_at_column(
+    world: &WorldToModify,
+    x: i32,
+    z: i32,
+    ground_level: i32,
+) -> (i32, i32, i32) {
+    use crate::block_definitions::*;
+    let non_ground = [
+        OAK_LOG,
+        OAK_LEAVES,
+        BIRCH_LOG,
+        BIRCH_LEAVES,
+        DARK_OAK_LOG,
+        DARK_OAK_LEAVES,
+        JUNGLE_LOG,
+        JUNGLE_LEAVES,
+        ACACIA_LOG,
+        ACACIA_LEAVES,
+        SPRUCE_LOG,
+        SPRUCE_LEAVES,
+    ];
+    for y in (ground_level..=ground_level + 400).rev() {
+        if let Some(b) = world.get_block(x, y, z) {
+            if b == AIR || non_ground.contains(&b) {
+                continue;
+            }
+            return (x, y + 1, z);
+        }
+    }
+    (x, ground_level + 3, z)
+}
+
 /// Creates all Luanti world files and writes the map database.
 #[allow(clippy::too_many_arguments)]
 pub fn save_luanti_world(
@@ -257,15 +286,14 @@ pub fn save_luanti_world(
     // Create world directory if needed
     fs::create_dir_all(world_dir)?;
 
-    // Determine spawn coordinates — find an outdoor position
-    let (base_x, base_z) = if let Some((sx, sz)) = spawn_point {
-        (sx, sz)
+    let (spawn_x, spawn_y, spawn_z) = if let Some((sx, sz)) = spawn_point {
+        // Explicit spawn: only scan the single column, no perimeter search.
+        find_spawn_y_at_column(world, sx, sz, ground_level)
     } else {
         let cx = (xzbbox.min_x() + xzbbox.max_x()) / 2;
         let cz = (xzbbox.min_z() + xzbbox.max_z()) / 2;
-        (cx, cz)
+        find_safe_spawn(world, cx, cz, ground_level)
     };
-    let (spawn_x, spawn_y, spawn_z) = find_safe_spawn(world, base_x, base_z, ground_level);
 
     // Convert spawn Z from internal (Z+ = South) to Luanti (Z+ = North)
     let spawn_z = -spawn_z - 1;
@@ -497,7 +525,7 @@ fn write_worldmod(
 
 /// Serialize an air-only mapblock with full sunlight.
 /// Used to place sky blocks above the world so the engine can propagate sun downward.
-fn serialize_air_mapblock(game: LuantiGame) -> Vec<u8> {
+fn serialize_air_mapblock(game: LuantiGame) -> std::io::Result<Vec<u8>> {
     let air_name = to_luanti_node(AIR, game, None).name;
 
     let mut buf: Vec<u8> = Vec::with_capacity(4096);
@@ -537,12 +565,11 @@ fn serialize_air_mapblock(game: LuantiGame) -> Vec<u8> {
     buf.push(10);
     buf.extend_from_slice(&0u16.to_be_bytes());
 
-    // Compress with zstd, prepend version byte
-    let compressed = zstd::bulk::compress(&buf, 3).expect("zstd compression failed");
+    let compressed = zstd::bulk::compress(&buf, 3)?;
     let mut blob = Vec::with_capacity(1 + compressed.len());
     blob.push(MAP_FORMAT_VERSION);
     blob.extend_from_slice(&compressed);
-    blob
+    Ok(blob)
 }
 
 fn write_map_database(
@@ -607,15 +634,13 @@ fn write_map_database(
         block_entries.len().to_string().bold()
     );
 
-    // Serialize mapblocks in parallel
     let serialized: Vec<(i64, Vec<u8>)> = block_entries
         .par_iter()
         .map(|&(bx, by, bz, section)| serialize_mapblock(bx, by, bz, section, game))
-        .collect();
+        .collect::<std::io::Result<Vec<_>>>()?;
 
-    // Generate air-only mapblocks above the world (2 extra layers) so the engine
-    // can propagate sunlight down into the content blocks.
-    let air_blob = serialize_air_mapblock(game);
+    // Air mapblocks above the world so the engine can propagate sunlight down.
+    let air_blob = serialize_air_mapblock(game)?;
     let mut air_blocks: Vec<(i64, Vec<u8>)> = Vec::new();
     for extra_y in 1..=2 {
         let ay = mb_max_y + extra_y;
@@ -668,6 +693,6 @@ mod tests {
     fn test_encode_block_pos_negative() {
         // Negative coordinates should work with signed arithmetic
         let pos = encode_block_pos(-1, -1, -1);
-        assert_eq!(pos, (-1i64) * 0x1000000 + (-1i64) * 0x1000 + (-1i64));
+        assert_eq!(pos, -0x1000000_i64 - 0x1000_i64 - 1);
     }
 }

--- a/src/world_editor/luanti.rs
+++ b/src/world_editor/luanti.rs
@@ -1,0 +1,673 @@
+use crate::block_definitions::AIR;
+use crate::coordinate_system::cartesian::XZBBox;
+use crate::coordinate_system::geographic::LLBBox;
+use crate::luanti_block_map::{to_luanti_node, LuantiGame};
+use crate::progress::emit_gui_progress_update;
+use crate::world_editor::common::WorldToModify;
+use colored::Colorize;
+use fastnbt::Value;
+use rayon::prelude::*;
+use rusqlite::Connection;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+/// Mapblock format version — 29 uses zstd compression for the entire block
+const MAP_FORMAT_VERSION: u8 = 29;
+
+/// 16×16×16 nodes per mapblock
+const NODES_PER_BLOCK: usize = 16 * 16 * 16;
+
+/// Encode a mapblock position (x, y, z) into the SQLite integer key.
+///
+/// Uses the legacy single-integer encoding for compatibility with Luanti 5.5.0+:
+/// `pos = z * 0x1000000 + y * 0x1000 + x`
+fn encode_block_pos(x: i32, y: i32, z: i32) -> i64 {
+    (z as i64) * 0x1000000 + (y as i64) * 0x1000 + (x as i64)
+}
+
+/// Serialize a mapblock into the v29 binary format (zstd-compressed).
+///
+/// The mapblock contains 16×16×16 nodes. Each node has:
+/// - param0: content ID (u16) — mapped to block-local IDs via name-id mapping
+/// - param1: lighting (u8) — lower nibble = day light, upper nibble = night light
+/// - param2: rotation/facedir (u8)
+///
+/// Returns `(encoded_pos, blob)` ready for SQLite insertion.
+fn serialize_mapblock(
+    block_x: i32,
+    block_y: i32,
+    block_z: i32,
+    section: &crate::world_editor::common::SectionToModify,
+    game: LuantiGame,
+) -> (i64, Vec<u8>) {
+    // Build name-ID mapping: collect unique node names in this mapblock
+    let mut name_to_local_id: std::collections::HashMap<&'static str, u16> =
+        std::collections::HashMap::new();
+    let mut local_id_to_name: Vec<&str> = Vec::new();
+
+    // Pre-populate with air (always ID 0 for efficiency)
+    let air_node = to_luanti_node(AIR, game, None);
+    name_to_local_id.insert(air_node.name, 0);
+    local_id_to_name.push(air_node.name);
+
+    // Arrays for the 4096 nodes
+    let mut param0 = vec![0u16; NODES_PER_BLOCK];
+    let mut param1 = vec![0u8; NODES_PER_BLOCK];
+    let mut param2 = vec![0u8; NODES_PER_BLOCK];
+
+    // SectionToModify uses (u8,u8,u8) get_block returning Option<Block>
+    // Luanti serialization order is ZYX (z varies slowest)
+    // Luanti Z+ = North, but internal data has Z+ = South (Minecraft convention).
+    // We flip Z within each mapblock: serialized z reads from internal (15 - z).
+    for sz in 0u8..16 {
+        for y in 0u8..16 {
+            for x in 0u8..16 {
+                let serial_idx = (sz as usize) * 256 + (y as usize) * 16 + (x as usize); // ZYX
+                let internal_z = 15 - sz;
+
+                let block = section.get_block(x, y, internal_z).unwrap_or(AIR);
+                let props_idx =
+                    crate::world_editor::common::SectionToModify::index(x, y, internal_z);
+                let props = section.properties.get(&props_idx).map(|v| v as &Value);
+                let node = to_luanti_node(block, game, props);
+
+                let local_id = if let Some(&id) = name_to_local_id.get(node.name) {
+                    id
+                } else {
+                    let id = local_id_to_name.len() as u16;
+                    name_to_local_id.insert(node.name, id);
+                    local_id_to_name.push(node.name);
+                    id
+                };
+
+                param0[serial_idx] = local_id;
+                param2[serial_idx] = node.param2;
+            }
+        }
+    }
+
+    // Intra-mapblock sunlight propagation: for each (x,z) column, scan top-down.
+    // If we encounter air, it gets full sunlight (day=15). Once we hit a solid
+    // (non-air) block, all air below it is dark (day=0). This is a heuristic that
+    // works correctly for roofed buildings and underground spaces within one mapblock.
+    // Cross-mapblock boundaries are handled by the engine via lighting_complete flags.
+    for sz in 0u8..16 {
+        for x in 0u8..16 {
+            let mut has_sunlight = true;
+            for y in (0u8..16).rev() {
+                let idx = (sz as usize) * 256 + (y as usize) * 16 + (x as usize);
+                if param0[idx] == 0 {
+                    // Air node: gets sunlight if no solid block above in this mapblock
+                    param1[idx] = if has_sunlight { 15 } else { 0 };
+                } else {
+                    // Solid block: blocks sunlight, param1 stays 0
+                    has_sunlight = false;
+                }
+            }
+        }
+    }
+
+    // Build the uncompressed mapblock buffer (everything after the version byte)
+    let mut buf: Vec<u8> = Vec::with_capacity(16384);
+
+    // flags: is_underground (blocks below y=-1), day_night_differs, generated
+    let mut flags: u8 = 0x02 | 0x08; // day_night_differs + generated
+    if block_y < -1 {
+        flags |= 0x01; // is_underground
+    }
+    buf.push(flags);
+
+    // lighting_complete: upper 4 "nothing" bits must always be set per spec;
+    // lower 12 boundary flags cleared = engine recalculates boundary lighting.
+    buf.extend_from_slice(&0xF000u16.to_be_bytes());
+
+    // timestamp
+    buf.extend_from_slice(&0xFFFFFFFFu32.to_be_bytes());
+
+    // name-id mapping (v29: comes before node data)
+    buf.push(0); // name_id_mapping_version
+    buf.extend_from_slice(&(local_id_to_name.len() as u16).to_be_bytes());
+    for (i, name) in local_id_to_name.iter().enumerate() {
+        buf.extend_from_slice(&(i as u16).to_be_bytes());
+        buf.extend_from_slice(&(name.len() as u16).to_be_bytes());
+        buf.extend_from_slice(name.as_bytes());
+    }
+
+    // content_width and params_width
+    buf.push(2); // content_width (u16 per node)
+    buf.push(2); // params_width (param1 + param2)
+
+    // Node data: param0 (u16 BE), param1 (u8), param2 (u8) — all in ZYX order
+    for &p0 in &param0 {
+        buf.extend_from_slice(&p0.to_be_bytes());
+    }
+    buf.extend_from_slice(&param1);
+    buf.extend_from_slice(&param2);
+
+    // Node metadata: empty (version 2, count 0)
+    buf.push(2); // metadata version
+    buf.extend_from_slice(&0u16.to_be_bytes()); // count = 0
+
+    // Static objects
+    buf.push(0); // version
+    buf.extend_from_slice(&0u16.to_be_bytes()); // count = 0
+
+    // Node timers (v25+ format, placed after static objects in v29)
+    buf.push(10); // data length per timer (2 + 4 + 4)
+    buf.extend_from_slice(&0u16.to_be_bytes()); // count = 0
+
+    // Compress the entire buffer with zstd
+    let compressed =
+        zstd::bulk::compress(&buf, 3).expect("zstd compression failed for mapblock data");
+
+    // Final blob: version byte + compressed data
+    let mut blob = Vec::with_capacity(1 + compressed.len());
+    blob.push(MAP_FORMAT_VERSION);
+    blob.extend_from_slice(&compressed);
+
+    let pos = encode_block_pos(block_x, block_y, block_z);
+    (pos, blob)
+}
+
+/// Find a spawn position that is outdoors on solid ground.
+/// Spirals outward from (center_x, center_z) looking for a column where
+/// there is solid ground (not trees/leaves) with air above.
+fn find_safe_spawn(
+    world: &WorldToModify,
+    center_x: i32,
+    center_z: i32,
+    ground_level: i32,
+) -> (i32, i32, i32) {
+    use crate::block_definitions::*;
+    // Blocks to avoid spawning on (trees, leaves, vegetation)
+    let non_ground = [
+        OAK_LOG,
+        OAK_LEAVES,
+        BIRCH_LOG,
+        BIRCH_LEAVES,
+        DARK_OAK_LOG,
+        DARK_OAK_LEAVES,
+        JUNGLE_LOG,
+        JUNGLE_LEAVES,
+        ACACIA_LOG,
+        ACACIA_LEAVES,
+        SPRUCE_LOG,
+        SPRUCE_LEAVES,
+    ];
+
+    // Scan range: from ground_level up to ground_level + 400 to cover elevation
+    let y_max = ground_level + 400;
+    for radius in 0i32..=40 {
+        for dx in -radius..=radius {
+            for dz in -radius..=radius {
+                if dx.abs() != radius && dz.abs() != radius {
+                    continue; // only check perimeter
+                }
+                let x = center_x + dx;
+                let z = center_z + dz;
+                // Scan from top down to find the highest solid block
+                for y in (ground_level..=y_max).rev() {
+                    let block = world.get_block(x, y, z);
+                    if let Some(b) = block {
+                        if b == AIR {
+                            continue;
+                        }
+                        // Skip tree/leaf blocks — keep scanning down
+                        if non_ground.contains(&b) {
+                            continue;
+                        }
+                        // Found solid ground — check air above
+                        let above1 = world.get_block(x, y + 1, z);
+                        let above2 = world.get_block(x, y + 2, z);
+                        if (above1.is_none()
+                            || above1 == Some(AIR)
+                            || non_ground.contains(&above1.unwrap()))
+                            && (above2.is_none()
+                                || above2 == Some(AIR)
+                                || non_ground.contains(&above2.unwrap()))
+                        {
+                            return (x, y + 1, z);
+                        }
+                        break; // solid non-tree block but enclosed, try next column
+                    }
+                }
+            }
+        }
+    }
+    // Fallback: center, above ground
+    (center_x, ground_level + 3, center_z)
+}
+
+/// Creates all Luanti world files and writes the map database.
+#[allow(clippy::too_many_arguments)]
+pub fn save_luanti_world(
+    world: &WorldToModify,
+    world_dir: &Path,
+    xzbbox: &XZBBox,
+    _llbbox: &LLBBox,
+    game: LuantiGame,
+    level_name: Option<&str>,
+    spawn_point: Option<(i32, i32)>,
+    ground_level: i32,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    println!("{} Saving Luanti world...", "[7/7]".bold());
+    emit_gui_progress_update(90.0, "Saving Luanti world...");
+
+    // Create world directory if needed
+    fs::create_dir_all(world_dir)?;
+
+    // Determine spawn coordinates — find an outdoor position
+    let (base_x, base_z) = if let Some((sx, sz)) = spawn_point {
+        (sx, sz)
+    } else {
+        let cx = (xzbbox.min_x() + xzbbox.max_x()) / 2;
+        let cz = (xzbbox.min_z() + xzbbox.max_z()) / 2;
+        (cx, cz)
+    };
+    let (spawn_x, spawn_y, spawn_z) = find_safe_spawn(world, base_x, base_z, ground_level);
+
+    // Convert spawn Z from internal (Z+ = South) to Luanti (Z+ = North)
+    let spawn_z = -spawn_z - 1;
+
+    // Write world.mt
+    write_world_mt(world_dir, game, level_name, spawn_x, spawn_y, spawn_z)?;
+
+    // Write map_meta.txt
+    write_map_meta(world_dir, game)?;
+
+    // Write env_meta.txt
+    write_env_meta(world_dir)?;
+
+    // Write worldmod for singlenode mapgen + spawn
+    write_worldmod(world_dir, spawn_x, spawn_y, spawn_z, game)?;
+
+    // Remove stale mod storage so fix_light runs again on regenerated worlds
+    let mod_storage_sqlite = world_dir.join("mod_storage.sqlite");
+    if mod_storage_sqlite.exists() {
+        let _ = fs::remove_file(&mod_storage_sqlite);
+    }
+    // Also remove any WAL/journal files for mod_storage
+    let _ = fs::remove_file(world_dir.join("mod_storage.sqlite-wal"));
+    let _ = fs::remove_file(world_dir.join("mod_storage.sqlite-journal"));
+    let _ = fs::remove_file(world_dir.join("mod_storage.sqlite-shm"));
+
+    // Write map.sqlite
+    write_map_database(world, world_dir, game)?;
+
+    emit_gui_progress_update(99.0, "Luanti world saved.");
+    println!(
+        "{} Luanti world saved to: {}",
+        "Done!".green().bold(),
+        world_dir.display()
+    );
+
+    Ok(())
+}
+
+fn write_world_mt(
+    world_dir: &Path,
+    game: LuantiGame,
+    level_name: Option<&str>,
+    spawn_x: i32,
+    spawn_y: i32,
+    spawn_z: i32,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut f = fs::File::create(world_dir.join("world.mt"))?;
+    writeln!(f, "backend = sqlite3")?;
+    writeln!(f, "player_backend = sqlite3")?;
+    writeln!(f, "auth_backend = sqlite3")?;
+    writeln!(f, "mod_storage_backend = sqlite3")?;
+    writeln!(f, "gameid = {}", game.game_id())?;
+    if let Some(name) = level_name {
+        writeln!(f, "world_name = {}", name)?;
+    }
+    writeln!(f, "creative_mode = true")?;
+    writeln!(f, "enable_damage = false")?;
+    writeln!(f, "server_announce = false")?;
+    writeln!(
+        f,
+        "static_spawnpoint = {}, {}, {}",
+        spawn_x, spawn_y, spawn_z
+    )?;
+    Ok(())
+}
+
+fn write_map_meta(
+    world_dir: &Path,
+    game: LuantiGame,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut f = fs::File::create(world_dir.join("map_meta.txt"))?;
+    writeln!(f, "mg_name = singlenode")?;
+    writeln!(f, "seed = 0")?;
+    if game == LuantiGame::Mineclonia {
+        // Tell Mineclonia not to activate its custom levelgen system,
+        // so it won't generate terrain over our pre-built map.
+        writeln!(f, "mcl_singlenode_mapgen = false")?;
+    }
+    writeln!(f, "[end_of_params]")?;
+    Ok(())
+}
+
+fn write_env_meta(world_dir: &Path) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut f = fs::File::create(world_dir.join("env_meta.txt"))?;
+    writeln!(f, "game_time = 0")?;
+    writeln!(f, "time_of_day = 6000")?;
+    writeln!(f, "EnvArgsEnd")?;
+    Ok(())
+}
+
+fn write_worldmod(
+    world_dir: &Path,
+    spawn_x: i32,
+    spawn_y: i32,
+    spawn_z: i32,
+    game: LuantiGame,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mod_dir = world_dir.join("worldmods").join("arnis_mapgen");
+    fs::create_dir_all(&mod_dir)?;
+
+    // Write mod.conf (optional_depends on mcl_spawn so we load after Mineclonia's spawn)
+    let mut mc = fs::File::create(mod_dir.join("mod.conf"))?;
+    writeln!(mc, "name = arnis_mapgen")?;
+    writeln!(
+        mc,
+        "description = Arnis world configuration (singlenode mapgen + spawn)"
+    )?;
+    writeln!(mc, "optional_depends = mcl_spawn")?;
+
+    if game == LuantiGame::Mineclonia {
+        // Write mcl_levelgen.conf to inhibit Mineclonia's custom mapgen
+        let mut lc = fs::File::create(mod_dir.join("mcl_levelgen.conf"))?;
+        writeln!(lc, "disable_mcl_levelgen = true")?;
+    }
+
+    let mut f = fs::File::create(mod_dir.join("init.lua"))?;
+    writeln!(f, "-- Arnis world configuration")?;
+    writeln!(
+        f,
+        "minetest.set_mapgen_setting(\"mg_name\", \"singlenode\", true)"
+    )?;
+    writeln!(f)?;
+    writeln!(
+        f,
+        "local SPAWN = {{x={}, y={}, z={}}}",
+        spawn_x, spawn_y, spawn_z
+    )?;
+    writeln!(f)?;
+    writeln!(f, "-- Teleport player to our spawn after a short delay")?;
+    writeln!(
+        f,
+        "-- (overrides game-specific spawn handlers like Mineclonia's)"
+    )?;
+    writeln!(f, "minetest.register_on_joinplayer(function(player)")?;
+    writeln!(f, "    minetest.after(0.5, function()")?;
+    writeln!(f, "        if player:is_player() then")?;
+    writeln!(f, "            player:set_pos(SPAWN)")?;
+    writeln!(f, "        end")?;
+    writeln!(f, "    end)")?;
+    writeln!(f, "end)")?;
+    writeln!(f)?;
+    writeln!(f, "minetest.register_on_respawnplayer(function(player)")?;
+    writeln!(f, "    minetest.after(0.5, function()")?;
+    writeln!(f, "        if player:is_player() then")?;
+    writeln!(f, "            player:set_pos(SPAWN)")?;
+    writeln!(f, "        end")?;
+    writeln!(f, "    end)")?;
+    writeln!(f, "    return true")?;
+    writeln!(f, "end)")?;
+    writeln!(f)?;
+
+    // Grant fast and fly privileges to all joining players
+    writeln!(f, "-- Grant fast and fly privileges")?;
+    writeln!(f, "minetest.register_on_joinplayer(function(player)")?;
+    writeln!(f, "    local name = player:get_player_name()")?;
+    writeln!(f, "    local privs = minetest.get_player_privs(name)")?;
+    writeln!(f, "    privs.fast = true")?;
+    writeln!(f, "    privs.fly = true")?;
+    writeln!(f, "    minetest.set_player_privs(name, privs)")?;
+    writeln!(f, "end)")?;
+    writeln!(f)?;
+
+    writeln!(
+        f,
+        "-- Lazy fix-lighting: fix mapblock lighting around players as they move"
+    )?;
+    writeln!(
+        f,
+        "-- instead of fixing the entire world at once on first load."
+    )?;
+    writeln!(f, "local fixed_blocks = {{}}")?;
+    writeln!(
+        f,
+        "local RADIUS = 3          -- fix 3 mapblocks in each direction"
+    )?;
+    writeln!(f, "local CHECK_INTERVAL = 0.3 -- seconds between checks")?;
+    writeln!(
+        f,
+        "local MAX_FIXES = 8        -- max fix_light calls per check"
+    )?;
+    writeln!(f, "local timer = 0")?;
+    writeln!(f)?;
+    writeln!(f, "minetest.register_globalstep(function(dtime)")?;
+    writeln!(f, "    timer = timer + dtime")?;
+    writeln!(f, "    if timer < CHECK_INTERVAL then return end")?;
+    writeln!(f, "    timer = 0")?;
+    writeln!(f, "    local fixes = 0")?;
+    writeln!(
+        f,
+        "    for _, player in ipairs(minetest.get_connected_players()) do"
+    )?;
+    writeln!(f, "        local pos = player:get_pos()")?;
+    writeln!(f, "        local bx = math.floor(pos.x / 16)")?;
+    writeln!(f, "        local by = math.floor(pos.y / 16)")?;
+    writeln!(f, "        local bz = math.floor(pos.z / 16)")?;
+    writeln!(f, "        for dx = -RADIUS, RADIUS do")?;
+    writeln!(f, "            for dy = -RADIUS, RADIUS do")?;
+    writeln!(f, "                for dz = -RADIUS, RADIUS do")?;
+    writeln!(
+        f,
+        "                    local key = (bx+dx) .. \",\" .. (by+dy) .. \",\" .. (bz+dz)"
+    )?;
+    writeln!(f, "                    if not fixed_blocks[key] then")?;
+    writeln!(f, "                        fixed_blocks[key] = true")?;
+    writeln!(f, "                        local x1 = (bx+dx) * 16")?;
+    writeln!(f, "                        local y1 = (by+dy) * 16")?;
+    writeln!(f, "                        local z1 = (bz+dz) * 16")?;
+    writeln!(f, "                        minetest.fix_light(")?;
+    writeln!(f, "                            {{x=x1, y=y1, z=z1}},")?;
+    writeln!(
+        f,
+        "                            {{x=x1+15, y=y1+15, z=z1+15}})"
+    )?;
+    writeln!(f, "                        fixes = fixes + 1")?;
+    writeln!(
+        f,
+        "                        if fixes >= MAX_FIXES then return end"
+    )?;
+    writeln!(f, "                    end")?;
+    writeln!(f, "                end")?;
+    writeln!(f, "            end")?;
+    writeln!(f, "        end")?;
+    writeln!(f, "    end")?;
+    writeln!(f, "end)")?;
+
+    Ok(())
+}
+
+/// Serialize an air-only mapblock with full sunlight.
+/// Used to place sky blocks above the world so the engine can propagate sun downward.
+fn serialize_air_mapblock(game: LuantiGame) -> Vec<u8> {
+    let air_name = to_luanti_node(AIR, game, None).name;
+
+    let mut buf: Vec<u8> = Vec::with_capacity(4096);
+
+    // flags: day_night_differs + generated (not underground)
+    buf.push(0x02 | 0x08);
+    // lighting_complete: upper 4 "nothing" bits set, boundary flags cleared
+    buf.extend_from_slice(&0xF000u16.to_be_bytes());
+    // timestamp
+    buf.extend_from_slice(&0xFFFFFFFFu32.to_be_bytes());
+
+    // name-id mapping: only air (ID 0)
+    buf.push(0); // version
+    buf.extend_from_slice(&1u16.to_be_bytes()); // 1 type
+    buf.extend_from_slice(&0u16.to_be_bytes()); // id = 0
+    buf.extend_from_slice(&(air_name.len() as u16).to_be_bytes());
+    buf.extend_from_slice(air_name.as_bytes());
+
+    // content_width, params_width
+    buf.push(2);
+    buf.push(2);
+
+    // param0: all zeros (air = ID 0)
+    buf.extend_from_slice(&[0u8; NODES_PER_BLOCK * 2]);
+    // param1: full day-light for all air (day=15 in lower nibble, night=0 in upper)
+    buf.extend_from_slice(&[15u8; NODES_PER_BLOCK]);
+    // param2: all zeros
+    buf.extend_from_slice(&[0u8; NODES_PER_BLOCK]);
+
+    // Node metadata: empty
+    buf.push(2);
+    buf.extend_from_slice(&0u16.to_be_bytes());
+    // Static objects: empty
+    buf.push(0);
+    buf.extend_from_slice(&0u16.to_be_bytes());
+    // Node timers: empty
+    buf.push(10);
+    buf.extend_from_slice(&0u16.to_be_bytes());
+
+    // Compress with zstd, prepend version byte
+    let compressed = zstd::bulk::compress(&buf, 3).expect("zstd compression failed");
+    let mut blob = Vec::with_capacity(1 + compressed.len());
+    blob.push(MAP_FORMAT_VERSION);
+    blob.extend_from_slice(&compressed);
+    blob
+}
+
+fn write_map_database(
+    world: &WorldToModify,
+    world_dir: &Path,
+    game: LuantiGame,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let db_path = world_dir.join("map.sqlite");
+
+    // Remove existing database if present
+    if db_path.exists() {
+        fs::remove_file(&db_path)?;
+    }
+
+    let conn = Connection::open(&db_path)?;
+
+    // Optimize for bulk writes
+    conn.execute_batch(
+        "PRAGMA journal_mode = OFF;
+         PRAGMA synchronous = OFF;
+         PRAGMA locking_mode = EXCLUSIVE;",
+    )?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS `blocks` (`pos` INT NOT NULL PRIMARY KEY, `data` BLOB)",
+        [],
+    )?;
+
+    // Collect all mapblock positions and sections for parallel serialization
+    let mut block_entries: Vec<(i32, i32, i32, &crate::world_editor::common::SectionToModify)> =
+        Vec::new();
+
+    // Track XZ extents and max Y to generate air mapblocks above
+    let mut mb_min_x = i32::MAX;
+    let mut mb_max_x = i32::MIN;
+    let mut mb_min_z = i32::MAX;
+    let mut mb_max_z = i32::MIN;
+    let mut mb_max_y = i32::MIN;
+
+    for (&(region_x, region_z), region) in &world.regions {
+        for (&(chunk_x, chunk_z), chunk) in &region.chunks {
+            for (&section_y, section) in &chunk.sections {
+                // region_x * 32 + chunk_x = absolute chunk X = mapblock X
+                // section_y (i8) = mapblock Y
+                // Negate Z: Luanti Z+ = North, internal Z+ = South
+                let mb_x = region_x * 32 + chunk_x;
+                let orig_z = region_z * 32 + chunk_z;
+                let mb_z = -orig_z - 1;
+                let mb_y = section_y as i32;
+                block_entries.push((mb_x, mb_y, mb_z, section));
+                mb_min_x = mb_min_x.min(mb_x);
+                mb_max_x = mb_max_x.max(mb_x);
+                mb_min_z = mb_min_z.min(mb_z);
+                mb_max_z = mb_max_z.max(mb_z);
+                mb_max_y = mb_max_y.max(mb_y);
+            }
+        }
+    }
+
+    println!(
+        "  Serializing {} mapblocks...",
+        block_entries.len().to_string().bold()
+    );
+
+    // Serialize mapblocks in parallel
+    let serialized: Vec<(i64, Vec<u8>)> = block_entries
+        .par_iter()
+        .map(|&(bx, by, bz, section)| serialize_mapblock(bx, by, bz, section, game))
+        .collect();
+
+    // Generate air-only mapblocks above the world (2 extra layers) so the engine
+    // can propagate sunlight down into the content blocks.
+    let air_blob = serialize_air_mapblock(game);
+    let mut air_blocks: Vec<(i64, Vec<u8>)> = Vec::new();
+    for extra_y in 1..=2 {
+        let ay = mb_max_y + extra_y;
+        for ax in mb_min_x..=mb_max_x {
+            for az in mb_min_z..=mb_max_z {
+                air_blocks.push((encode_block_pos(ax, ay, az), air_blob.clone()));
+            }
+        }
+    }
+
+    // Insert all serialized blocks into SQLite (must be sequential)
+    conn.execute_batch("BEGIN TRANSACTION")?;
+    {
+        let mut stmt = conn.prepare("INSERT INTO `blocks` (`pos`, `data`) VALUES (?1, ?2)")?;
+        for (pos, data) in &serialized {
+            stmt.execute(rusqlite::params![pos, data])?;
+        }
+        for (pos, data) in &air_blocks {
+            stmt.execute(rusqlite::params![pos, data])?;
+        }
+    }
+    conn.execute_batch("COMMIT")?;
+
+    println!(
+        "  Wrote {} mapblocks to map.sqlite ({} content + {} air)",
+        serialized.len() + air_blocks.len(),
+        serialized.len(),
+        air_blocks.len(),
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_block_pos_origin() {
+        assert_eq!(encode_block_pos(0, 0, 0), 0);
+    }
+
+    #[test]
+    fn test_encode_block_pos_positive() {
+        // pos = z * 0x1000000 + y * 0x1000 + x
+        assert_eq!(encode_block_pos(1, 2, 3), 3 * 0x1000000 + 2 * 0x1000 + 1);
+    }
+
+    #[test]
+    fn test_encode_block_pos_negative() {
+        // Negative coordinates should work with signed arithmetic
+        let pos = encode_block_pos(-1, -1, -1);
+        assert_eq!(pos, (-1i64) * 0x1000000 + (-1i64) * 0x1000 + (-1i64));
+    }
+}

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -248,6 +248,8 @@ impl<'a> WorldEditor<'a> {
             luanti_game: game,
         }
     }
+
+    /// Sets the ground reference for elevation-based block placement
     pub fn set_ground(&mut self, ground: Arc<Ground>) {
         self.ground = Some(ground);
     }

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -7,20 +7,17 @@
 //!
 //! - `common` - Shared data structures for world modification
 //! - `java` - Java Edition Anvil format saving
-//! - `bedrock` - Bedrock Edition .mcworld format saving (behind `bedrock` feature)
+//! - `bedrock` - Bedrock Edition .mcworld format saving
 
 mod common;
 mod java;
 mod luanti;
 
-#[cfg(feature = "bedrock")]
 pub mod bedrock;
 
-// Re-export common types used internally
 pub(crate) use common::WorldToModify;
 pub use common::MIN_Y;
 
-#[cfg(feature = "bedrock")]
 pub(crate) use bedrock::{BedrockSaveError, BedrockWriter};
 
 use crate::block_definitions::*;
@@ -134,13 +131,8 @@ pub struct WorldEditor<'a> {
     /// Uses FNV hashing (not SipHash): `get_ground_level` sits on a hot
     /// path (called per-block during placement), so the hash cost matters.
     road_surface_overrides: FnvHashMap<(i32, i32), i32>,
-    /// Optional level name for Bedrock worlds (e.g., "Arnis World: New York City")
-    #[cfg(feature = "bedrock")]
     bedrock_level_name: Option<String>,
-    /// Optional spawn point for Bedrock worlds (x, z coordinates)
-    #[cfg(feature = "bedrock")]
     bedrock_spawn_point: Option<(i32, i32)>,
-    #[cfg(feature = "bedrock")]
     bedrock_extend_height: bool,
     /// Optional level name for Luanti worlds
     luanti_level_name: Option<String>,
@@ -166,11 +158,8 @@ impl<'a> WorldEditor<'a> {
             ground: None,
             format: WorldFormat::JavaAnvil,
             road_surface_overrides: FnvHashMap::default(),
-            #[cfg(feature = "bedrock")]
             bedrock_level_name: None,
-            #[cfg(feature = "bedrock")]
             bedrock_spawn_point: None,
-            #[cfg(feature = "bedrock")]
             bedrock_extend_height: false,
             luanti_level_name: None,
             luanti_spawn_point: None,
@@ -180,21 +169,15 @@ impl<'a> WorldEditor<'a> {
     }
 
     /// Creates a new WorldEditor with a specific format and optional level name.
-    ///
-    /// Used by GUI mode to support both Java and Bedrock formats.
     #[allow(dead_code)]
     pub fn new_with_format_and_name(
         world_dir: PathBuf,
         xzbbox: &'a XZBBox,
         llbbox: LLBBox,
         format: WorldFormat,
-        #[cfg_attr(not(feature = "bedrock"), allow(unused_variables))] bedrock_level_name: Option<
-            String,
-        >,
-        #[cfg_attr(not(feature = "bedrock"), allow(unused_variables))] bedrock_spawn_point: Option<
-            (i32, i32),
-        >,
-        #[cfg_attr(not(feature = "bedrock"), allow(unused_variables))] bedrock_extend_height: bool,
+        bedrock_level_name: Option<String>,
+        bedrock_spawn_point: Option<(i32, i32)>,
+        bedrock_extend_height: bool,
     ) -> Self {
         Self {
             world_dir,
@@ -204,11 +187,8 @@ impl<'a> WorldEditor<'a> {
             ground: None,
             format,
             road_surface_overrides: FnvHashMap::default(),
-            #[cfg(feature = "bedrock")]
             bedrock_level_name,
-            #[cfg(feature = "bedrock")]
             bedrock_spawn_point,
-            #[cfg(feature = "bedrock")]
             bedrock_extend_height,
             luanti_level_name: None,
             luanti_spawn_point: None,
@@ -236,11 +216,8 @@ impl<'a> WorldEditor<'a> {
             ground: None,
             format: WorldFormat::LuantiWorld,
             road_surface_overrides: FnvHashMap::default(),
-            #[cfg(feature = "bedrock")]
             bedrock_level_name: None,
-            #[cfg(feature = "bedrock")]
             bedrock_spawn_point: None,
-            #[cfg(feature = "bedrock")]
             bedrock_extend_height: false,
             luanti_level_name: level_name,
             luanti_spawn_point: spawn_point,
@@ -1154,37 +1131,20 @@ impl<'a> WorldEditor<'a> {
         Ok(())
     }
 
-    #[allow(unreachable_code)]
     fn save_bedrock(&mut self) {
         println!("{} Saving Bedrock world...", "[7/7]".bold());
         emit_gui_progress_update(90.0, "Saving Bedrock world...");
 
-        #[cfg(feature = "bedrock")]
-        {
-            if let Err(error) = self.save_bedrock_internal() {
-                eprintln!("Failed to save Bedrock world: {error}");
-                #[cfg(feature = "gui")]
-                send_log(
-                    LogLevel::Error,
-                    &format!("Failed to save Bedrock world: {error}"),
-                );
-            }
-        }
-
-        #[cfg(not(feature = "bedrock"))]
-        {
-            eprintln!(
-                "Bedrock output requested but the 'bedrock' feature is not enabled at build time."
-            );
+        if let Err(error) = self.save_bedrock_internal() {
+            eprintln!("Failed to save Bedrock world: {error}");
             #[cfg(feature = "gui")]
             send_log(
                 LogLevel::Error,
-                "Bedrock output requested but the 'bedrock' feature is not enabled at build time.",
+                &format!("Failed to save Bedrock world: {error}"),
             );
         }
     }
 
-    #[cfg(feature = "bedrock")]
     fn save_bedrock_internal(&mut self) -> Result<(), BedrockSaveError> {
         // Use the stored level name if available, otherwise extract from path
         let level_name = self.bedrock_level_name.clone().unwrap_or_else(|| {

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -11,6 +11,7 @@
 
 mod common;
 mod java;
+mod luanti;
 
 #[cfg(feature = "bedrock")]
 pub mod bedrock;
@@ -26,6 +27,7 @@ use crate::block_definitions::*;
 use crate::coordinate_system::cartesian::{XZBBox, XZPoint};
 use crate::coordinate_system::geographic::LLBBox;
 use crate::ground::Ground;
+use crate::luanti_block_map::LuantiGame;
 use crate::progress::emit_gui_progress_update;
 use colored::Colorize;
 use fastnbt::{IntArray, Value};
@@ -92,6 +94,8 @@ pub enum WorldFormat {
     JavaAnvil,
     /// Bedrock Edition .mcworld format
     BedrockMcWorld,
+    /// Luanti/Minetest world (map.sqlite)
+    LuantiWorld,
 }
 
 /// Metadata saved with the world
@@ -138,6 +142,14 @@ pub struct WorldEditor<'a> {
     bedrock_spawn_point: Option<(i32, i32)>,
     #[cfg(feature = "bedrock")]
     bedrock_extend_height: bool,
+    /// Optional level name for Luanti worlds
+    luanti_level_name: Option<String>,
+    /// Optional spawn point for Luanti worlds (x, z coordinates)
+    luanti_spawn_point: Option<(i32, i32)>,
+    /// Ground level for Luanti worlds
+    luanti_ground_level: i32,
+    /// Luanti game pack
+    luanti_game: LuantiGame,
 }
 
 impl<'a> WorldEditor<'a> {
@@ -160,6 +172,10 @@ impl<'a> WorldEditor<'a> {
             bedrock_spawn_point: None,
             #[cfg(feature = "bedrock")]
             bedrock_extend_height: false,
+            luanti_level_name: None,
+            luanti_spawn_point: None,
+            luanti_ground_level: -62,
+            luanti_game: LuantiGame::Mineclonia,
         }
     }
 
@@ -194,10 +210,44 @@ impl<'a> WorldEditor<'a> {
             bedrock_spawn_point,
             #[cfg(feature = "bedrock")]
             bedrock_extend_height,
+            luanti_level_name: None,
+            luanti_spawn_point: None,
+            luanti_ground_level: -62,
+            luanti_game: LuantiGame::Mineclonia,
         }
     }
 
-    /// Sets the ground reference for elevation-based block placement
+    /// Creates a new WorldEditor configured for Luanti output.
+    #[allow(dead_code)]
+    pub fn new_luanti(
+        world_dir: PathBuf,
+        xzbbox: &'a XZBBox,
+        llbbox: LLBBox,
+        game: LuantiGame,
+        level_name: Option<String>,
+        spawn_point: Option<(i32, i32)>,
+        ground_level: i32,
+    ) -> Self {
+        Self {
+            world_dir,
+            world: WorldToModify::default(),
+            xzbbox,
+            llbbox,
+            ground: None,
+            format: WorldFormat::LuantiWorld,
+            road_surface_overrides: FnvHashMap::default(),
+            #[cfg(feature = "bedrock")]
+            bedrock_level_name: None,
+            #[cfg(feature = "bedrock")]
+            bedrock_spawn_point: None,
+            #[cfg(feature = "bedrock")]
+            bedrock_extend_height: false,
+            luanti_level_name: level_name,
+            luanti_spawn_point: spawn_point,
+            luanti_ground_level: ground_level,
+            luanti_game: game,
+        }
+    }
     pub fn set_ground(&mut self, ground: Arc<Ground>) {
         self.ground = Some(ground);
     }
@@ -323,6 +373,7 @@ impl<'a> WorldEditor<'a> {
             crate::world_editor::WorldFormat::BedrockMcWorld => {
                 self.set_bedrock_banner_block_entity_absolute(x, y, z, base_color, patterns);
             }
+            crate::world_editor::WorldFormat::LuantiWorld => {}
         }
     }
 
@@ -1049,6 +1100,7 @@ impl<'a> WorldEditor<'a> {
             match self.format {
                 WorldFormat::JavaAnvil => "Java Edition (Anvil)",
                 WorldFormat::BedrockMcWorld => "Bedrock Edition (.mcworld)",
+                WorldFormat::LuantiWorld => "Luanti/Minetest",
             }
         );
 
@@ -1074,6 +1126,27 @@ impl<'a> WorldEditor<'a> {
                 }
             }
             WorldFormat::BedrockMcWorld => self.save_bedrock(),
+            WorldFormat::LuantiWorld => {
+                if let Err(e) = luanti::save_luanti_world(
+                    &self.world,
+                    &self.world_dir,
+                    self.xzbbox,
+                    &self.llbbox,
+                    self.luanti_game,
+                    self.luanti_level_name.as_deref(),
+                    self.luanti_spawn_point,
+                    self.luanti_ground_level,
+                ) {
+                    let user_msg = format!("Failed to save Luanti world: {}", e);
+                    eprintln!("{}", user_msg);
+                    #[cfg(feature = "gui")]
+                    {
+                        send_log(LogLevel::Error, &user_msg);
+                        emit_gui_error(&user_msg);
+                    }
+                    return Err(e);
+                }
+            }
         }
 
         Ok(())

--- a/src/world_utils.rs
+++ b/src/world_utils.rs
@@ -14,6 +14,27 @@ pub fn get_bedrock_output_directory() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
 }
 
+/// Returns Luanti's worlds directory for the current OS.
+/// Windows: %APPDATA%\Minetest\worlds
+/// macOS:   ~/Library/Application Support/minetest/worlds
+/// Linux:   ~/.minetest/worlds
+/// Falls back to Desktop/Arnis Luanti Worlds if no path can be resolved.
+pub fn get_luanti_worlds_directory() -> PathBuf {
+    let base = if cfg!(target_os = "windows") {
+        dirs::data_dir().map(|p| p.join("Minetest"))
+    } else if cfg!(target_os = "macos") {
+        dirs::data_dir().map(|p| p.join("minetest"))
+    } else {
+        dirs::home_dir().map(|p| p.join(".minetest"))
+    };
+
+    base.map(|p| p.join("worlds")).unwrap_or_else(|| {
+        dirs::desktop_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("Arnis Luanti Worlds")
+    })
+}
+
 /// Gets the area name for a given bounding box using the center point.
 pub fn get_area_name_for_bedrock(bbox: &LLBBox) -> String {
     let center_lat = (bbox.min().lat() + bbox.max().lat()) / 2.0;


### PR DESCRIPTION
## Summary

Adds a third output target alongside Java and Bedrock: a native Luanti world (`map.sqlite`, v29 mapblock format, zstd-compressed) using Mineclonia node names. Hidden behind a **"Luanti (experimental)"** toggle in the GUI settings panel.

Continues the work from #808 by @3rd3, rebased onto current `main` with fixes for block-ID drift and several UX improvements.

## Credit

Built on top of @3rd3's #808 (the heavy lifting — v29 mapblock format, SQLite serialization, zstd compression, worldmod + lazy lighting, MC2MT-derived block mapping). Their original commits are squashed into the single commit on this branch; the git `Co-Authored-By` trailer preserves attribution.

## What changed on top of #808

- **Block-ID drift fixed:** ~15 Arnis block IDs were reassigned on `main` after #808 was opened (e.g. ID 16 went from `crimson_planks` → `LEVER`; IDs 17, 38, 56, 62, 63, 64, 75, 86, 97, 102, 112, 133, 195, 199, 204, 215, 230, 231, 232 all changed). The Luanti map now reflects current IDs.
- **New blocks mapped:** wall banners (145–149, 255), mossy stone bricks (150), deepslate / tuff / cobbled deepslate (151–153), water cauldron (154), waxed copper variants, brown/gray concrete powder, cyan terracotta, black wool.
- **OS-aware Luanti worlds directory:**
  - Windows: `%APPDATA%\Minetest\worlds`
  - macOS: `~/Library/Application Support/minetest/worlds`
  - Linux: `~/.minetest/worlds`
  - Falls back to `Desktop\Arnis Luanti Worlds` if neither resolves.
- **CLI:** `--path` is now optional for `--luanti` (defaults to the OS Luanti worlds dir, matching how `--bedrock` defaults to Desktop).
- **GUI:** Luanti format button is hidden by default. Users enable it via a new **Settings → World → Luanti (experimental)** toggle. State persists in `localStorage`. Turning the toggle off while Luanti is selected falls back to Java automatically.
- **Styling:** Added `accent-color` for the new toggle to match the yellow theme of the other settings switches.

## Known limitations (experimental)

- Mineclonia only (minetest_game was dropped upstream after block-mapping similarity analysis showed it produced much worse results)
- A handful of new block mappings (waxed copper stairs, cherry log/leaves) are educated guesses based on naming patterns — Mineclonia may not have direct equivalents for all of them; those fall back to `mcl_core:stone`
- Trapdoor orientation near windows can be off
- Lazy lighting (`fix_light()` around player position) is not tested with many concurrent players
- Windows/macOS GUI flow not battle-tested
- License: `src/luanti_block_map.rs` is LGPLv2.1+ (ported from [MC2MT](https://github.com/rollerozxa/MC2MT) by rollerozxa); the file header preserves the original copyright

## Why a new PR instead of merging #808 directly

#808 is in merge conflict with `main` after ~2 months of divergence. Rather than force-pushing a rebase onto @3rd3's fork (which would wipe their 38-commit history), this PR brings the same logical change rebased and updated for current `main`. #808 will be closed in favor of this one.