### PR TITLE
Better barriers and fences generation

### DIFF
--- a/src/element_processing/barriers.rs
+++ b/src/element_processing/barriers.rs
@@ -263,12 +263,10 @@ pub fn generate_barriers(
                 Axis::Z
             };
 
-            let mut counter = 0;
-            for (bx, _, bz) in bresenham_points {
+            for (counter, (bx, _, bz)) in bresenham_points.into_iter().enumerate() {
                 let edge = (bx, bz) == (prev.x, prev.z) || (bx, bz) == (cur.x, cur.z);
                 let deck_y = bridge_surface.nearby_deck_y(bx, bz, BRIDGE_BARRIER_NEARBY_RADIUS);
                 place_barrier(&setting, editor, bx, bz, deck_y, counter, axis, edge);
-                counter += 1;
             }
         }
     }
@@ -337,6 +335,7 @@ pub fn generate_barrier_nodes(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn place_barrier(
     setting: &BarrierSetting,
     editor: &mut WorldEditor,
@@ -373,7 +372,7 @@ fn place_barrier(
             spacing,
             use_post_on_edge,
         } => {
-            let is_post = (edge && *use_post_on_edge) || counter % (spacing + 1) == 0;
+            let is_post = (edge && *use_post_on_edge) || counter.is_multiple_of(spacing + 1);
             let material = if is_post {
                 post_material.get(axis).clone()
             } else {

--- a/src/element_processing/barriers.rs
+++ b/src/element_processing/barriers.rs
@@ -20,10 +20,9 @@ enum BarrierMaterial {
     Axial { x: BlockWithProperties, z: BlockWithProperties },
 }
 
-#[allow(dead_code)]
 impl BarrierMaterial {
     fn simple(block: Block) -> Self {
-        Self::Simple(BlockWithProperties::new(block, None))
+        Self::Simple(BlockWithProperties::simple(block))
     }
     
     fn simple_with_properties(block: BlockWithProperties) -> Self {
@@ -94,9 +93,16 @@ fn fence_axis_properties(axis: Axis) -> Value {
     Value::Compound(props)
 }
 
+fn chain_y_properties() -> Value {
+    let mut props = HashMap::new();
+    props.insert("axis".to_string(), Value::String("y".to_string()));
+    Value::Compound(props)
+}
+
 fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting> {
     let iron_bars_x: BlockWithProperties = BlockWithProperties::new(IRON_BARS, Some(fence_axis_properties(Axis::X)));
     let iron_bars_z: BlockWithProperties = BlockWithProperties::new(IRON_BARS, Some(fence_axis_properties(Axis::Z)));
+    let chain_y: BlockWithProperties = BlockWithProperties::new(CHAIN_Z, Some(chain_y_properties()));
 
     // Determine the base settinguration from tags.
     let setting = match element.tags().get("barrier").map(|s| s.as_str()) {
@@ -108,35 +114,41 @@ fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting>
             // Handle fence sub-types
             match element.tags().get("fence_type").map(|s| s.as_str()) {
                 Some("railing" | "bars" | "krest") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 1)),
-                Some("chain_link" | "metal" | "wire" | "corrugated_metal" | "metal_bars") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)),
+                Some("corrugated_metal") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)),
                 Some("slatted" | "paling") => Some(BarrierSetting::solid(OAK_FENCE, 1)),
                 Some("wood" | "split_rail" | "panel" | "pole") => Some(BarrierSetting::solid(OAK_FENCE, 2)),
                 Some("concrete" | "stone") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)),
                 Some("glass") => Some(BarrierSetting::solid(GLASS, 1)),
-                Some("barbed_wire") => {
-                    Some(BarrierSetting {
-                        style: BarrierStyle::Alternating {
-                            post_material: BarrierMaterial::simple(ANDESITE_WALL),
-                            link_material: BarrierMaterial::axial_with_properties(iron_bars_x.clone(), iron_bars_z.clone()),
-                            top_material: Some(BarrierMaterial::simple(COBWEB)),
-                            spacing: 3,
-                            use_post_on_edge: true,
-                        },
-                        height: 2
-                    })
-                }
-                Some("electric") => {
-                    Some(BarrierSetting {
-                        style: BarrierStyle::Alternating {
-                            post_material: BarrierMaterial::simple(OAK_FENCE),
-                            link_material: BarrierMaterial::axial(CHAIN_X, CHAIN_Z),
-                            top_material: None,
-                            spacing: 2,
-                            use_post_on_edge: true,
-                        },
-                        height: 1
-                    })
-                }
+                Some("metal" | "wire" | "chain_link" | "metal_bars") => Some(BarrierSetting {
+                    style: BarrierStyle::Alternating {
+                        post_material: BarrierMaterial::simple_with_properties(chain_y.clone()),
+                        link_material: BarrierMaterial::axial_with_properties(iron_bars_x.clone(), iron_bars_z.clone()),
+                        top_material: None,
+                        spacing: 2,
+                        use_post_on_edge: true,
+                    },
+                    height: 2
+                }),
+                Some("barbed_wire") => Some(BarrierSetting {
+                    style: BarrierStyle::Alternating {
+                        post_material: BarrierMaterial::simple(ANDESITE_WALL),
+                        link_material: BarrierMaterial::axial_with_properties(iron_bars_x.clone(), iron_bars_z.clone()),
+                        top_material: Some(BarrierMaterial::simple(COBWEB)),
+                        spacing: 3,
+                        use_post_on_edge: true,
+                    },
+                    height: 2
+                }),
+                Some("electric") => Some(BarrierSetting {
+                    style: BarrierStyle::Alternating {
+                        post_material: BarrierMaterial::simple(OAK_FENCE),
+                        link_material: BarrierMaterial::axial(CHAIN_X, CHAIN_Z),
+                        top_material: None,
+                        spacing: 2,
+                        use_post_on_edge: true,
+                    },
+                    height: 1
+                }),
                 _ => None
             }
         }
@@ -291,7 +303,7 @@ fn place_barrier(
             }
         }
         BarrierStyle::Alternating { post_material, link_material, top_material, spacing, use_post_on_edge } => {
-            let is_post = (edge && *use_post_on_edge) || counter % spacing == 0;
+            let is_post = (edge && *use_post_on_edge) || counter % (spacing+1) == 0;
             let material =
                 if is_post { post_material.get(axis).clone() }
                 else { link_material.get(axis).clone() };

--- a/src/element_processing/barriers.rs
+++ b/src/element_processing/barriers.rs
@@ -117,7 +117,8 @@ fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting>
                 Some("corrugated_metal") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)),
                 Some("slatted" | "paling") => Some(BarrierSetting::solid(OAK_FENCE, 1)),
                 Some("wood" | "split_rail" | "panel" | "pole") => Some(BarrierSetting::solid(OAK_FENCE, 2)),
-                Some("concrete" | "stone") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)),
+                Some("concrete") => Some(BarrierSetting::solid(ANDESITE_WALL, 2)),
+                Some("stone") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)),
                 Some("glass") => Some(BarrierSetting::solid(GLASS, 1)),
                 Some("metal" | "wire" | "chain_link" | "metal_bars") => Some(BarrierSetting {
                     style: BarrierStyle::Alternating {

--- a/src/element_processing/barriers.rs
+++ b/src/element_processing/barriers.rs
@@ -59,7 +59,10 @@ struct BarrierSetting {
 impl BarrierSetting {
     fn solid(block: Block, height: i32) -> Self {
         Self {
-            style: BarrierStyle::Solid { material: BarrierMaterial::simple(block) },
+            style: BarrierStyle::Solid {
+                material: BarrierMaterial::simple(block),
+                top_material: Some(BarrierMaterial::simple(STONE_BRICK_SLAB)),
+            },
             height,
         }
     }
@@ -68,6 +71,7 @@ impl BarrierSetting {
 enum BarrierStyle {
     Solid {
         material: BarrierMaterial,
+        top_material: Option<BarrierMaterial>,
     },
     Alternating {
         post_material: BarrierMaterial,
@@ -104,7 +108,11 @@ fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting>
     let iron_bars_z: BlockWithProperties = BlockWithProperties::new(IRON_BARS, Some(fence_axis_properties(Axis::Z)));
     let chain_y: BlockWithProperties = BlockWithProperties::new(CHAIN_Z, Some(chain_y_properties()));
 
+    let oak_fence_x: BlockWithProperties = BlockWithProperties::new(OAK_FENCE, Some(fence_axis_properties(Axis::X)));
+    let oak_fence_z: BlockWithProperties = BlockWithProperties::new(OAK_FENCE, Some(fence_axis_properties(Axis::Z)));
+
     // Determine the base settinguration from tags.
+    // https://wiki.openstreetmap.org/wiki/Key:barrier
     let setting = match element.tags().get("barrier").map(|s| s.as_str()) {
         Some("bollard") => Some(BarrierSetting::solid(COBBLESTONE_WALL, 1)),
         Some("kerb") => None, // Ignore kerbs.
@@ -112,15 +120,29 @@ fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting>
         Some("wall") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 3)),
         Some("fence") => {
             // Handle fence sub-types
+            // https://wiki.openstreetmap.org/wiki/Key:fence%20type
             match element.tags().get("fence_type").map(|s| s.as_str()) {
-                Some("railing" | "bars" | "krest") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 1)),
-                Some("corrugated_metal") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)),
-                Some("slatted" | "paling") => Some(BarrierSetting::solid(OAK_FENCE, 1)),
-                Some("wood" | "split_rail" | "panel" | "pole") => Some(BarrierSetting::solid(OAK_FENCE, 2)),
+                Some("corrugated_metal") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)), // TODO: pale_oak_shelf could work well.
+                Some("knee_rail") => Some(BarrierSetting::solid(OAK_FENCE, 1)), // TODO: alterning between fence, slab and air.
+                Some("net") => Some(BarrierSetting::solid(COBWEB, 2)),
                 Some("concrete") => Some(BarrierSetting::solid(ANDESITE_WALL, 2)),
                 Some("stone") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)),
                 Some("glass") => Some(BarrierSetting::solid(GLASS, 1)),
-                Some("metal" | "wire" | "chain_link" | "metal_bars") => Some(BarrierSetting {
+                Some("panel" | "slatted") => Some(BarrierSetting { // TODO: spruce trapdoors or shelves.
+                    style: BarrierStyle::Solid {
+                        material: BarrierMaterial::axial_with_properties(oak_fence_x.clone(), oak_fence_z.clone()),
+                        top_material: None,
+                    },
+                    height: 2
+                }),
+                Some("paling" | "pole" | "post_and_rail" | "roundpole" | "split_rail" | "wood") => Some(BarrierSetting {
+                    style: BarrierStyle::Solid {
+                        material: BarrierMaterial::axial_with_properties(oak_fence_x.clone(), oak_fence_z.clone()),
+                        top_material: None,
+                    },
+                    height: 1
+                }),
+                Some("bars" | "railing" | "krest" | "metal" | "chain_link" | "metal_bars" | "temporary" | "welded_diamond_mesh" | "wire") => Some(BarrierSetting {
                     style: BarrierStyle::Alternating {
                         post_material: BarrierMaterial::simple_with_properties(chain_y.clone()),
                         link_material: BarrierMaterial::axial_with_properties(iron_bars_x.clone(), iron_bars_z.clone()),
@@ -162,7 +184,7 @@ fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting>
 
     // Apply tag overrides for the material.
     if let Some(barrier_mat) = element.tags().get("material") {
-        if let BarrierStyle::Solid { ref mut material } = setting.style {
+        if let BarrierStyle::Solid { ref mut material, .. } = setting.style {
             match barrier_mat.as_str() {
                 "brick" => *material = BarrierMaterial::simple(BRICK),
                 "concrete" => *material = BarrierMaterial::simple(LIGHT_GRAY_CONCRETE),
@@ -295,12 +317,14 @@ fn place_barrier(
     };
 
     match &setting.style {
-        BarrierStyle::Solid { material } => {
+        BarrierStyle::Solid { material, top_material } => {
             for y in 1..=setting.height {
                 place_block(editor, material.get(axis).clone(), y);
             }
             if setting.height > 1 {
-                place_block(editor, BlockWithProperties::new(STONE_BRICK_SLAB, None), setting.height + 1);
+                if let Some(top_material) = top_material {
+                    place_block(editor, top_material.get(axis).clone(), setting.height + 1);
+                }
             }
         }
         BarrierStyle::Alternating { post_material, link_material, top_material, spacing, use_post_on_edge } => {

--- a/src/element_processing/barriers.rs
+++ b/src/element_processing/barriers.rs
@@ -6,137 +6,197 @@ use crate::world_editor::WorldEditor;
 
 const BRIDGE_BARRIER_NEARBY_RADIUS: i32 = 2;
 
+struct BarrierSetting {
+    pub style: BarrierStyle,
+    pub height: i32,
+}
+
+enum BarrierStyle {
+    Solid {
+        material: Block,
+    },
+    Alternating {
+        post_xz: [Block; 2],
+        chain_xz: [Block; 2],
+        spacing: usize,
+        use_post_on_edge: bool,
+    },
+}
+
+fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting> {
+    // Determine the base settinguration from tags.
+    let setting = match element.tags().get("barrier").map(|s| s.as_str()) {
+        Some("bollard") => {
+            Some(BarrierSetting {
+                style: BarrierStyle::Solid { material: COBBLESTONE_WALL },
+                height: 1
+            })
+        }
+        Some("kerb") => None, // Ignore kerbs.
+        Some("hedge") => {
+            Some(BarrierSetting {
+                style: BarrierStyle::Solid { material: OAK_LEAVES },
+                height: 2
+            })
+        }
+        Some("wall") => {
+            Some(BarrierSetting {
+                style: BarrierStyle::Solid { material: STONE_BRICK_WALL },
+                height: 3
+            })
+        }
+        Some("fence") => {
+            match element.tags().get("fence_type").map(|s| s.as_str()) {
+                Some("railing" | "bars" | "krest") => {
+                    Some(BarrierSetting {
+                        style: BarrierStyle::Solid { material: STONE_BRICK_WALL },
+                        height: 1
+                    })
+                }
+                Some("chain_link" | "metal" | "wire" | "barbed_wire" | "corrugated_metal" | "metal_bars") => {
+                    Some(BarrierSetting {
+                        style: BarrierStyle::Solid { material: STONE_BRICK_WALL },
+                        height: 2
+                    })
+                }
+                Some("electric") => {
+                    Some(BarrierSetting {
+                        style: BarrierStyle::Alternating {
+                            post_xz: [OAK_FENCE, OAK_FENCE],
+                            chain_xz: [CHAIN_X, CHAIN_Z],
+                            spacing: 2,
+                            use_post_on_edge: true,
+                        },
+                        height: 1
+                    })
+                }
+                Some("slatted" | "paling") => {
+                    Some(BarrierSetting {
+                        style: BarrierStyle::Solid { material: OAK_FENCE },
+                        height: 1
+                    })
+                }
+                Some("wood" | "split_rail" | "panel" | "pole") => {
+                    Some(BarrierSetting {
+                        style: BarrierStyle::Solid { material: OAK_FENCE },
+                        height: 2
+                    })
+                }
+                Some("concrete" | "stone") => {
+                    Some(BarrierSetting {
+                        style: BarrierStyle::Solid { material: STONE_BRICK_WALL },
+                        height: 2
+                    })
+                }
+                Some("glass") => {
+                    Some(BarrierSetting {
+                        style: BarrierStyle::Solid { material: GLASS },
+                        height: 1
+                    })
+                }
+                _ => None
+            }
+        }
+        _ => None
+    };
+
+    let Some(mut setting) = setting else {
+        return None; // Skip processing if no valid barrier type is found.
+    };
+
+    // Apply tag overrides for the material.
+    if let Some(barrier_mat) = element.tags().get("material") {
+        if let BarrierStyle::Solid { ref mut material } = setting.style {
+            match barrier_mat.as_str() {
+                "brick" => *material = BRICK,
+                "concrete" => *material = LIGHT_GRAY_CONCRETE,
+                "metal" => *material = STONE_BRICK_WALL,
+                _ => {}
+            }
+        }
+    }
+    
+    // Apply tag overrides for the height.
+    if let Some(h_str) = element.tags().get("height") {
+        if let Ok(h_f32) = h_str.parse::<f32>() {
+            // Apply custom height (with a floor of 1 if user manually overrode it).
+            setting.height = (h_f32.round() as i32).max(1);
+        }
+    }
+
+    Some(setting)
+}
+
+fn place_barrier(
+    setting: &mut BarrierSetting, 
+    editor: &mut WorldEditor, 
+    bx: i32, 
+    bz: i32, 
+    deck_y: Option<i32>,
+    counter: &mut usize,
+    axis: usize,
+    edge: bool,
+) {
+    let place_block = |editor: &mut WorldEditor, block: Block, dy: i32| match deck_y {
+        Some(y) => editor.set_block_absolute(block, bx, y + dy, bz, None, None),
+        None => editor.set_block(block, bx, dy, bz, None, None),
+    };
+
+    match setting.style {
+        BarrierStyle::Solid { material } => {
+            for y in 1..=setting.height {
+                place_block(editor, material, y);
+            }
+            if setting.height > 1 {
+                place_block(editor, STONE_BRICK_SLAB, setting.height + 1);
+            }
+        }
+        BarrierStyle::Alternating { post_xz, chain_xz, spacing, use_post_on_edge } => {
+            let material =
+                if (edge && use_post_on_edge) || *counter >= spacing { post_xz[axis] }
+                else { chain_xz[axis] };
+
+            for y in 1..=setting.height {
+                place_block(editor, material, y);
+            }
+
+            // Reset the counter if we've reached the spacing limit. This is to avoid using modulos.
+            if *counter >= spacing {
+                *counter = 0;
+            }
+        }
+    }
+}
+
 pub fn generate_barriers(
     editor: &mut WorldEditor,
     element: &ProcessedElement,
     bridge_surface: &BridgeSurfaceMap,
 ) {
-    // Default values
-    let mut barrier_material: Block = COBBLESTONE_WALL;
-    let mut barrier_height: i32 = 2;
-
-    match element.tags().get("barrier").map(|s| s.as_str()) {
-        Some("bollard") => {
-            barrier_material = COBBLESTONE_WALL;
-            barrier_height = 1;
-        }
-        Some("kerb") => {
-            // Ignore kerbs
-            return;
-        }
-        Some("hedge") => {
-            barrier_material = OAK_LEAVES;
-            barrier_height = 2;
-        }
-        Some("fence") => {
-            // Handle fence sub-types
-            match element.tags().get("fence_type").map(|s| s.as_str()) {
-                Some("railing" | "bars" | "krest") => {
-                    barrier_material = STONE_BRICK_WALL;
-                    barrier_height = 1;
-                }
-                Some(
-                    "chain_link" | "metal" | "wire" | "barbed_wire" | "corrugated_metal"
-                    | "electric" | "metal_bars",
-                ) => {
-                    barrier_material = STONE_BRICK_WALL; // IRON_BARS
-                    barrier_height = 2;
-                }
-                Some("slatted" | "paling") => {
-                    barrier_material = OAK_FENCE;
-                    barrier_height = 1;
-                }
-                Some("wood" | "split_rail" | "panel" | "pole") => {
-                    barrier_material = OAK_FENCE;
-                    barrier_height = 2;
-                }
-                Some("concrete" | "stone") => {
-                    barrier_material = STONE_BRICK_WALL;
-                    barrier_height = 2;
-                }
-                Some("glass") => {
-                    barrier_material = GLASS;
-                    barrier_height = 1;
-                }
-                _ => {}
-            }
-        }
-        Some("wall") => {
-            barrier_material = STONE_BRICK_WALL;
-            barrier_height = 3;
-        }
-        _ => {}
-    }
-    // Tagged material takes priority over inferred
-    if let Some(barrier_mat) = element.tags().get("material") {
-        if barrier_mat == "brick" {
-            barrier_material = BRICK;
-        }
-        if barrier_mat == "concrete" {
-            barrier_material = LIGHT_GRAY_CONCRETE;
-        }
-        if barrier_mat == "metal" {
-            barrier_material = STONE_BRICK_WALL;
-        }
-    }
+    let Some(mut setting) = get_setting_for_barrier(element) else {
+        return; // Skip processing if no valid barrier type is found.
+    };
 
     if let ProcessedElement::Way(way) = element {
-        // Determine wall height
-        let wall_height: i32 = element
-            .tags()
-            .get("height")
-            .and_then(|height: &String| height.parse::<f32>().ok())
-            .map(|height: f32| height.round() as i32)
-            .unwrap_or(barrier_height)
-            .max(2); // Minimum height of 2
-
-        // Process nodes to create the barrier wall
         for i in 1..way.nodes.len() {
-            let prev: &crate::osm_parser::ProcessedNode = &way.nodes[i - 1];
-            let x1: i32 = prev.x;
-            let z1: i32 = prev.z;
+            let prev = &way.nodes[i - 1];
+            let cur = &way.nodes[i];
 
-            let cur: &crate::osm_parser::ProcessedNode = &way.nodes[i];
-            let x2: i32 = cur.x;
-            let z2: i32 = cur.z;
+            let bresenham_points = bresenham_line(prev.x, 0, prev.z, cur.x, 0, cur.z);
 
-            // Generate the line of coordinates between the two nodes
-            let bresenham_points: Vec<(i32, i32, i32)> = bresenham_line(x1, 0, z1, x2, 0, z2);
+            let mut counter = 0;
+            let axis = if prev.x.abs_diff(cur.x) > prev.z.abs_diff(cur.z) {  0 } else { 1 };
 
             for (bx, _, bz) in bresenham_points {
-                let deck = bridge_surface.nearby_deck_y(bx, bz, BRIDGE_BARRIER_NEARBY_RADIUS);
-                match deck {
-                    Some(deck_y) => {
-                        for y in 1..=wall_height {
-                            editor.set_block_absolute(
-                                barrier_material,
-                                bx,
-                                deck_y + y,
-                                bz,
-                                None,
-                                None,
-                            );
-                        }
-                        if wall_height > 1 {
-                            editor.set_block_absolute(
-                                STONE_BRICK_SLAB,
-                                bx,
-                                deck_y + wall_height + 1,
-                                bz,
-                                None,
-                                None,
-                            );
-                        }
-                    }
-                    None => {
-                        for y in 1..=wall_height {
-                            editor.set_block(barrier_material, bx, y, bz, None, None);
-                        }
-                        if wall_height > 1 {
-                            editor.set_block(STONE_BRICK_SLAB, bx, wall_height + 1, bz, None, None);
-                        }
-                    }
-                }
+                let edge = (bx, bz) == (prev.x, prev.z) || (bx, bz) == (cur.x, cur.z);
+
+                let deck_y = bridge_surface.nearby_deck_y(bx, bz, BRIDGE_BARRIER_NEARBY_RADIUS);
+                let mut local_counter = counter;
+
+                place_barrier(&mut setting, editor, bx, bz, deck_y, &mut local_counter, axis, edge);
+
+                // Increment counter only if it hasn't been modified in place_barrier.
+                counter = if counter == local_counter { counter + 1 } else { 0 };
             }
         }
     }
@@ -148,14 +208,13 @@ pub fn generate_barrier_nodes(
     bridge_surface: &BridgeSurfaceMap,
 ) {
     let deck = bridge_surface.nearby_deck_y(node.x, node.z, BRIDGE_BARRIER_NEARBY_RADIUS);
-    let place = |editor: &mut WorldEditor<'_>, block: Block, dy: i32| match deck {
+    let place_block = |editor: &mut WorldEditor<'_>, block: Block, dy: i32| match deck {
         Some(deck_y) => editor.set_block_absolute(block, node.x, deck_y + dy, node.z, None, None),
         None => editor.set_block(block, node.x, dy, node.z, None, None),
     };
+    
     match node.tags.get("barrier").map(|s| s.as_str()) {
-        Some("bollard") => {
-            place(editor, COBBLESTONE_WALL, 1);
-        }
+        Some("bollard") => place_block(editor, COBBLESTONE_WALL, 1),
         Some("stile" | "gate" | "swing_gate" | "lift_gate") => {
             /*editor.set_block(
                 OAK_TRAPDOOR,
@@ -200,13 +259,8 @@ pub fn generate_barrier_nodes(
                 None,
             );*/
         }
-        Some("block") => {
-            place(editor, STONE, 1);
-        }
-        Some("entrance") => {
-            place(editor, AIR, 1);
-        }
-        None => {}
+        Some("block") => place_block(editor, STONE, 1),
+        Some("entrance") => place_block(editor, AIR, 1),
         _ => {}
     }
 }

--- a/src/element_processing/barriers.rs
+++ b/src/element_processing/barriers.rs
@@ -3,94 +3,137 @@ use crate::bresenham::bresenham_line;
 use crate::element_processing::bridges::BridgeSurfaceMap;
 use crate::osm_parser::{ProcessedElement, ProcessedNode};
 use crate::world_editor::WorldEditor;
+use fastnbt::Value;
+use std::collections::HashMap;
 
 const BRIDGE_BARRIER_NEARBY_RADIUS: i32 = 2;
 
+// Should probably be moved to a different file so it can be shared and reused.
+#[derive(Clone, Copy)]
+enum Axis {
+    X,
+    Z,
+}
+
+enum BarrierMaterial {
+    Simple(BlockWithProperties),
+    Axial { x: BlockWithProperties, z: BlockWithProperties },
+}
+
+#[allow(dead_code)]
+impl BarrierMaterial {
+    fn simple(block: Block) -> Self {
+        Self::Simple(BlockWithProperties::new(block, None))
+    }
+    
+    fn simple_with_properties(block: BlockWithProperties) -> Self {
+        Self::Simple(block)
+    }
+
+    fn axial(x: Block, z: Block) -> Self {
+        Self::Axial {
+            x: BlockWithProperties::new(x, None),
+            z: BlockWithProperties::new(z, None),
+        }
+    }
+
+    fn axial_with_properties(x: BlockWithProperties, z: BlockWithProperties) -> Self {
+        Self::Axial { x, z }
+    }
+
+    fn get(&self, axis: Axis) -> &BlockWithProperties {
+        match self {
+            BarrierMaterial::Simple(block) => block,
+            BarrierMaterial::Axial { x, z } => match axis {
+                Axis::X => x,
+                Axis::Z => z,
+            },
+        }
+    }
+}
+
 struct BarrierSetting {
-    pub style: BarrierStyle,
-    pub height: i32,
+    style: BarrierStyle,
+    height: i32,
+}
+
+impl BarrierSetting {
+    fn solid(block: Block, height: i32) -> Self {
+        Self {
+            style: BarrierStyle::Solid { material: BarrierMaterial::simple(block) },
+            height,
+        }
+    }
 }
 
 enum BarrierStyle {
     Solid {
-        material: Block,
+        material: BarrierMaterial,
     },
     Alternating {
-        post_xz: [Block; 2],
-        chain_xz: [Block; 2],
+        post_material: BarrierMaterial,
+        link_material: BarrierMaterial,
+        top_material: Option<BarrierMaterial>,
         spacing: usize,
         use_post_on_edge: bool,
     },
 }
 
+fn fence_axis_properties(axis: Axis) -> Value {
+    let mut props = HashMap::new();
+    match axis {
+        Axis::X => {
+            props.insert("east".to_string(), Value::String("true".to_string()));
+            props.insert("west".to_string(), Value::String("true".to_string()));
+        }
+        Axis::Z => {
+            props.insert("north".to_string(), Value::String("true".to_string()));
+            props.insert("south".to_string(), Value::String("true".to_string()));
+        }
+    }
+    Value::Compound(props)
+}
+
 fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting> {
+    let iron_bars_x: BlockWithProperties = BlockWithProperties::new(IRON_BARS, Some(fence_axis_properties(Axis::X)));
+    let iron_bars_z: BlockWithProperties = BlockWithProperties::new(IRON_BARS, Some(fence_axis_properties(Axis::Z)));
+
     // Determine the base settinguration from tags.
     let setting = match element.tags().get("barrier").map(|s| s.as_str()) {
-        Some("bollard") => {
-            Some(BarrierSetting {
-                style: BarrierStyle::Solid { material: COBBLESTONE_WALL },
-                height: 1
-            })
-        }
+        Some("bollard") => Some(BarrierSetting::solid(COBBLESTONE_WALL, 1)),
         Some("kerb") => None, // Ignore kerbs.
-        Some("hedge") => {
-            Some(BarrierSetting {
-                style: BarrierStyle::Solid { material: OAK_LEAVES },
-                height: 2
-            })
-        }
-        Some("wall") => {
-            Some(BarrierSetting {
-                style: BarrierStyle::Solid { material: STONE_BRICK_WALL },
-                height: 3
-            })
-        }
+        Some("hedge") => Some(BarrierSetting::solid(OAK_LEAVES, 2)),
+        Some("wall") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 3)),
         Some("fence") => {
+            // Handle fence sub-types
             match element.tags().get("fence_type").map(|s| s.as_str()) {
-                Some("railing" | "bars" | "krest") => {
+                Some("railing" | "bars" | "krest") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 1)),
+                Some("chain_link" | "metal" | "wire" | "corrugated_metal" | "metal_bars") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)),
+                Some("slatted" | "paling") => Some(BarrierSetting::solid(OAK_FENCE, 1)),
+                Some("wood" | "split_rail" | "panel" | "pole") => Some(BarrierSetting::solid(OAK_FENCE, 2)),
+                Some("concrete" | "stone") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)),
+                Some("glass") => Some(BarrierSetting::solid(GLASS, 1)),
+                Some("barbed_wire") => {
                     Some(BarrierSetting {
-                        style: BarrierStyle::Solid { material: STONE_BRICK_WALL },
-                        height: 1
-                    })
-                }
-                Some("chain_link" | "metal" | "wire" | "barbed_wire" | "corrugated_metal" | "metal_bars") => {
-                    Some(BarrierSetting {
-                        style: BarrierStyle::Solid { material: STONE_BRICK_WALL },
+                        style: BarrierStyle::Alternating {
+                            post_material: BarrierMaterial::simple(ANDESITE_WALL),
+                            link_material: BarrierMaterial::axial_with_properties(iron_bars_x.clone(), iron_bars_z.clone()),
+                            top_material: Some(BarrierMaterial::simple(COBWEB)),
+                            spacing: 3,
+                            use_post_on_edge: true,
+                        },
                         height: 2
                     })
                 }
                 Some("electric") => {
                     Some(BarrierSetting {
                         style: BarrierStyle::Alternating {
-                            post_xz: [OAK_FENCE, OAK_FENCE],
-                            chain_xz: [CHAIN_X, CHAIN_Z],
+                            post_material: BarrierMaterial::simple(OAK_FENCE),
+                            link_material: BarrierMaterial::axial(CHAIN_X, CHAIN_Z),
+                            top_material: None,
                             spacing: 2,
                             use_post_on_edge: true,
                         },
-                        height: 1
-                    })
-                }
-                Some("slatted" | "paling") => {
-                    Some(BarrierSetting {
-                        style: BarrierStyle::Solid { material: OAK_FENCE },
-                        height: 1
-                    })
-                }
-                Some("wood" | "split_rail" | "panel" | "pole") => {
-                    Some(BarrierSetting {
-                        style: BarrierStyle::Solid { material: OAK_FENCE },
-                        height: 2
-                    })
-                }
-                Some("concrete" | "stone") => {
-                    Some(BarrierSetting {
-                        style: BarrierStyle::Solid { material: STONE_BRICK_WALL },
-                        height: 2
-                    })
-                }
-                Some("glass") => {
-                    Some(BarrierSetting {
-                        style: BarrierStyle::Solid { material: GLASS },
                         height: 1
                     })
                 }
@@ -108,9 +151,9 @@ fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting>
     if let Some(barrier_mat) = element.tags().get("material") {
         if let BarrierStyle::Solid { ref mut material } = setting.style {
             match barrier_mat.as_str() {
-                "brick" => *material = BRICK,
-                "concrete" => *material = LIGHT_GRAY_CONCRETE,
-                "metal" => *material = STONE_BRICK_WALL,
+                "brick" => *material = BarrierMaterial::simple(BRICK),
+                "concrete" => *material = BarrierMaterial::simple(LIGHT_GRAY_CONCRETE),
+                "metal" => *material = BarrierMaterial::simple(STONE_BRICK_WALL),
                 _ => {}
             }
         }
@@ -127,53 +170,12 @@ fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting>
     Some(setting)
 }
 
-fn place_barrier(
-    setting: &mut BarrierSetting, 
-    editor: &mut WorldEditor, 
-    bx: i32, 
-    bz: i32, 
-    deck_y: Option<i32>,
-    counter: &mut usize,
-    axis: usize,
-    edge: bool,
-) {
-    let place_block = |editor: &mut WorldEditor, block: Block, dy: i32| match deck_y {
-        Some(y) => editor.set_block_absolute(block, bx, y + dy, bz, None, None),
-        None => editor.set_block(block, bx, dy, bz, None, None),
-    };
-
-    match setting.style {
-        BarrierStyle::Solid { material } => {
-            for y in 1..=setting.height {
-                place_block(editor, material, y);
-            }
-            if setting.height > 1 {
-                place_block(editor, STONE_BRICK_SLAB, setting.height + 1);
-            }
-        }
-        BarrierStyle::Alternating { post_xz, chain_xz, spacing, use_post_on_edge } => {
-            let material =
-                if (edge && use_post_on_edge) || *counter >= spacing { post_xz[axis] }
-                else { chain_xz[axis] };
-
-            for y in 1..=setting.height {
-                place_block(editor, material, y);
-            }
-
-            // Reset the counter if we've reached the spacing limit. This is to avoid using modulos.
-            if *counter >= spacing {
-                *counter = 0;
-            }
-        }
-    }
-}
-
 pub fn generate_barriers(
     editor: &mut WorldEditor,
     element: &ProcessedElement,
     bridge_surface: &BridgeSurfaceMap,
 ) {
-    let Some(mut setting) = get_setting_for_barrier(element) else {
+    let Some(setting) = get_setting_for_barrier(element) else {
         return; // Skip processing if no valid barrier type is found.
     };
 
@@ -184,19 +186,18 @@ pub fn generate_barriers(
 
             let bresenham_points = bresenham_line(prev.x, 0, prev.z, cur.x, 0, cur.z);
 
-            let mut counter = 0;
-            let axis = if prev.x.abs_diff(cur.x) > prev.z.abs_diff(cur.z) {  0 } else { 1 };
+            let axis = if prev.x.abs_diff(cur.x) > prev.z.abs_diff(cur.z) {
+                Axis::X
+            } else {
+                Axis::Z
+            };
 
+            let mut counter = 0;
             for (bx, _, bz) in bresenham_points {
                 let edge = (bx, bz) == (prev.x, prev.z) || (bx, bz) == (cur.x, cur.z);
-
                 let deck_y = bridge_surface.nearby_deck_y(bx, bz, BRIDGE_BARRIER_NEARBY_RADIUS);
-                let mut local_counter = counter;
-
-                place_barrier(&mut setting, editor, bx, bz, deck_y, &mut local_counter, axis, edge);
-
-                // Increment counter only if it hasn't been modified in place_barrier.
-                counter = if counter == local_counter { counter + 1 } else { 0 };
+                place_barrier(&setting, editor, bx, bz, deck_y, counter, axis, edge);
+                counter += 1;
             }
         }
     }
@@ -262,5 +263,46 @@ pub fn generate_barrier_nodes(
         Some("block") => place_block(editor, STONE, 1),
         Some("entrance") => place_block(editor, AIR, 1),
         _ => {}
+    }
+}
+
+fn place_barrier(
+    setting: &BarrierSetting, 
+    editor: &mut WorldEditor, 
+    bx: i32, 
+    bz: i32, 
+    deck_y: Option<i32>,
+    counter: usize,
+    axis: Axis,
+    edge: bool,
+) {
+    let place_block = |editor: &mut WorldEditor, block: BlockWithProperties, dy: i32| match deck_y {
+        Some(y) => editor.set_block_with_properties_absolute(block, bx, y + dy, bz, None, None),
+        None => editor.set_block_with_properties(block, bx, dy, bz, None, None),
+    };
+
+    match &setting.style {
+        BarrierStyle::Solid { material } => {
+            for y in 1..=setting.height {
+                place_block(editor, material.get(axis).clone(), y);
+            }
+            if setting.height > 1 {
+                place_block(editor, BlockWithProperties::new(STONE_BRICK_SLAB, None), setting.height + 1);
+            }
+        }
+        BarrierStyle::Alternating { post_material, link_material, top_material, spacing, use_post_on_edge } => {
+            let is_post = (edge && *use_post_on_edge) || counter % spacing == 0;
+            let material =
+                if is_post { post_material.get(axis).clone() }
+                else { link_material.get(axis).clone() };
+
+            for y in 1..=setting.height {
+                place_block(editor, material.clone(), y);
+            }
+
+            if let Some(top_material) = top_material {
+                place_block(editor, top_material.get(axis).clone(), setting.height + 1);
+            }
+        }
     }
 }

--- a/src/element_processing/barriers.rs
+++ b/src/element_processing/barriers.rs
@@ -17,14 +17,17 @@ enum Axis {
 
 enum BarrierMaterial {
     Simple(BlockWithProperties),
-    Axial { x: BlockWithProperties, z: BlockWithProperties },
+    Axial {
+        x: BlockWithProperties,
+        z: BlockWithProperties,
+    },
 }
 
 impl BarrierMaterial {
     fn simple(block: Block) -> Self {
         Self::Simple(BlockWithProperties::simple(block))
     }
-    
+
     fn simple_with_properties(block: BlockWithProperties) -> Self {
         Self::Simple(block)
     }
@@ -104,12 +107,17 @@ fn chain_y_properties() -> Value {
 }
 
 fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting> {
-    let iron_bars_x: BlockWithProperties = BlockWithProperties::new(IRON_BARS, Some(fence_axis_properties(Axis::X)));
-    let iron_bars_z: BlockWithProperties = BlockWithProperties::new(IRON_BARS, Some(fence_axis_properties(Axis::Z)));
-    let chain_y: BlockWithProperties = BlockWithProperties::new(CHAIN_Z, Some(chain_y_properties()));
+    let iron_bars_x: BlockWithProperties =
+        BlockWithProperties::new(IRON_BARS, Some(fence_axis_properties(Axis::X)));
+    let iron_bars_z: BlockWithProperties =
+        BlockWithProperties::new(IRON_BARS, Some(fence_axis_properties(Axis::Z)));
+    let chain_y: BlockWithProperties =
+        BlockWithProperties::new(CHAIN_Z, Some(chain_y_properties()));
 
-    let oak_fence_x: BlockWithProperties = BlockWithProperties::new(OAK_FENCE, Some(fence_axis_properties(Axis::X)));
-    let oak_fence_z: BlockWithProperties = BlockWithProperties::new(OAK_FENCE, Some(fence_axis_properties(Axis::Z)));
+    let oak_fence_x: BlockWithProperties =
+        BlockWithProperties::new(OAK_FENCE, Some(fence_axis_properties(Axis::X)));
+    let oak_fence_z: BlockWithProperties =
+        BlockWithProperties::new(OAK_FENCE, Some(fence_axis_properties(Axis::Z)));
 
     // Determine the base settinguration from tags.
     // https://wiki.openstreetmap.org/wiki/Key:barrier
@@ -128,39 +136,64 @@ fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting>
                 Some("concrete") => Some(BarrierSetting::solid(ANDESITE_WALL, 2)),
                 Some("stone") => Some(BarrierSetting::solid(STONE_BRICK_WALL, 2)),
                 Some("glass") => Some(BarrierSetting::solid(GLASS, 1)),
-                Some("panel" | "slatted") => Some(BarrierSetting { // TODO: spruce trapdoors or shelves.
+                Some("panel" | "slatted") => Some(BarrierSetting {
+                    // TODO: spruce trapdoors or shelves.
                     style: BarrierStyle::Solid {
-                        material: BarrierMaterial::axial_with_properties(oak_fence_x.clone(), oak_fence_z.clone()),
+                        material: BarrierMaterial::axial_with_properties(
+                            oak_fence_x.clone(),
+                            oak_fence_z.clone(),
+                        ),
                         top_material: None,
                     },
-                    height: 2
+                    height: 2,
                 }),
-                Some("paling" | "pole" | "post_and_rail" | "roundpole" | "split_rail" | "wood") => Some(BarrierSetting {
-                    style: BarrierStyle::Solid {
-                        material: BarrierMaterial::axial_with_properties(oak_fence_x.clone(), oak_fence_z.clone()),
-                        top_material: None,
-                    },
-                    height: 1
-                }),
-                Some("bars" | "railing" | "krest" | "metal" | "chain_link" | "metal_bars" | "temporary" | "welded_diamond_mesh" | "wire") => Some(BarrierSetting {
+                Some("paling" | "pole" | "post_and_rail" | "roundpole" | "split_rail" | "wood") => {
+                    Some(BarrierSetting {
+                        style: BarrierStyle::Solid {
+                            material: BarrierMaterial::axial_with_properties(
+                                oak_fence_x.clone(),
+                                oak_fence_z.clone(),
+                            ),
+                            top_material: None,
+                        },
+                        height: 1,
+                    })
+                }
+                Some(
+                    "bars"
+                    | "railing"
+                    | "krest"
+                    | "metal"
+                    | "chain_link"
+                    | "metal_bars"
+                    | "temporary"
+                    | "welded_diamond_mesh"
+                    | "wire",
+                ) => Some(BarrierSetting {
                     style: BarrierStyle::Alternating {
                         post_material: BarrierMaterial::simple_with_properties(chain_y.clone()),
-                        link_material: BarrierMaterial::axial_with_properties(iron_bars_x.clone(), iron_bars_z.clone()),
+                        link_material: BarrierMaterial::axial_with_properties(
+                            iron_bars_x.clone(),
+                            iron_bars_z.clone(),
+                        ),
                         top_material: None,
                         spacing: 2,
                         use_post_on_edge: true,
                     },
-                    height: 2
+                    height: 2,
                 }),
                 Some("barbed_wire") => Some(BarrierSetting {
                     style: BarrierStyle::Alternating {
                         post_material: BarrierMaterial::simple(ANDESITE_WALL),
-                        link_material: BarrierMaterial::axial_with_properties(iron_bars_x.clone(), iron_bars_z.clone()),
+                        link_material: BarrierMaterial::axial_with_properties(
+                            iron_bars_x.clone(),
+                            iron_bars_z.clone(),
+                        ),
                         top_material: Some(BarrierMaterial::simple(COBWEB)),
                         spacing: 3,
                         use_post_on_edge: true,
                     },
-                    height: 2
+                    height: 2,
                 }),
                 Some("electric") => Some(BarrierSetting {
                     style: BarrierStyle::Alternating {
@@ -170,12 +203,12 @@ fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting>
                         spacing: 2,
                         use_post_on_edge: true,
                     },
-                    height: 1
+                    height: 1,
                 }),
-                _ => None
+                _ => None,
             }
         }
-        _ => None
+        _ => None,
     };
 
     let Some(mut setting) = setting else {
@@ -184,7 +217,10 @@ fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting>
 
     // Apply tag overrides for the material.
     if let Some(barrier_mat) = element.tags().get("material") {
-        if let BarrierStyle::Solid { ref mut material, .. } = setting.style {
+        if let BarrierStyle::Solid {
+            ref mut material, ..
+        } = setting.style
+        {
             match barrier_mat.as_str() {
                 "brick" => *material = BarrierMaterial::simple(BRICK),
                 "concrete" => *material = BarrierMaterial::simple(LIGHT_GRAY_CONCRETE),
@@ -193,7 +229,7 @@ fn get_setting_for_barrier(element: &ProcessedElement) -> Option<BarrierSetting>
             }
         }
     }
-    
+
     // Apply tag overrides for the height.
     if let Some(h_str) = element.tags().get("height") {
         if let Ok(h_f32) = h_str.parse::<f32>() {
@@ -248,7 +284,7 @@ pub fn generate_barrier_nodes(
         Some(deck_y) => editor.set_block_absolute(block, node.x, deck_y + dy, node.z, None, None),
         None => editor.set_block(block, node.x, dy, node.z, None, None),
     };
-    
+
     match node.tags.get("barrier").map(|s| s.as_str()) {
         Some("bollard") => place_block(editor, COBBLESTONE_WALL, 1),
         Some("stile" | "gate" | "swing_gate" | "lift_gate") => {
@@ -302,10 +338,10 @@ pub fn generate_barrier_nodes(
 }
 
 fn place_barrier(
-    setting: &BarrierSetting, 
-    editor: &mut WorldEditor, 
-    bx: i32, 
-    bz: i32, 
+    setting: &BarrierSetting,
+    editor: &mut WorldEditor,
+    bx: i32,
+    bz: i32,
     deck_y: Option<i32>,
     counter: usize,
     axis: Axis,
@@ -317,7 +353,10 @@ fn place_barrier(
     };
 
     match &setting.style {
-        BarrierStyle::Solid { material, top_material } => {
+        BarrierStyle::Solid {
+            material,
+            top_material,
+        } => {
             for y in 1..=setting.height {
                 place_block(editor, material.get(axis).clone(), y);
             }
@@ -327,11 +366,19 @@ fn place_barrier(
                 }
             }
         }
-        BarrierStyle::Alternating { post_material, link_material, top_material, spacing, use_post_on_edge } => {
-            let is_post = (edge && *use_post_on_edge) || counter % (spacing+1) == 0;
-            let material =
-                if is_post { post_material.get(axis).clone() }
-                else { link_material.get(axis).clone() };
+        BarrierStyle::Alternating {
+            post_material,
+            link_material,
+            top_material,
+            spacing,
+            use_post_on_edge,
+        } => {
+            let is_post = (edge && *use_post_on_edge) || counter % (spacing + 1) == 0;
+            let material = if is_post {
+                post_material.get(axis).clone()
+            } else {
+                link_material.get(axis).clone()
+            };
 
             for y in 1..=setting.height {
                 place_block(editor, material.clone(), y);

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -838,7 +838,7 @@ impl<'a> WorldEditor<'a> {
             override_blacklist,
         );
     }
-    
+
     /// Sets a block with properties of the specified type at the given coordinates.
     ///
     /// Y value is interpreted as an offset from ground level.

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -838,6 +838,37 @@ impl<'a> WorldEditor<'a> {
             override_blacklist,
         );
     }
+    
+    /// Sets a block with properties of the specified type at the given coordinates.
+    ///
+    /// Y value is interpreted as an offset from ground level.
+    #[inline]
+    pub fn set_block_with_properties(
+        &mut self,
+        block_with_props: BlockWithProperties,
+        x: i32,
+        y: i32,
+        z: i32,
+        override_whitelist: Option<&[Block]>,
+        override_blacklist: Option<&[Block]>,
+    ) {
+        // Short-circuit for out-of-bbox writes before we pay for a
+        // ground-level lookup (bilinear interpolation of the elevation
+        // grid). The downstream `set_block_with_properties_absolute`
+        // does the same check, but only *after* we would have done the
+        // elevation work.
+        if !self.xzbbox.contains(&XZPoint::new(x, z)) {
+            return;
+        }
+        self.set_block_with_properties_absolute(
+            block_with_props,
+            x,
+            self.get_absolute_y(x, y, z),
+            z,
+            override_whitelist,
+            override_blacklist,
+        );
+    }
 
     /// Sets a block of the specified type at the given coordinates with absolute Y value.
     #[inline]


### PR DESCRIPTION
### What Changed?
- Refactored the barrier generation to allow for more customization while avoiding redundancies.
- Improved generation for the following fence types:
  - `paling`, `pole`, `post_and_rail`, `roundpole`, `split_rail`, `wood`
  - `panel`, `slatted` (W.I.P)
  - `knee_rail` (W.I.P)
  - `corrugated_metal` (W.I.P)
  - `net`
  - `concrete`
  - `bars`, `railing`, `krest`, `metal`, `chain_link`, `metal_bars`, `temporary`, `welded_diamond_mesh`, `wire`
  - `barbed_wire`
  - `electric`
- Added `set_block_with_properties` function in world_editor/mod.rs

### Illustrations

<img width="800" height="auto" alt="fence_electric" src="https://github.com/user-attachments/assets/82653e13-d294-4751-9f80-552a95f1ffc5" />
electric
<br><br>
<img width="800" height="auto" alt="fence_metal_bars" src="https://github.com/user-attachments/assets/bd607086-e642-450a-8da8-52d3531b2896" />
<img width="800" height="auto" alt="fence_chain_link" src="https://github.com/user-attachments/assets/909a4b1f-3207-42ff-a722-fdea647f575b" />
chain_link, metal_bars...
<br><br>
<img width="800" height="auto" alt="fence_wood" src="https://github.com/user-attachments/assets/64d67380-df65-4c44-ae45-a3e6e119deeb" />
paling, pole, post_and_rail...
<br><br>
<img width="1391" height="783" alt="fence_barbed_wire" src="https://github.com/user-attachments/assets/23b10174-2710-4b39-94ee-b8aedb566ed6" />
barbed_wire
