### PR TITLE
feat(water): per-cell water depth carving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,7 @@ Thumbs.db
 # Generated files
 /export.json
 /parsed_osm_data.txt
-/elevation_debug.png
-/landcover_debug*.png
+/*debug*.png
 /terrain-tile-cache
 /arnis-tile-cache
 

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -68,6 +68,9 @@ pub fn generate_world_with_options(
     };
     let ground = Arc::new(ground);
 
+    // Per-cell water depth field from the LC_WATER mask; empty without land cover.
+    let big_water_field = crate::water_depth::compute_big_water_field(&ground, &xzbbox);
+
     println!("{} Processing data...", "[4/7]".bold());
 
     // Build highway connectivity map once before processing
@@ -250,7 +253,12 @@ pub fn generate_world_with_options(
                 } else if let Some(val) = way.tags.get("waterway") {
                     if val == "dock" {
                         // docks count as water areas
-                        water_areas::generate_water_area_from_way(&mut editor, way, &xzbbox);
+                        water_areas::generate_water_area_from_way(
+                            &mut editor,
+                            way,
+                            &xzbbox,
+                            &big_water_field,
+                        );
                     } else {
                         waterways::generate_waterways(&mut editor, way);
                     }
@@ -349,7 +357,12 @@ pub fn generate_world_with_options(
                         .map(|val| val == "water" || val == "bay")
                         .unwrap_or(false)
                 {
-                    water_areas::generate_water_areas_from_relation(&mut editor, rel, &xzbbox);
+                    water_areas::generate_water_areas_from_relation(
+                        &mut editor,
+                        rel,
+                        &xzbbox,
+                        &big_water_field,
+                    );
                 } else if rel.tags.contains_key("natural") {
                     natural::generate_natural_from_relation(
                         &mut editor,
@@ -388,10 +401,9 @@ pub fn generate_world_with_options(
     process_pb.inc(element_counter % pb_batch_size);
     process_pb.finish();
 
-    // Drop remaining caches
+    // Keep road_mask alive for the LC_WATER carve below.
     drop(highway_connectivity);
     drop(flood_fill_cache);
-    drop(road_mask);
 
     // Generate ground layer (surface blocks, vegetation, shorelines, underground fill)
     ground_generation::generate_ground_layer(
@@ -401,6 +413,17 @@ pub fn generate_world_with_options(
         &xzbbox,
         &building_footprints,
     )?;
+
+    // Carve depth into ESA water cells (water_areas.rs only covers OSM polygons).
+    crate::water_depth::carve_lc_water_pass(
+        &mut editor,
+        ground.as_ref(),
+        &xzbbox,
+        &big_water_field,
+        &road_mask,
+    );
+
+    drop(road_mask);
 
     // Carve subway tunnel interiors now that underground is filled with stone.
     // This must happen after ground generation so AIR blocks are not overwritten.

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -258,6 +258,7 @@ pub fn generate_world_with_options(
                             way,
                             &xzbbox,
                             &big_water_field,
+                            &road_mask,
                         );
                     } else {
                         waterways::generate_waterways(&mut editor, way);
@@ -362,6 +363,7 @@ pub fn generate_world_with_options(
                         rel,
                         &xzbbox,
                         &big_water_field,
+                        &road_mask,
                     );
                 } else if rel.tags.contains_key("natural") {
                     natural::generate_natural_from_relation(

--- a/src/element_processing/water_areas.rs
+++ b/src/element_processing/water_areas.rs
@@ -1,5 +1,5 @@
-use crate::block_definitions::WATER;
 use crate::clipping::clip_water_ring_to_bbox;
+use crate::water_depth::{carve_water_column, BigWaterField};
 use crate::{
     coordinate_system::cartesian::{XZBBox, XZPoint},
     osm_parser::{ProcessedMemberRole, ProcessedNode, ProcessedRelation, ProcessedWay},
@@ -10,6 +10,7 @@ pub fn generate_water_area_from_way(
     editor: &mut WorldEditor,
     element: &ProcessedWay,
     _xzbbox: &XZBBox,
+    bwf: &BigWaterField,
 ) {
     let outers = [element.nodes.clone()];
     if !verify_closed_rings(&outers) {
@@ -17,13 +18,14 @@ pub fn generate_water_area_from_way(
         return;
     }
 
-    generate_water_areas(editor, &outers, &[]);
+    generate_water_areas(editor, &outers, &[], bwf);
 }
 
 pub fn generate_water_areas_from_relation(
     editor: &mut WorldEditor,
     element: &ProcessedRelation,
     xzbbox: &XZBBox,
+    bwf: &BigWaterField,
 ) {
     // Check if this is a water relation (either with water tag or natural=water)
     let is_water = element.tags.contains_key("water")
@@ -116,13 +118,14 @@ pub fn generate_water_areas_from_relation(
         return;
     }
 
-    generate_water_areas(editor, &outers, &inners);
+    generate_water_areas(editor, &outers, &inners, bwf);
 }
 
 fn generate_water_areas(
     editor: &mut WorldEditor,
     outers: &[Vec<ProcessedNode>],
     inners: &[Vec<ProcessedNode>],
+    bwf: &BigWaterField,
 ) {
     // Calculate polygon bounding box to limit fill area
     let mut poly_min_x = i32::MAX;
@@ -161,7 +164,9 @@ fn generate_water_areas(
         .map(|x| x.iter().map(|y| y.xz()).collect::<Vec<_>>())
         .collect();
 
-    scanline_fill_water(min_x, min_z, max_x, max_z, &outers_xz, &inners_xz, editor);
+    scanline_fill_water(
+        min_x, min_z, max_x, max_z, &outers_xz, &inners_xz, editor, bwf,
+    );
 }
 
 /// Verifies all rings are properly closed (first node matches last).
@@ -391,6 +396,7 @@ fn scanline_fill_water(
     outers: &[Vec<XZPoint>],
     inners: &[Vec<XZPoint>],
     editor: &mut WorldEditor,
+    bwf: &BigWaterField,
 ) {
     // Collect edges per outer ring so we can union their spans correctly,
     // even if multiple outer rings happen to overlap (invalid OSM, but
@@ -429,12 +435,12 @@ fn scanline_fill_water(
             for x in start..=end {
                 let water_y = editor.get_water_level(x, z);
                 let ground_y = editor.get_ground_level(x, z);
-                // Only place water where terrain is at or below the water
-                // surface — skip hillside blocks where the polygon extends
-                // above the actual waterline.
-                if ground_y <= water_y {
-                    editor.set_block_absolute(WATER, x, water_y, z, None, None);
+                // Skip hillside blocks the polygon claims above the waterline.
+                if ground_y > water_y {
+                    continue;
                 }
+                // depth_at is 0 for OSM-only water, giving a single surface block.
+                carve_water_column(editor, x, z, water_y, bwf.depth_at(x, z));
             }
         }
     }

--- a/src/element_processing/water_areas.rs
+++ b/src/element_processing/water_areas.rs
@@ -1,4 +1,5 @@
 use crate::clipping::clip_water_ring_to_bbox;
+use crate::floodfill_cache::RoadMaskBitmap;
 use crate::water_depth::{carve_water_column, BigWaterField};
 use crate::{
     coordinate_system::cartesian::{XZBBox, XZPoint},
@@ -11,6 +12,7 @@ pub fn generate_water_area_from_way(
     element: &ProcessedWay,
     _xzbbox: &XZBBox,
     bwf: &BigWaterField,
+    road_mask: &RoadMaskBitmap,
 ) {
     let outers = [element.nodes.clone()];
     if !verify_closed_rings(&outers) {
@@ -18,7 +20,7 @@ pub fn generate_water_area_from_way(
         return;
     }
 
-    generate_water_areas(editor, &outers, &[], bwf);
+    generate_water_areas(editor, &outers, &[], bwf, road_mask);
 }
 
 pub fn generate_water_areas_from_relation(
@@ -26,6 +28,7 @@ pub fn generate_water_areas_from_relation(
     element: &ProcessedRelation,
     xzbbox: &XZBBox,
     bwf: &BigWaterField,
+    road_mask: &RoadMaskBitmap,
 ) {
     // Check if this is a water relation (either with water tag or natural=water)
     let is_water = element.tags.contains_key("water")
@@ -118,7 +121,7 @@ pub fn generate_water_areas_from_relation(
         return;
     }
 
-    generate_water_areas(editor, &outers, &inners, bwf);
+    generate_water_areas(editor, &outers, &inners, bwf, road_mask);
 }
 
 fn generate_water_areas(
@@ -126,6 +129,7 @@ fn generate_water_areas(
     outers: &[Vec<ProcessedNode>],
     inners: &[Vec<ProcessedNode>],
     bwf: &BigWaterField,
+    road_mask: &RoadMaskBitmap,
 ) {
     // Calculate polygon bounding box to limit fill area
     let mut poly_min_x = i32::MAX;
@@ -165,7 +169,7 @@ fn generate_water_areas(
         .collect();
 
     scanline_fill_water(
-        min_x, min_z, max_x, max_z, &outers_xz, &inners_xz, editor, bwf,
+        min_x, min_z, max_x, max_z, &outers_xz, &inners_xz, editor, bwf, road_mask,
     );
 }
 
@@ -397,6 +401,7 @@ fn scanline_fill_water(
     inners: &[Vec<XZPoint>],
     editor: &mut WorldEditor,
     bwf: &BigWaterField,
+    road_mask: &RoadMaskBitmap,
 ) {
     // Collect edges per outer ring so we can union their spans correctly,
     // even if multiple outer rings happen to overlap (invalid OSM, but
@@ -433,6 +438,10 @@ fn scanline_fill_water(
 
         for (start, end) in fill_spans {
             for x in start..=end {
+                // Keep road/bridge surfaces (carve would overwrite them).
+                if road_mask.contains(x, z) {
+                    continue;
+                }
                 let water_y = editor.get_water_level(x, z);
                 let ground_y = editor.get_ground_level(x, z);
                 // Skip hillside blocks the polygon claims above the waterline.

--- a/src/element_processing/water_areas.rs
+++ b/src/element_processing/water_areas.rs
@@ -448,7 +448,7 @@ fn scanline_fill_water(
                 if ground_y > water_y {
                     continue;
                 }
-                // depth_at is 0 for OSM-only water, giving a single surface block.
+                // depth_at gives the carved depth (0 without land-cover water data).
                 carve_water_column(editor, x, z, water_y, bwf.depth_at(x, z));
             }
         }

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -175,6 +175,36 @@ impl Ground {
         );
     }
 
+    /// Local block bbox (min_x, min_z, max_x, max_z) covering all LC_WATER cells,
+    /// derived from the land-cover grid; None if no land cover or no water.
+    pub fn lc_water_block_bounds(&self) -> Option<(i32, i32, i32, i32)> {
+        let (lc, data) = match (&self.land_cover, &self.elevation_data) {
+            (Some(lc), Some(data)) => (lc, data),
+            _ => return None,
+        };
+        let (mut gx0, mut gz0, mut gx1, mut gz1) = (usize::MAX, usize::MAX, 0usize, 0usize);
+        let mut any = false;
+        for (z, row) in lc.grid.iter().enumerate() {
+            for (x, &c) in row.iter().enumerate() {
+                if c == land_cover::LC_WATER {
+                    gx0 = gx0.min(x);
+                    gx1 = gx1.max(x);
+                    gz0 = gz0.min(z);
+                    gz1 = gz1.max(z);
+                    any = true;
+                }
+            }
+        }
+        if !any {
+            return None;
+        }
+        let (x0, x1) =
+            crate::water_depth::grid_span_to_block_span(gx0, gx1, data.world_width, lc.width);
+        let (z0, z1) =
+            crate::water_depth::grid_span_to_block_span(gz0, gz1, data.world_height, lc.height);
+        Some((x0, z0, x1, z1))
+    }
+
     /// Returns the ESA WorldCover land cover class at the given coordinates.
     /// Returns 0 if land cover data is not available.
     #[inline(always)]

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -65,7 +65,7 @@ impl Ground {
         // post-processing pipeline for land-cover-aware artifact repair.
         // The elevation grid is built from the same (bbox, scale) so both
         // grids share dimensions (both use compute_grid_dims).
-        let (_, _, grid_w, grid_h) = compute_grid_dims(bbox, scale);
+        let (world_w, world_h, grid_w, grid_h) = compute_grid_dims(bbox, scale);
         let mut land_cover = if fetch_land_cover {
             let lc = land_cover::fetch_land_cover_data(bbox, grid_w, grid_h);
             if lc.is_some() {
@@ -76,6 +76,16 @@ impl Ground {
             lc
         } else {
             None
+        };
+
+        // Raise the floor just enough for the deepest water carve to clear bedrock.
+        let ground_level = match &land_cover {
+            Some(lc) => {
+                let max_depth =
+                    crate::water_depth::estimate_max_carve_depth(&lc.grid, world_w, world_h);
+                ground_level.max(crate::world_editor::MIN_Y + max_depth + 2)
+            }
+            None => ground_level,
         };
 
         match fetch_elevation_data(

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -78,8 +78,8 @@ impl Ground {
             None
         };
 
-        // Raise the floor just enough for the deepest water carve to clear bedrock.
-        let ground_level = match &land_cover {
+        // Raise the floor for the deepest water carve (elevation path only).
+        let water_floor = match &land_cover {
             Some(lc) => {
                 let max_depth =
                     crate::water_depth::estimate_max_carve_depth(&lc.grid, world_w, world_h);
@@ -91,7 +91,7 @@ impl Ground {
         match fetch_elevation_data(
             bbox,
             scale,
-            ground_level,
+            water_floor,
             disable_height_limit,
             extended_max_y,
             land_cover.as_mut(),
@@ -99,7 +99,7 @@ impl Ground {
         ) {
             Ok(elevation_data) => Self {
                 elevation_enabled: true,
-                ground_level,
+                ground_level: water_floor,
                 elevation_data: Some(elevation_data),
                 land_cover,
                 rotation_mask: None,

--- a/src/ground_generation.rs
+++ b/src/ground_generation.rs
@@ -318,18 +318,10 @@ pub fn generate_ground_layer(
                         }
 
                         if place_esa_water {
-                            // Single block of water at snapped level
+                            // Pre-paint; carve_lc_water_pass later overwrites with depth.
                             editor.set_block_if_absent_absolute(WATER, x, water_y, z);
-
-                            // Floor: sand/gravel/clay + sandstone below
-                            let h = land_cover::coord_hash(x, z);
-                            let floor_block = match h % 5 {
-                                0 => GRAVEL,
-                                1 => CLAY,
-                                _ => SAND,
-                            };
                             if water_y - 1 > MIN_Y {
-                                editor.set_block_if_absent_absolute(floor_block, x, water_y - 1, z);
+                                editor.set_block_if_absent_absolute(SAND, x, water_y - 1, z);
                             }
                             if water_y - 2 > MIN_Y {
                                 editor.set_block_if_absent_absolute(SANDSTONE, x, water_y - 2, z);
@@ -1132,7 +1124,7 @@ pub fn generate_ground_layer(
 ///
 /// Cost: 4 hash calls + a few f64 ops per block — still well under 100 ns,
 /// negligible over the whole ground pass.
-fn value_noise_01(x: i32, z: i32, scale: i32) -> f64 {
+pub(crate) fn value_noise_01(x: i32, z: i32, scale: i32) -> f64 {
     let s = scale.max(1);
     // Integer lattice cell containing (x, z). div_euclid gives floor
     // division for negative coordinates too, so patches tile uniformly

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod telemetry;
 #[cfg(test)]
 mod test_utilities;
 mod version_check;
+mod water_depth;
 mod world_editor;
 mod world_utils;
 

--- a/src/water_depth.rs
+++ b/src/water_depth.rs
@@ -1,0 +1,449 @@
+//! Per-cell water depth carving from a chamfer-3-4 distance transform over the LC_WATER mask.
+
+use crate::block_definitions::{GRAVEL, SAND, SANDSTONE, STONE, WATER};
+use crate::coordinate_system::cartesian::{XZBBox, XZPoint};
+use crate::floodfill_cache::RoadMaskBitmap;
+use crate::ground::Ground;
+use crate::land_cover::LC_WATER;
+use crate::world_editor::{WorldEditor, MIN_Y};
+
+/// Flat shoal width in chamfer-DT units; slope only starts past it.
+const SHOAL_DT_UNITS: u16 = 9;
+
+/// DT saturation cap. Depth clamps to <=6 long before this.
+const DT_MAX: u8 = u8::MAX;
+
+/// Deepest block the carve places below the surface (max depth + SAND bed).
+pub const MAX_CARVE_BELOW_SURFACE: i32 = 7;
+
+#[inline]
+fn nibble_get(buf: &[u8], i: usize) -> u8 {
+    let byte = buf[i >> 1];
+    if i & 1 == 0 {
+        byte & 0x0F
+    } else {
+        byte >> 4
+    }
+}
+
+#[inline]
+fn nibble_set(buf: &mut [u8], i: usize, v: u8) {
+    let byte = &mut buf[i >> 1];
+    if i & 1 == 0 {
+        *byte = (*byte & 0xF0) | (v & 0x0F);
+    } else {
+        *byte = (*byte & 0x0F) | (v << 4);
+    }
+}
+
+#[inline]
+fn bit_get(b: &[u64], i: usize) -> bool {
+    (b[i >> 6] >> (i & 63)) & 1 == 1
+}
+
+#[inline]
+fn bit_set(b: &mut [u64], i: usize) {
+    b[i >> 6] |= 1u64 << (i & 63);
+}
+
+/// Baked per-cell carve depth (0..=6), nibble-packed over the water sub-rect.
+pub struct BigWaterField {
+    depth: Vec<u8>,
+    width: usize,
+    height: usize,
+    min_x: i32,
+    min_z: i32,
+}
+
+impl BigWaterField {
+    fn empty() -> Self {
+        Self {
+            depth: Vec::new(),
+            width: 0,
+            height: 0,
+            min_x: 0,
+            min_z: 0,
+        }
+    }
+
+    #[inline]
+    fn local_idx(&self, x: i32, z: i32) -> Option<usize> {
+        let lx = i64::from(x) - i64::from(self.min_x);
+        let lz = i64::from(z) - i64::from(self.min_z);
+        if lx < 0 || lz < 0 || lx as usize >= self.width || lz as usize >= self.height {
+            return None;
+        }
+        Some(lz as usize * self.width + lx as usize)
+    }
+
+    /// Carve depth at the cell; 0 outside the water sub-rect.
+    #[inline]
+    pub fn depth_at(&self, x: i32, z: i32) -> i32 {
+        match self.local_idx(x, z) {
+            Some(i) => i32::from(nibble_get(&self.depth, i)),
+            None => 0,
+        }
+    }
+}
+
+/// Run a chamfer DT over the LC_WATER mask and bake per-cell carve depth.
+pub fn compute_big_water_field(ground: &Ground, xzbbox: &XZBBox) -> BigWaterField {
+    if !ground.has_land_cover() {
+        return BigWaterField::empty();
+    }
+    let min_x = xzbbox.min_x();
+    let max_x = xzbbox.max_x();
+    let min_z = xzbbox.min_z();
+    let max_z = xzbbox.max_z();
+
+    let is_lc_water =
+        |x: i32, z: i32| ground.cover_class(XZPoint::new(x - min_x, z - min_z)) == LC_WATER;
+
+    // Tight bbox of all water cells.
+    let (mut wmin_x, mut wmin_z, mut wmax_x, mut wmax_z) = (i32::MAX, i32::MAX, i32::MIN, i32::MIN);
+    for z in min_z..=max_z {
+        for x in min_x..=max_x {
+            if is_lc_water(x, z) {
+                wmin_x = wmin_x.min(x);
+                wmax_x = wmax_x.max(x);
+                wmin_z = wmin_z.min(z);
+                wmax_z = wmax_z.max(z);
+            }
+        }
+    }
+    if wmax_x < wmin_x {
+        return BigWaterField::empty();
+    }
+
+    // Pad by one for the shore ring (clamped); keeps the DT identical to full-bbox.
+    let smin_x = (wmin_x - 1).max(min_x);
+    let smax_x = (wmax_x + 1).min(max_x);
+    let smin_z = (wmin_z - 1).max(min_z);
+    let smax_z = (wmax_z + 1).min(max_z);
+    let sw = (smax_x - smin_x + 1) as usize;
+    let sh = (smax_z - smin_z + 1) as usize;
+    let total = sw.checked_mul(sh).expect("water sub-rect size overflow");
+
+    // Seed DT: water = DT_MAX (unreached), shore/land = 0.
+    let mut dt = vec![0u8; total];
+    for z in smin_z..=smax_z {
+        let row = (z - smin_z) as usize * sw;
+        for x in smin_x..=smax_x {
+            if is_lc_water(x, z) {
+                dt[row + (x - smin_x) as usize] = DT_MAX;
+            }
+        }
+    }
+    chamfer_3_4_dt(&mut dt, sw, sh);
+
+    // Per-component BFS for the max DT, then bake each cell's depth.
+    let mut depth = vec![0u8; total.div_ceil(2)];
+    let mut visited = vec![0u64; total.div_ceil(64)];
+    let mut comp: Vec<u32> = Vec::new();
+    for start in 0..total {
+        if dt[start] == 0 || bit_get(&visited, start) {
+            continue;
+        }
+        comp.clear();
+        comp.push(start as u32);
+        bit_set(&mut visited, start);
+        let mut comp_max = 0u8;
+        let mut head = 0;
+        while head < comp.len() {
+            let idx = comp[head] as usize;
+            head += 1;
+            comp_max = comp_max.max(dt[idx]);
+            let i = idx % sw;
+            let j = idx / sw;
+            let mut visit = |n: usize, comp: &mut Vec<u32>| {
+                if dt[n] != 0 && !bit_get(&visited, n) {
+                    bit_set(&mut visited, n);
+                    comp.push(n as u32);
+                }
+            };
+            if i > 0 {
+                visit(idx - 1, &mut comp);
+            }
+            if i + 1 < sw {
+                visit(idx + 1, &mut comp);
+            }
+            if j > 0 {
+                visit(idx - sw, &mut comp);
+            }
+            if j + 1 < sh {
+                visit(idx + sw, &mut comp);
+            }
+        }
+        let cm = u16::from(comp_max);
+        for &c in &comp {
+            let idx = c as usize;
+            let x = smin_x + (idx % sw) as i32;
+            let z = smin_z + (idx / sw) as i32;
+            let d = ocean_depth_for_cell(x, z, u16::from(dt[idx]), cm);
+            nibble_set(&mut depth, idx, d as u8);
+        }
+    }
+
+    BigWaterField {
+        depth,
+        width: sw,
+        height: sh,
+        min_x: smin_x,
+        min_z: smin_z,
+    }
+}
+
+/// In-place two-sweep chamfer-3-4 DT. Input: 0 = shore, `DT_MAX` = water seed.
+fn chamfer_3_4_dt(d: &mut [u8], w: usize, h: usize) {
+    let step = |v: u8, add: u8| v.saturating_add(add);
+    for j in 0..h {
+        for i in 0..w {
+            let idx = j * w + i;
+            if d[idx] == 0 {
+                continue;
+            }
+            let mut best = d[idx];
+            if i > 0 {
+                best = best.min(step(d[idx - 1], 3));
+            }
+            if j > 0 {
+                best = best.min(step(d[idx - w], 3));
+                if i > 0 {
+                    best = best.min(step(d[idx - w - 1], 4));
+                }
+                if i + 1 < w {
+                    best = best.min(step(d[idx - w + 1], 4));
+                }
+            }
+            d[idx] = best;
+        }
+    }
+    for j in (0..h).rev() {
+        for i in (0..w).rev() {
+            let idx = j * w + i;
+            if d[idx] == 0 {
+                continue;
+            }
+            let mut best = d[idx];
+            if i + 1 < w {
+                best = best.min(step(d[idx + 1], 3));
+            }
+            if j + 1 < h {
+                best = best.min(step(d[idx + w], 3));
+                if i > 0 {
+                    best = best.min(step(d[idx + w - 1], 4));
+                }
+                if i + 1 < w {
+                    best = best.min(step(d[idx + w + 1], 4));
+                }
+            }
+            d[idx] = best;
+        }
+    }
+}
+
+/// Width-tiered max carve depth. Bigger bodies reach a deeper floor.
+#[inline]
+fn polygon_local_max(component_max_units: u16) -> i32 {
+    if component_max_units < 21 {
+        2
+    } else if component_max_units < 45 {
+        3
+    } else if component_max_units < 75 {
+        4
+    } else {
+        6
+    }
+}
+
+/// Depth from an effective DT and component max: ramp past the shoal, tier-clamped.
+fn depth_from_dt(dt_eff: f64, component_max_units: u16) -> i32 {
+    if dt_eff < f64::from(SHOAL_DT_UNITS) {
+        return 0;
+    }
+    let local_max = polygon_local_max(component_max_units);
+    let slope = if component_max_units < 21 {
+        1.0 / 3.0
+    } else if component_max_units < 45 {
+        1.0 / 4.0
+    } else if component_max_units < 75 {
+        1.0 / 6.0
+    } else {
+        1.0 / 8.0
+    };
+    let dist_blocks = (dt_eff - f64::from(SHOAL_DT_UNITS)) / 3.0;
+    ((dist_blocks * slope).floor() as i32).clamp(0, local_max)
+}
+
+/// Per-cell carve depth, with deterministic contour wobble on the bank lines.
+fn ocean_depth_for_cell(x: i32, z: i32, dt_units: u16, component_max_units: u16) -> i32 {
+    if dt_units == 0 {
+        return 0;
+    }
+    let wobble = (crate::ground_generation::value_noise_01(x, z, 12) - 0.5) * 4.0;
+    depth_from_dt(f64::from(dt_units) + wobble, component_max_units)
+}
+
+/// Safe upper bound on a map's deepest carve, from the pre-repair water mask.
+pub fn estimate_max_carve_depth(
+    lc_grid: &[Vec<u8>],
+    world_width: usize,
+    world_height: usize,
+) -> i32 {
+    let gh = lc_grid.len();
+    let gw = lc_grid.first().map_or(0, Vec::len);
+    if gw == 0 || gh == 0 {
+        return 0;
+    }
+    let mut dt = vec![0u8; gw * gh];
+    let mut any_water = false;
+    for (z, row) in lc_grid.iter().enumerate() {
+        for (x, &c) in row.iter().enumerate() {
+            if c == LC_WATER {
+                dt[z * gw + x] = DT_MAX;
+                any_water = true;
+            }
+        }
+    }
+    if !any_water {
+        return 0;
+    }
+    chamfer_3_4_dt(&mut dt, gw, gh);
+    let grid_max_dt = dt.iter().copied().max().unwrap_or(0);
+    // Stretch grid DT to block units by the larger axis ratio (rounding up = safe).
+    let ratio = (world_width as f64 / gw as f64)
+        .max(world_height as f64 / gh as f64)
+        .max(1.0);
+    let block_max_dt = f64::from(grid_max_dt) * ratio;
+    let comp_max = block_max_dt.min(f64::from(u16::MAX)) as u16;
+    depth_from_dt(block_max_dt + 2.0, comp_max)
+}
+
+/// Place the underwater stack: WATER column, then a SAND/GRAVEL bed over SANDSTONE/STONE.
+pub fn carve_water_column(editor: &mut WorldEditor, x: i32, z: i32, water_y: i32, depth: i32) {
+    debug_assert!(
+        depth < MAX_CARVE_BELOW_SURFACE,
+        "water carve depth {depth} exceeds reserved headroom {MAX_CARVE_BELOW_SURFACE}"
+    );
+    // Safety net: keep the bed above bedrock even if the reserve fell short.
+    let depth = depth.min((water_y - MIN_Y - 2).max(0));
+    for dy in 0..=depth {
+        editor.set_block_absolute(WATER, x, water_y - dy, z, None, Some(&[]));
+    }
+    let bed_y = water_y - depth - 1;
+
+    // SAND share drifts down with depth; value_noise blends the boundary.
+    let (top_block, under_block) = match depth {
+        0..=1 => (SAND, SANDSTONE),
+        2..=4 => {
+            let sand_threshold = match depth {
+                2 => 0.70,
+                3 => 0.50,
+                _ => 0.30,
+            };
+            if crate::ground_generation::value_noise_01(x, z, 6) < sand_threshold {
+                (SAND, SANDSTONE)
+            } else {
+                (GRAVEL, STONE)
+            }
+        }
+        _ => (GRAVEL, STONE),
+    };
+
+    if bed_y > MIN_Y {
+        editor.set_block_absolute(top_block, x, bed_y, z, None, Some(&[]));
+    }
+    // Supports the gravity-affected bed; dropped onto bedrock at the lowest carve.
+    if bed_y - 1 > MIN_Y {
+        editor.set_block_absolute(under_block, x, bed_y - 1, z, None, Some(&[]));
+    }
+}
+
+/// Post-pass carving every LC_WATER cell, so ESA-only water gets depth too.
+pub fn carve_lc_water_pass(
+    editor: &mut WorldEditor,
+    ground: &Ground,
+    xzbbox: &XZBBox,
+    bwf: &BigWaterField,
+    road_mask: &RoadMaskBitmap,
+) {
+    let min_x = xzbbox.min_x();
+    let max_x = xzbbox.max_x();
+    let min_z = xzbbox.min_z();
+    let max_z = xzbbox.max_z();
+    for z in min_z..=max_z {
+        for x in min_x..=max_x {
+            // Keep road/bridge surfaces (causeways, decks).
+            if road_mask.contains(x, z) {
+                continue;
+            }
+            let coord = XZPoint::new(x - min_x, z - min_z);
+            if ground.cover_class(coord) != LC_WATER {
+                continue;
+            }
+            let water_y = ground.water_level(coord);
+            // Skip land bumps an over-claiming water polygon sits above.
+            if editor.get_ground_level(x, z) > water_y {
+                continue;
+            }
+            carve_water_column(editor, x, z, water_y, bwf.depth_at(x, z));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dt_distance_from_shore() {
+        let (w, h) = (7usize, 7usize);
+        let mut d = vec![0u8; w * h];
+        for j in 1..6 {
+            for i in 1..6 {
+                d[j * w + i] = DT_MAX;
+            }
+        }
+        chamfer_3_4_dt(&mut d, w, h);
+        assert_eq!(d[0], 0, "shore stays 0");
+        assert_eq!(d[w + 1], 3, "edge water is one ortho step from shore");
+        assert_eq!(d[3 * w + 3], 9, "centre is three ortho steps in");
+    }
+
+    #[test]
+    fn depth_zero_inside_shoal_and_on_land() {
+        assert_eq!(ocean_depth_for_cell(0, 0, 0, 0), 0);
+        assert_eq!(ocean_depth_for_cell(10, 10, 3, 200), 0);
+    }
+
+    #[test]
+    fn depth_clamps_to_tier_max() {
+        assert_eq!(ocean_depth_for_cell(5, 5, u16::from(DT_MAX), 200), 6);
+        assert_eq!(polygon_local_max(10), 2);
+        assert_eq!(polygon_local_max(60), 4);
+        assert_eq!(polygon_local_max(100), 6);
+    }
+
+    #[test]
+    fn estimate_no_water_is_zero() {
+        let grid = vec![vec![0u8; 16]; 16];
+        assert_eq!(estimate_max_carve_depth(&grid, 16, 16), 0);
+    }
+
+    #[test]
+    fn estimate_large_open_water_reaches_max() {
+        let grid = vec![vec![LC_WATER; 32]; 32];
+        assert_eq!(estimate_max_carve_depth(&grid, 32, 32), 6);
+    }
+
+    #[test]
+    fn nibble_round_trip() {
+        let mut buf = vec![0u8; 4];
+        for (i, v) in [0u8, 6, 3, 1, 5, 2, 4, 0].iter().enumerate() {
+            nibble_set(&mut buf, i, *v);
+        }
+        for (i, v) in [0u8, 6, 3, 1, 5, 2, 4, 0].iter().enumerate() {
+            assert_eq!(nibble_get(&buf, i), *v);
+        }
+    }
+}

--- a/src/water_depth.rs
+++ b/src/water_depth.rs
@@ -123,6 +123,11 @@ pub fn compute_big_water_field(ground: &Ground, xzbbox: &XZBBox) -> BigWaterFiel
     let sw = (smax_x - smin_x + 1) as usize;
     let sh = (smax_z - smin_z + 1) as usize;
     let total = sw.checked_mul(sh).expect("water sub-rect size overflow");
+    // comp stores cell indices as u32; bail clearly rather than truncate.
+    assert!(
+        total <= u32::MAX as usize,
+        "water sub-rect too large for u32 indices ({total} cells); tile the area"
+    );
 
     // Seed DT: water = DT_MAX (unreached), shore/land = 0.
     let mut dt = vec![0u8; total];

--- a/src/water_depth.rs
+++ b/src/water_depth.rs
@@ -16,6 +16,9 @@ const DT_MAX: u8 = u8::MAX;
 /// Maximum water carve depth, in blocks (the deepest tier).
 const MAX_WATER_DEPTH: i32 = 6;
 
+/// Cap on water sub-rect cells (bounds memory, keeps u32 indices valid); ~1000 km².
+const MAX_WATER_FIELD_CELLS: usize = 1_000_000_000;
+
 #[inline]
 fn nibble_get(buf: &[u8], i: usize) -> u8 {
     let byte = buf[i >> 1];
@@ -126,9 +129,9 @@ pub fn compute_big_water_field(ground: &Ground, xzbbox: &XZBBox) -> BigWaterFiel
     let smax_z = (wmax_z + 1).min(max_z);
     let sw = (smax_x - smin_x + 1) as usize;
     let sh = (smax_z - smin_z + 1) as usize;
-    // comp indexes cells as u32; on absurd sizes, render flat water instead of crashing.
+    // Cap cells to bound memory; above it, render flat water instead of crashing.
     let total = match sw.checked_mul(sh) {
-        Some(t) if t <= u32::MAX as usize => t,
+        Some(t) if t <= MAX_WATER_FIELD_CELLS => t,
         _ => {
             eprintln!("Warning: water area too large for depth carving; rendering flat water");
             return BigWaterField::empty();
@@ -321,11 +324,10 @@ pub fn estimate_max_carve_depth(
     }
     chamfer_3_4_dt(&mut dt, gw, gh);
     let grid_max_dt = dt.iter().copied().max().unwrap_or(0);
-    // Stretch grid DT to block units by the larger axis ratio (rounding up = safe).
-    let ratio = (world_width as f64 / gw as f64)
-        .max(world_height as f64 / gh as f64)
-        .max(1.0);
-    let block_max_dt = f64::from(grid_max_dt) * ratio;
+    // Inclusive-span ratio, matching the grid<->block mapping elsewhere (safe upper bound).
+    let wr = world_width.saturating_sub(1).max(1) as f64 / gw.saturating_sub(1).max(1) as f64;
+    let hr = world_height.saturating_sub(1).max(1) as f64 / gh.saturating_sub(1).max(1) as f64;
+    let block_max_dt = f64::from(grid_max_dt) * wr.max(hr).max(1.0);
     let comp_max = block_max_dt.min(f64::from(u16::MAX)) as u16;
     depth_from_dt(block_max_dt + 2.0, comp_max)
 }

--- a/src/water_depth.rs
+++ b/src/water_depth.rs
@@ -28,11 +28,12 @@ fn nibble_get(buf: &[u8], i: usize) -> u8 {
 
 #[inline]
 fn nibble_set(buf: &mut [u8], i: usize, v: u8) {
+    debug_assert!(v < 16, "nibble value {v} out of range");
     let byte = &mut buf[i >> 1];
     if i & 1 == 0 {
         *byte = (*byte & 0xF0) | (v & 0x0F);
     } else {
-        *byte = (*byte & 0x0F) | (v << 4);
+        *byte = (*byte & 0x0F) | ((v & 0x0F) << 4);
     }
 }
 
@@ -125,12 +126,14 @@ pub fn compute_big_water_field(ground: &Ground, xzbbox: &XZBBox) -> BigWaterFiel
     let smax_z = (wmax_z + 1).min(max_z);
     let sw = (smax_x - smin_x + 1) as usize;
     let sh = (smax_z - smin_z + 1) as usize;
-    let total = sw.checked_mul(sh).expect("water sub-rect size overflow");
-    // comp stores cell indices as u32; bail clearly rather than truncate.
-    assert!(
-        total <= u32::MAX as usize,
-        "water sub-rect too large for u32 indices ({total} cells); tile the area"
-    );
+    // comp indexes cells as u32; on absurd sizes, render flat water instead of crashing.
+    let total = match sw.checked_mul(sh) {
+        Some(t) if t <= u32::MAX as usize => t,
+        _ => {
+            eprintln!("Warning: water area too large for depth carving; rendering flat water");
+            return BigWaterField::empty();
+        }
+    };
 
     // Seed DT: water = DT_MAX (unreached), shore/land = 0.
     let mut dt = vec![0u8; total];
@@ -333,8 +336,10 @@ pub fn carve_water_column(editor: &mut WorldEditor, x: i32, z: i32, water_y: i32
         depth <= MAX_WATER_DEPTH,
         "water carve depth {depth} exceeds the max tier {MAX_WATER_DEPTH}"
     );
-    // Safety net: keep the bed above bedrock even if the reserve fell short.
-    let depth = depth.min((water_y - MIN_Y - 2).max(0));
+    // Clamp to the valid tier range, and keep the bed above bedrock.
+    let depth = depth
+        .clamp(0, MAX_WATER_DEPTH)
+        .min((water_y - MIN_Y - 2).max(0));
     for dy in 0..=depth {
         editor.set_block_absolute(WATER, x, water_y - dy, z, None, Some(&[]));
     }

--- a/src/water_depth.rs
+++ b/src/water_depth.rs
@@ -13,8 +13,8 @@ const SHOAL_DT_UNITS: u16 = 9;
 /// DT saturation cap. Depth clamps to <=6 long before this.
 const DT_MAX: u8 = u8::MAX;
 
-/// Deepest block the carve places below the surface (max depth + SAND bed).
-pub const MAX_CARVE_BELOW_SURFACE: i32 = 7;
+/// Maximum water carve depth, in blocks (the deepest tier).
+const MAX_WATER_DEPTH: i32 = 6;
 
 #[inline]
 fn nibble_get(buf: &[u8], i: usize) -> u8 {
@@ -86,34 +86,37 @@ impl BigWaterField {
     }
 }
 
+/// Map a grid-cell span to the block span that samples into it (a safe superset).
+pub(crate) fn grid_span_to_block_span(
+    g_lo: usize,
+    g_hi: usize,
+    world_dim: usize,
+    grid_dim: usize,
+) -> (i32, i32) {
+    if grid_dim <= 1 || world_dim <= 1 {
+        return (0, world_dim.saturating_sub(1) as i32);
+    }
+    let f = (world_dim - 1) as f64 / (grid_dim - 1) as f64;
+    let lo = ((g_lo as f64 - 0.5) * f).floor() as i32 - 1;
+    let hi = ((g_hi as f64 + 0.5) * f).ceil() as i32 + 1;
+    (lo.max(0), hi.min(world_dim as i32 - 1))
+}
+
 /// Run a chamfer DT over the LC_WATER mask and bake per-cell carve depth.
 pub fn compute_big_water_field(ground: &Ground, xzbbox: &XZBBox) -> BigWaterField {
-    if !ground.has_land_cover() {
-        return BigWaterField::empty();
-    }
     let min_x = xzbbox.min_x();
     let max_x = xzbbox.max_x();
     let min_z = xzbbox.min_z();
     let max_z = xzbbox.max_z();
 
+    // Water bbox from the small land-cover grid, avoiding a full-world scan.
+    let (wmin_x, wmin_z, wmax_x, wmax_z) = match ground.lc_water_block_bounds() {
+        Some((lx, lz, hx, hz)) => (min_x + lx, min_z + lz, min_x + hx, min_z + hz),
+        None => return BigWaterField::empty(),
+    };
+
     let is_lc_water =
         |x: i32, z: i32| ground.cover_class(XZPoint::new(x - min_x, z - min_z)) == LC_WATER;
-
-    // Tight bbox of all water cells.
-    let (mut wmin_x, mut wmin_z, mut wmax_x, mut wmax_z) = (i32::MAX, i32::MAX, i32::MIN, i32::MIN);
-    for z in min_z..=max_z {
-        for x in min_x..=max_x {
-            if is_lc_water(x, z) {
-                wmin_x = wmin_x.min(x);
-                wmax_x = wmax_x.max(x);
-                wmin_z = wmin_z.min(z);
-                wmax_z = wmax_z.max(z);
-            }
-        }
-    }
-    if wmax_x < wmin_x {
-        return BigWaterField::empty();
-    }
 
     // Pad by one for the shore ring (clamped); keeps the DT identical to full-bbox.
     let smin_x = (wmin_x - 1).max(min_x);
@@ -327,8 +330,8 @@ pub fn estimate_max_carve_depth(
 /// Place the underwater stack: WATER column, then a SAND/GRAVEL bed over SANDSTONE/STONE.
 pub fn carve_water_column(editor: &mut WorldEditor, x: i32, z: i32, water_y: i32, depth: i32) {
     debug_assert!(
-        depth < MAX_CARVE_BELOW_SURFACE,
-        "water carve depth {depth} exceeds reserved headroom {MAX_CARVE_BELOW_SURFACE}"
+        depth <= MAX_WATER_DEPTH,
+        "water carve depth {depth} exceeds the max tier {MAX_WATER_DEPTH}"
     );
     // Safety net: keep the bed above bedrock even if the reserve fell short.
     let depth = depth.min((water_y - MIN_Y - 2).max(0));
@@ -372,17 +375,18 @@ pub fn carve_lc_water_pass(
     bwf: &BigWaterField,
     road_mask: &RoadMaskBitmap,
 ) {
-    let min_x = xzbbox.min_x();
-    let max_x = xzbbox.max_x();
-    let min_z = xzbbox.min_z();
-    let max_z = xzbbox.max_z();
-    for z in min_z..=max_z {
-        for x in min_x..=max_x {
+    let off_x = xzbbox.min_x();
+    let off_z = xzbbox.min_z();
+    // Only the water sub-rect can hold LC_WATER cells; skip the rest of the world.
+    let x1 = bwf.min_x + bwf.width as i32 - 1;
+    let z1 = bwf.min_z + bwf.height as i32 - 1;
+    for z in bwf.min_z..=z1 {
+        for x in bwf.min_x..=x1 {
             // Keep road/bridge surfaces (causeways, decks).
             if road_mask.contains(x, z) {
                 continue;
             }
-            let coord = XZPoint::new(x - min_x, z - min_z);
+            let coord = XZPoint::new(x - off_x, z - off_z);
             if ground.cover_class(coord) != LC_WATER {
                 continue;
             }
@@ -439,6 +443,24 @@ mod tests {
     fn estimate_large_open_water_reaches_max() {
         let grid = vec![vec![LC_WATER; 32]; 32];
         assert_eq!(estimate_max_carve_depth(&grid, 32, 32), 6);
+    }
+
+    #[test]
+    fn grid_span_covers_all_mapped_blocks() {
+        // Brute-force every block that samples into grid cells [1,2]; the span must cover them.
+        let (world_dim, grid_dim) = (100usize, 10usize);
+        let (g_lo, g_hi) = (1usize, 2usize);
+        let (lo, hi) = grid_span_to_block_span(g_lo, g_hi, world_dim, grid_dim);
+        for bx in 0..world_dim {
+            let gx =
+                ((bx as f64 / (world_dim - 1) as f64) * (grid_dim - 1) as f64).round() as usize;
+            if gx >= g_lo && gx <= g_hi {
+                assert!(
+                    bx as i32 >= lo && bx as i32 <= hi,
+                    "block {bx} (grid {gx}) not covered by span [{lo},{hi}]"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Carve depth below the waterline from a chamfer-3-4 distance transform over the LC_WATER mask: width-tiered sloped beds with a SAND/GRAVEL over SANDSTONE/STONE palette, covering both ESA and OSM water. The elevation floor is raised by a per-map estimate so the deepest carve clears bedrock without wasting world height.

Ported from Teddy563's Meld fork and reworked: nibble-packed depth grid sized to the water bbox (not the world bbox) for low peak memory, and no stone-to-bedrock backfill (the two-block bed is self-supporting).