### PR TITLE
Prepare v2.8.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "arnis"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "base64 0.22.1",
  "bedrockrs_level",
@@ -2645,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "i_overlay"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934cba666ad1bf60436a190af6eaa3f58f57b5bad28268ce3fb45d9185862232"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
 dependencies = [
  "i_float",
  "i_key_sort",
@@ -3536,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -5682,9 +5682,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -5698,9 +5698,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
+checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5749,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
+checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -5770,9 +5770,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
+checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -5797,9 +5797,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
+checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5811,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.6.1"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eefb2c18e8a605c23edb48fc56bb77381199e1a1e7f6ff0c9b970afe7b3cb8ee"
+checksum = "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e"
 dependencies = [
  "anyhow",
  "glob",
@@ -5870,9 +5870,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
+checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
 dependencies = [
  "cookie",
  "dpi",
@@ -5895,9 +5895,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
+checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
@@ -5921,9 +5921,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
+checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
 dependencies = [
  "anyhow",
  "brotli",
@@ -6311,9 +6311,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -7910,18 +7910,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.1"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arnis"
-version = "2.7.0"
+version = "2.8.0"
 edition = "2021"
 description = "Arnis - Generate real life cities in Minecraft"
 homepage = "https://github.com/louis-e/arnis"

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -222,46 +222,32 @@ async function checkForUpdates() {
     ]);
     latestReleaseInfo = info;
     currentPlatform = platform || "unknown";
-    if (!info) return;
+    if (!info || !info.isNewer) return;
 
-    const seen = localStorage.getItem(SEEN_VERSION_KEY);
-
-    if (info.isNewer) {
-      const footer = document.querySelector(".footer");
-      const updateMessage = document.createElement("span");
-      updateMessage.setAttribute("role", "button");
-      updateMessage.setAttribute("tabindex", "0");
-      updateMessage.style.color = "#fecc44";
-      updateMessage.style.marginTop = "-5px";
-      updateMessage.style.fontSize = "0.95em";
-      updateMessage.style.display = "block";
-      updateMessage.style.cursor = "pointer";
-      updateMessage.addEventListener("click", () => openUpdateModal());
-      updateMessage.addEventListener("keydown", (e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          openUpdateModal();
-        }
-      });
-      localizeElement(window.localization, { element: updateMessage }, "new_version_available");
-      footer.style.marginTop = "10px";
-      footer.appendChild(updateMessage);
-
-      // Auto-open once per new remote version; "seen" key records the last auto-shown version.
-      if (seen !== info.remoteVersion) {
+    const footer = document.querySelector(".footer");
+    const updateMessage = document.createElement("span");
+    updateMessage.setAttribute("role", "button");
+    updateMessage.setAttribute("tabindex", "0");
+    updateMessage.style.color = "#fecc44";
+    updateMessage.style.marginTop = "-5px";
+    updateMessage.style.fontSize = "0.95em";
+    updateMessage.style.display = "block";
+    updateMessage.style.cursor = "pointer";
+    updateMessage.addEventListener("click", () => openUpdateModal());
+    updateMessage.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
         openUpdateModal();
       }
-    } else if (
-      info.localVersion &&
-      info.localVersion === info.remoteVersion &&
-      seen !== info.localVersion
-    ) {
-      // First startup on a fresh install or after an update: show the release
-      // notes for the current version once, then record the local version as seen.
-      openUpdateModal({ showDownload: false });
-      try {
-        localStorage.setItem(SEEN_VERSION_KEY, info.localVersion);
-      } catch (_) {}
+    });
+    localizeElement(window.localization, { element: updateMessage }, "new_version_available");
+    footer.style.marginTop = "10px";
+    footer.appendChild(updateMessage);
+
+    // Auto-open once per new remote version; "seen" key records the last auto-shown version.
+    const seen = localStorage.getItem(SEEN_VERSION_KEY);
+    if (seen !== info.remoteVersion) {
+      openUpdateModal();
     }
   } catch (error) {
     console.error("Failed to check for updates: ", error);

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -222,32 +222,46 @@ async function checkForUpdates() {
     ]);
     latestReleaseInfo = info;
     currentPlatform = platform || "unknown";
-    if (!info || !info.isNewer) return;
+    if (!info) return;
 
-    const footer = document.querySelector(".footer");
-    const updateMessage = document.createElement("span");
-    updateMessage.setAttribute("role", "button");
-    updateMessage.setAttribute("tabindex", "0");
-    updateMessage.style.color = "#fecc44";
-    updateMessage.style.marginTop = "-5px";
-    updateMessage.style.fontSize = "0.95em";
-    updateMessage.style.display = "block";
-    updateMessage.style.cursor = "pointer";
-    updateMessage.addEventListener("click", () => openUpdateModal());
-    updateMessage.addEventListener("keydown", (e) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
+    const seen = localStorage.getItem(SEEN_VERSION_KEY);
+
+    if (info.isNewer) {
+      const footer = document.querySelector(".footer");
+      const updateMessage = document.createElement("span");
+      updateMessage.setAttribute("role", "button");
+      updateMessage.setAttribute("tabindex", "0");
+      updateMessage.style.color = "#fecc44";
+      updateMessage.style.marginTop = "-5px";
+      updateMessage.style.fontSize = "0.95em";
+      updateMessage.style.display = "block";
+      updateMessage.style.cursor = "pointer";
+      updateMessage.addEventListener("click", () => openUpdateModal());
+      updateMessage.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          openUpdateModal();
+        }
+      });
+      localizeElement(window.localization, { element: updateMessage }, "new_version_available");
+      footer.style.marginTop = "10px";
+      footer.appendChild(updateMessage);
+
+      // Auto-open once per new remote version; "seen" key records the last auto-shown version.
+      if (seen !== info.remoteVersion) {
         openUpdateModal();
       }
-    });
-    localizeElement(window.localization, { element: updateMessage }, "new_version_available");
-    footer.style.marginTop = "10px";
-    footer.appendChild(updateMessage);
-
-    // Auto-open once per new remote version; "seen" key records the last auto-shown version.
-    const seen = localStorage.getItem(SEEN_VERSION_KEY);
-    if (seen !== info.remoteVersion) {
-      openUpdateModal();
+    } else if (
+      info.localVersion &&
+      info.localVersion === info.remoteVersion &&
+      seen !== info.localVersion
+    ) {
+      // First startup on a fresh install or after an update: show the release
+      // notes for the current version once, then record the local version as seen.
+      openUpdateModal({ showDownload: false });
+      try {
+        localStorage.setItem(SEEN_VERSION_KEY, info.localVersion);
+      } catch (_) {}
     }
   } catch (error) {
     console.error("Failed to check for updates: ", error);

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Arnis",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "identifier": "com.louisdev.arnis",
   "build": {
     "frontendDist": "src/gui"


### PR DESCRIPTION
## Summary
- Bump version `2.7.0` → `2.8.0` in `Cargo.toml` and `tauri.conf.json`
- `cargo update` refresh on `Cargo.lock` (14 transitive crates, notably tauri `2.11.1` → `2.11.2` and zstd-sys `1.5.6` → `1.5.7`)

## Verified
- `cargo check` clean across default / gui / --all-features
- `cargo clippy --all-features -- -D warnings` clean
- 120/121 tests pass (1 ignored, pre-existing)