### PR TITLE
Bake chunk lighting so generated worlds load lit

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -104,6 +104,11 @@ pub struct Args {
     /// Print generation-only timing to stderr (excludes data fetching)
     #[arg(long, hide = true)]
     pub benchmark: bool,
+
+    /// Bake per-chunk lighting so distant chunks render lit in LOD mods
+    /// (Voxy/Chunky) without visiting them. Slower; off by default.
+    #[arg(long, default_value_t = false)]
+    pub bake_lighting: bool,
 }
 
 /// Validates CLI arguments after parsing.
@@ -220,6 +225,7 @@ mod tests {
         assert!(!args.terrain);
         assert!(!args.bedrock);
         assert!(!args.disable_height_limit);
+        assert!(!args.bake_lighting);
         // interior, roof, land_cover default to true
         assert!(args.interior);
         assert!(args.roof);

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -66,6 +66,7 @@ pub fn generate_world_with_options(
             args.disable_height_limit,
         )
     };
+    editor.set_bake_lighting(args.bake_lighting);
     let ground = Arc::new(ground);
 
     // Per-cell water depth field from the LC_WATER mask; empty without land cover.

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -846,6 +846,7 @@ fn gui_start_generation(
     use_3d_enabled: bool,
     disable_height_limit: bool,
     aws_only_elevation: bool,
+    bake_lighting_enabled: bool,
     is_new_world: bool,
     spawn_point: Option<(f64, f64)>,
     telemetry_consent: bool,
@@ -1096,6 +1097,7 @@ fn gui_start_generation(
                 disable_height_limit,
                 aws_only_elevation,
                 benchmark: false,
+                bake_lighting: bake_lighting_enabled,
             };
 
             // If skip_osm_objects is true (terrain-only mode), skip fetching and processing OSM data

--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -656,6 +656,10 @@ button:hover {
   accent-color: #fecc44;
 }
 
+#aws-only-elevation-toggle {
+  accent-color: #fecc44;
+}
+
 #bake-lighting-toggle {
   accent-color: #fecc44;
 }

--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -656,6 +656,10 @@ button:hover {
   accent-color: #fecc44;
 }
 
+#bake-lighting-toggle {
+  accent-color: #fecc44;
+}
+
 #enable-luanti-toggle {
   accent-color: #fecc44;
 }

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -176,6 +176,17 @@
           </div>
         </div>
 
+        <!-- Bake Lighting Toggle -->
+        <div class="settings-row">
+          <label for="bake-lighting-toggle">
+            <span data-localize="bake_lighting">Bake lighting</span>
+            <span class="tooltip-icon" data-tooltip="Precompute lighting so distant chunks render lit in LOD mods (Voxy/Chunky) without visiting them. Not needed for vanilla; slower generation.">?</span>
+          </label>
+          <div class="settings-control">
+            <input type="checkbox" id="bake-lighting-toggle" name="bake-lighting-toggle">
+          </div>
+        </div>
+
         <!-- World Scale Slider -->
         <div class="settings-row">
           <label for="scale-value-slider">

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -120,6 +120,7 @@ async function applyLocalization(localization) {
     "span[data-localize='three_dmr']": "three_dmr",
     "span[data-localize='disable_height_limit']": "disable_height_limit",
     "span[data-localize='aws_only_elevation']": "aws_only_elevation",
+    "span[data-localize='bake_lighting']": "bake_lighting",
     "span[data-localize='anonymous_crash_reports']": "anonymous_crash_reports",
     "span[data-localize='map_theme']": "map_theme",
     "span[data-localize='save_path']": "save_path",
@@ -1378,6 +1379,7 @@ async function startGeneration() {
     var use_3d = document.getElementById("use-3d-toggle").checked;
     var disable_height_limit = document.getElementById("disable-height-limit-toggle").checked;
     var aws_only_elevation = document.getElementById("aws-only-elevation-toggle").checked;
+    var bake_lighting = document.getElementById("bake-lighting-toggle").checked;
     var scale = parseFloat(document.getElementById("scale-value-slider").value);
     // var ground_level = parseInt(document.getElementById("ground-level").value, 10);
     // DEPRECATED: Ground level input removed from UI
@@ -1407,6 +1409,7 @@ async function startGeneration() {
         use3dEnabled: use_3d,
         disableHeightLimit: disable_height_limit,
         awsOnlyElevation: aws_only_elevation,
+        bakeLightingEnabled: bake_lighting,
         isNewWorld: true,
         spawnPoint: spawnPoint,
         telemetryConsent: telemetryConsent || false,

--- a/src/gui/locales/ar.json
+++ b/src/gui/locales/ar.json
@@ -45,6 +45,7 @@
   "three_dmr": "استخدام نماذج ثلاثية الأبعاد",
   "disable_height_limit": "توسيع ارتفاع البناء",
   "aws_only_elevation": "تضاريس قديمة",
+  "bake_lighting": "حساب الإضاءة مسبقًا",
   "bedrock_auto_generated": "يتم إنشاء عالم Bedrock تلقائيًا",
   "save_path": "مسار الحفظ",
   "rotation_angle": "زاوية الدوران",

--- a/src/gui/locales/de.json
+++ b/src/gui/locales/de.json
@@ -45,6 +45,7 @@
   "three_dmr": "3D-Modelle verwenden",
   "disable_height_limit": "Bauhöhe erweitern",
   "aws_only_elevation": "Klassisches Terrain",
+  "bake_lighting": "Licht vorberechnen",
   "bedrock_auto_generated": "Bedrock-Welt wird automatisch generiert",
   "save_path": "Speicherpfad",
   "rotation_angle": "Rotationswinkel",

--- a/src/gui/locales/en-US.json
+++ b/src/gui/locales/en-US.json
@@ -52,6 +52,7 @@
   "three_dmr": "Use 3D Models",
   "disable_height_limit": "Extend build height",
   "aws_only_elevation": "Legacy terrain",
+  "bake_lighting": "Bake lighting",
   "bedrock_auto_generated": "Bedrock world is auto-generated",
   "save_path": "Save Path",
   "rotation_angle": "Rotation Angle",

--- a/src/gui/locales/es.json
+++ b/src/gui/locales/es.json
@@ -45,6 +45,7 @@
   "three_dmr": "Usar modelos 3D",
   "disable_height_limit": "Ampliar altura de construcción",
   "aws_only_elevation": "Terreno clásico",
+  "bake_lighting": "Precalcular iluminación",
   "bedrock_auto_generated": "El mundo Bedrock se genera automáticamente",
   "save_path": "Ruta de guardado",
   "rotation_angle": "Ángulo de Rotación",

--- a/src/gui/locales/fi.json
+++ b/src/gui/locales/fi.json
@@ -45,6 +45,7 @@
   "three_dmr": "Käytä 3D-malleja",
   "disable_height_limit": "Laajenna rakennuskorkeutta",
   "aws_only_elevation": "Vanha maasto",
+  "bake_lighting": "Esilaske valaistus",
   "bedrock_auto_generated": "Bedrock-maailma luodaan automaattisesti",
   "save_path": "Tallennuspolku",
   "rotation_angle": "Kiertokulma",

--- a/src/gui/locales/fr-FR.json
+++ b/src/gui/locales/fr-FR.json
@@ -45,6 +45,7 @@
   "three_dmr": "Utiliser les modèles 3D",
   "disable_height_limit": "Étendre la hauteur de construction",
   "aws_only_elevation": "Terrain hérité",
+  "bake_lighting": "Précalculer l'éclairage",
   "bedrock_auto_generated": "Le monde Bedrock est généré automatiquement",
   "save_path": "Chemin de sauvegarde",
   "rotation_angle": "Angle de Rotation",

--- a/src/gui/locales/hu.json
+++ b/src/gui/locales/hu.json
@@ -45,6 +45,7 @@
   "three_dmr": "3D modellek használata",
   "disable_height_limit": "Építési magasság kiterjesztése",
   "aws_only_elevation": "Régi domborzat",
+  "bake_lighting": "Megvilágítás előszámítása",
   "bedrock_auto_generated": "A Bedrock világ automatikusan generálódik",
   "save_path": "Mentési útvonal",
   "rotation_angle": "Forgatási Szög",

--- a/src/gui/locales/ja.json
+++ b/src/gui/locales/ja.json
@@ -45,6 +45,7 @@
   "three_dmr": "3Dモデルを使用",
   "disable_height_limit": "建築高さを拡張",
   "aws_only_elevation": "従来の地形",
+  "bake_lighting": "ライティングをベイク",
   "bedrock_auto_generated": "Bedrock ワールドは自動生成されます",
   "save_path": "保存先",
   "rotation_angle": "回転角度",

--- a/src/gui/locales/ko.json
+++ b/src/gui/locales/ko.json
@@ -45,6 +45,7 @@
   "three_dmr": "3D 모델 사용",
   "disable_height_limit": "건축 높이 확장",
   "aws_only_elevation": "기존 지형",
+  "bake_lighting": "조명 베이크",
   "bedrock_auto_generated": "Bedrock 월드는 자동 생성됩니다",
   "save_path": "저장 경로",
   "rotation_angle": "회전 각도",

--- a/src/gui/locales/lt.json
+++ b/src/gui/locales/lt.json
@@ -45,6 +45,7 @@
   "three_dmr": "Naudoti 3D modelius",
   "disable_height_limit": "Praplėsti statybos aukštį",
   "aws_only_elevation": "Senasis reljefas",
+  "bake_lighting": "Iš anksto apskaičiuoti apšvietimą",
   "bedrock_auto_generated": "Bedrock pasaulis generuojamas automatiškai",
   "save_path": "Išsaugojimo kelias",
   "rotation_angle": "Pasukimo Kampas",

--- a/src/gui/locales/lv.json
+++ b/src/gui/locales/lv.json
@@ -45,6 +45,7 @@
   "three_dmr": "Lietot 3D modeļus",
   "disable_height_limit": "Paplašināt būvniecības augstumu",
   "aws_only_elevation": "Mantotais reljefs",
+  "bake_lighting": "Iepriekš aprēķināt apgaismojumu",
   "bedrock_auto_generated": "Bedrock pasaule tiek ģenerēta automātiski",
   "save_path": "Saglabāšanas ceļš",
   "rotation_angle": "Rotācijas Leņķis",

--- a/src/gui/locales/pl.json
+++ b/src/gui/locales/pl.json
@@ -45,6 +45,7 @@
   "three_dmr": "Użyj modeli 3D",
   "disable_height_limit": "Rozszerz wysokość budowania",
   "aws_only_elevation": "Klasyczny teren",
+  "bake_lighting": "Wstępne obliczanie oświetlenia",
   "bedrock_auto_generated": "Świat Bedrock jest generowany automatycznie",
   "save_path": "Ścieżka zapisu",
   "rotation_angle": "Kąt Obrotu",

--- a/src/gui/locales/pt-BR.json
+++ b/src/gui/locales/pt-BR.json
@@ -45,6 +45,7 @@
   "three_dmr": "Usar modelos 3D",
   "disable_height_limit": "Ampliar altura de construção",
   "aws_only_elevation": "Terreno antigo",
+  "bake_lighting": "Pré-calcular iluminação",
   "bedrock_auto_generated": "O mundo de bedrock é gerado automaticamente",
   "save_path": "Caminho de salvamento",
   "rotation_angle": "Ângulo de Rotação",

--- a/src/gui/locales/ru.json
+++ b/src/gui/locales/ru.json
@@ -45,6 +45,7 @@
   "three_dmr": "Использовать 3D-модели",
   "disable_height_limit": "Расширить высоту строительства",
   "aws_only_elevation": "Устаревший рельеф",
+  "bake_lighting": "Предрасчёт освещения",
   "bedrock_auto_generated": "Мир Bedrock генерируется автоматически",
   "save_path": "Путь сохранения",
   "rotation_angle": "Угол Поворота",

--- a/src/gui/locales/sl.json
+++ b/src/gui/locales/sl.json
@@ -45,6 +45,7 @@
   "three_dmr": "Uporabi 3D modele",
   "disable_height_limit": "Razširi višino gradnje",
   "aws_only_elevation": "Starejši teren",
+  "bake_lighting": "Predizračun osvetlitve",
   "bedrock_auto_generated": "Bedrock svet je samodejno ustvarjen",
   "save_path": "Pot shranjevanja",
   "rotation_angle": "Kot zasuka",

--- a/src/gui/locales/sv.json
+++ b/src/gui/locales/sv.json
@@ -45,6 +45,7 @@
   "three_dmr": "Använd 3D-modeller",
   "disable_height_limit": "Utöka byggnadshöjd",
   "aws_only_elevation": "Äldre terräng",
+  "bake_lighting": "Förberäkna ljussättning",
   "bedrock_auto_generated": "Bedrock-världen genereras automatiskt",
   "save_path": "Sökväg",
   "rotation_angle": "Rotationsvinkel",

--- a/src/gui/locales/ua.json
+++ b/src/gui/locales/ua.json
@@ -45,6 +45,7 @@
   "three_dmr": "Використовувати 3D-моделі",
   "disable_height_limit": "Розширити висоту будівництва",
   "aws_only_elevation": "Застарілий рельєф",
+  "bake_lighting": "Попередній розрахунок освітлення",
   "bedrock_auto_generated": "Bedrock світ генерується автоматично",
   "save_path": "Шлях збереження",
   "rotation_angle": "Кут Обертання",

--- a/src/gui/locales/zh-CN.json
+++ b/src/gui/locales/zh-CN.json
@@ -45,6 +45,7 @@
   "three_dmr": "使用3D模型",
   "disable_height_limit": "扩展建造高度",
   "aws_only_elevation": "旧版地形",
+  "bake_lighting": "烘焙光照",
   "bedrock_auto_generated": "Bedrock 世界自动生成",
   "save_path": "存档路径",
   "rotation_angle": "旋转角度",

--- a/src/world_editor/java.rs
+++ b/src/world_editor/java.rs
@@ -8,7 +8,7 @@ use crate::block_definitions::GRASS_BLOCK;
 use crate::progress::emit_gui_progress_update;
 use colored::Colorize;
 use fastanvil::Region;
-use fastnbt::{LongArray, Value};
+use fastnbt::{ByteArray, LongArray, Value};
 use fnv::FnvHashMap;
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
@@ -254,6 +254,317 @@ fn get_entity_coords(entity: &HashMap<String, Value>) -> Option<(i32, i32, i32)>
     Some((x, y, z))
 }
 
+// Light a block emits, 0 if none.
+fn block_light_emission(name: &str) -> u8 {
+    match name {
+        "minecraft:beacon"
+        | "minecraft:conduit"
+        | "minecraft:end_gateway"
+        | "minecraft:end_portal"
+        | "minecraft:fire"
+        | "minecraft:campfire"
+        | "minecraft:glowstone"
+        | "minecraft:jack_o_lantern"
+        | "minecraft:lantern"
+        | "minecraft:lava"
+        | "minecraft:ochre_froglight"
+        | "minecraft:pearlescent_froglight"
+        | "minecraft:verdant_froglight"
+        | "minecraft:sea_lantern"
+        | "minecraft:shroomlight" => 15,
+        "minecraft:end_rod" | "minecraft:torch" | "minecraft:wall_torch" => 14,
+        "minecraft:crying_obsidian"
+        | "minecraft:soul_campfire"
+        | "minecraft:soul_lantern"
+        | "minecraft:soul_torch"
+        | "minecraft:soul_wall_torch" => 10,
+        "minecraft:glow_lichen" | "minecraft:redstone_torch" | "minecraft:redstone_wall_torch" => 7,
+        "minecraft:sculk_catalyst" => 6,
+        "minecraft:magma_block" => 3,
+        "minecraft:brewing_stand" | "minecraft:brown_mushroom" => 1,
+        _ => 0,
+    }
+}
+
+// Blocks that don't occlude skylight: air, glass, leaves, water/ice, plants, thin decor.
+fn is_light_transparent(name: &str) -> bool {
+    let n = name.strip_prefix("minecraft:").unwrap_or(name);
+    if n.ends_with("air") || n.ends_with("leaves") || n.contains("glass") {
+        return true;
+    }
+    const EXACT: &[&str] = &[
+        "water",
+        "ice",
+        "frosted_ice",
+        "bubble_column",
+        "grass",
+        "short_grass",
+        "tall_grass",
+        "fern",
+        "large_fern",
+        "dead_bush",
+        "bush",
+        "dandelion",
+        "poppy",
+        "blue_orchid",
+        "allium",
+        "azure_bluet",
+        "oxeye_daisy",
+        "cornflower",
+        "lily_of_the_valley",
+        "wither_rose",
+        "torchflower",
+        "red_tulip",
+        "orange_tulip",
+        "white_tulip",
+        "pink_tulip",
+        "sunflower",
+        "lilac",
+        "rose_bush",
+        "peony",
+        "pink_petals",
+        "spore_blossom",
+        "hanging_roots",
+        "glow_lichen",
+        "sweet_berry_bush",
+        "cactus",
+        "bamboo",
+        "sugar_cane",
+        "nether_wart",
+        "lily_pad",
+        "sea_pickle",
+        "cobweb",
+        "snow",
+        "lever",
+        "tripwire",
+        "tripwire_hook",
+        "end_rod",
+        "lightning_rod",
+        "scaffolding",
+        "pointed_dripstone",
+        "turtle_egg",
+    ];
+    if EXACT.contains(&n) {
+        return true;
+    }
+    if n.ends_with("_block") || n.ends_with("_stem") {
+        return false;
+    }
+    const SUB: &[&str] = &[
+        "torch", "lantern", "sign", "rail", "carpet", "candle", "chain", "ladder", "banner",
+        "sapling", "coral", "sprouts", "roots", "vine", "flower", "mushroom", "amethyst", "_bud",
+        "seagrass", "kelp", "petals",
+    ];
+    SUB.iter().any(|s| n.contains(s))
+}
+
+// Per-cell opacity and emission for a section (YZX order, 4096 cells).
+fn decode_section_light_props(section: &Section) -> (Vec<bool>, Vec<u8>) {
+    let palette = &section.block_states.palette;
+    let pal_opaque: Vec<bool> = palette
+        .iter()
+        .map(|p| !is_light_transparent(&p.name))
+        .collect();
+    let pal_emission: Vec<u8> = palette
+        .iter()
+        .map(|p| block_light_emission(&p.name))
+        .collect();
+
+    let mut opaque = vec![false; 4096];
+    let mut emission = vec![0u8; 4096];
+
+    match &section.block_states.data {
+        None => {
+            let o = pal_opaque.first().copied().unwrap_or(false);
+            let e = pal_emission.first().copied().unwrap_or(0);
+            if o {
+                opaque.iter_mut().for_each(|v| *v = true);
+            }
+            if e > 0 {
+                emission.iter_mut().for_each(|v| *v = e);
+            }
+        }
+        Some(data) => {
+            let mut bits = 4;
+            while (1usize << bits) < palette.len() {
+                bits += 1;
+            }
+            let vals_per_long = 64 / bits;
+            let mask = (1u64 << bits) - 1;
+            for i in 0..4096usize {
+                let long_idx = i / vals_per_long;
+                let off = (i % vals_per_long) * bits;
+                if long_idx < data.len() {
+                    let pi = ((data[long_idx] as u64 >> off) & mask) as usize;
+                    if pi < palette.len() {
+                        opaque[i] = pal_opaque[pi];
+                        emission[i] = pal_emission[pi];
+                    }
+                }
+            }
+        }
+    }
+    (opaque, emission)
+}
+
+// Flood-fill light from the seeded queue, -1 per block, through non-opaque cells.
+fn propagate_light(
+    light: &mut [u8],
+    opaque: &[bool],
+    queue: &mut std::collections::VecDeque<(usize, usize, usize, u8)>,
+    height: usize,
+) {
+    let idx = |x: usize, y: usize, z: usize| y * 256 + z * 16 + x;
+    while let Some((x, y, z, level)) = queue.pop_front() {
+        if level <= 1 {
+            continue;
+        }
+        let next = level - 1;
+        let try_spread =
+            |nx: usize,
+             ny: usize,
+             nz: usize,
+             light: &mut [u8],
+             queue: &mut std::collections::VecDeque<(usize, usize, usize, u8)>| {
+                let g = idx(nx, ny, nz);
+                if !opaque[g] && light[g] < next {
+                    light[g] = next;
+                    queue.push_back((nx, ny, nz, next));
+                }
+            };
+        if x > 0 {
+            try_spread(x - 1, y, z, light, queue);
+        }
+        if x < 15 {
+            try_spread(x + 1, y, z, light, queue);
+        }
+        if z > 0 {
+            try_spread(x, y, z - 1, light, queue);
+        }
+        if z < 15 {
+            try_spread(x, y, z + 1, light, queue);
+        }
+        if y > 0 {
+            try_spread(x, y - 1, z, light, queue);
+        }
+        if y + 1 < height {
+            try_spread(x, y + 1, z, light, queue);
+        }
+    }
+}
+
+// Pack a 0..15 value into the 4-bit-per-cell light array.
+#[inline]
+fn pack_light_nibble(arr: &mut [i8], index: usize, value: u8) {
+    let byte = index >> 1;
+    let cur = arr[byte] as u8;
+    let new = if index & 1 == 0 {
+        (cur & 0xF0) | (value & 0x0F)
+    } else {
+        (cur & 0x0F) | (value << 4)
+    };
+    arr[byte] = new as i8;
+}
+
+// Sky + block light per section as 2048-byte nibble arrays.
+fn compute_lighting(
+    sections: &[Section],
+    min_section_y: i8,
+    max_section_y: i8,
+) -> HashMap<i8, (Vec<i8>, Vec<i8>)> {
+    use std::collections::VecDeque;
+
+    let num_sections = (max_section_y as i32 - min_section_y as i32 + 1).max(0) as usize;
+    let height = num_sections * 16;
+    if height == 0 {
+        return HashMap::new();
+    }
+    let idx = |x: usize, y: usize, z: usize| y * 256 + z * 16 + x;
+
+    let mut opaque = vec![false; height * 256];
+    let mut emission = vec![0u8; height * 256];
+
+    let sec_by_y: HashMap<i8, &Section> = sections.iter().map(|s| (s.y, s)).collect();
+    for sy in min_section_y..=max_section_y {
+        let Some(sec) = sec_by_y.get(&sy) else {
+            continue;
+        };
+        let base_y = ((sy as i32 - min_section_y as i32) * 16) as usize;
+        let (op, em) = decode_section_light_props(sec);
+        for ly in 0..16usize {
+            for z in 0..16usize {
+                for x in 0..16usize {
+                    let local = ly * 256 + z * 16 + x;
+                    let g = idx(x, base_y + ly, z);
+                    opaque[g] = op[local];
+                    emission[g] = em[local];
+                }
+            }
+        }
+    }
+
+    // SkyLight: vertical cast then flood-fill.
+    let mut sky = vec![0u8; height * 256];
+    let mut sq: VecDeque<(usize, usize, usize, u8)> = VecDeque::new();
+    for z in 0..16usize {
+        for x in 0..16usize {
+            for y in (0..height).rev() {
+                let g = idx(x, y, z);
+                if opaque[g] {
+                    break;
+                }
+                sky[g] = 15;
+            }
+        }
+    }
+    for y in 0..height {
+        for z in 0..16usize {
+            for x in 0..16usize {
+                if sky[idx(x, y, z)] == 15 {
+                    sq.push_back((x, y, z, 15));
+                }
+            }
+        }
+    }
+    propagate_light(&mut sky, &opaque, &mut sq, height);
+
+    // BlockLight: flood-fill from emitters.
+    let mut block = vec![0u8; height * 256];
+    let mut bq: VecDeque<(usize, usize, usize, u8)> = VecDeque::new();
+    for y in 0..height {
+        for z in 0..16usize {
+            for x in 0..16usize {
+                let g = idx(x, y, z);
+                if emission[g] > 0 {
+                    block[g] = emission[g];
+                    bq.push_back((x, y, z, emission[g]));
+                }
+            }
+        }
+    }
+    propagate_light(&mut block, &opaque, &mut bq, height);
+
+    // Pack each section.
+    let mut out = HashMap::new();
+    for sy in min_section_y..=max_section_y {
+        let base_y = ((sy as i32 - min_section_y as i32) * 16) as usize;
+        let mut sl = vec![0i8; 2048];
+        let mut bl = vec![0i8; 2048];
+        for ly in 0..16usize {
+            for z in 0..16usize {
+                for x in 0..16usize {
+                    let local = ly * 256 + z * 16 + x;
+                    let g = idx(x, base_y + ly, z);
+                    pack_light_nibble(&mut sl, local, sky[g]);
+                    pack_light_nibble(&mut bl, local, block[g]);
+                }
+            }
+        }
+        out.insert(sy, (sl, bl));
+    }
+    out
+}
+
 /// Creates modern chunk NBT data (post-1.18 format, no Level wrapper).
 ///
 /// Writes all required fields for server compatibility:
@@ -287,6 +598,9 @@ fn create_chunk_nbt(chunk: &Chunk) -> HashMap<String, Value> {
         Value::List(vec![Value::String("minecraft:plains".to_string())]),
     )]));
 
+    // Bake lighting so isLightOn=1 chunks load lit (vanilla + off-disk Voxy/Chunky).
+    let lighting = compute_lighting(&chunk.sections, min_section_y, max_section_y);
+
     // Build all sections in the determined range
     let sections: Vec<Value> = (min_section_y..=max_section_y)
         .map(|y| {
@@ -309,6 +623,16 @@ fn create_chunk_nbt(chunk: &Chunk) -> HashMap<String, Value> {
                 ])
             };
             section_nbt.insert("biomes".to_string(), biome_value.clone());
+            if let Some((sky_light, block_light)) = lighting.get(&y) {
+                section_nbt.insert(
+                    "SkyLight".to_string(),
+                    Value::ByteArray(ByteArray::new(sky_light.clone())),
+                );
+                section_nbt.insert(
+                    "BlockLight".to_string(),
+                    Value::ByteArray(ByteArray::new(block_light.clone())),
+                );
+            }
             Value::Compound(section_nbt)
         })
         .collect();
@@ -330,7 +654,8 @@ fn create_chunk_nbt(chunk: &Chunk) -> HashMap<String, Value> {
             "Status".to_string(),
             Value::String("minecraft:full".to_string()),
         ),
-        ("isLightOn".to_string(), Value::Byte(0)),
+        // Lighting baked above; mark valid.
+        ("isLightOn".to_string(), Value::Byte(1)),
         ("InhabitedTime".to_string(), Value::Long(0)),
         ("LastUpdate".to_string(), Value::Long(0)),
         ("sections".to_string(), Value::List(sections)),

--- a/src/world_editor/java.rs
+++ b/src/world_editor/java.rs
@@ -74,6 +74,7 @@ impl<'a> WorldEditor<'a> {
     pub(super) fn create_base_chunk(
         abs_chunk_x: i32,
         abs_chunk_z: i32,
+        bake_lighting: bool,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         // Use cached sections (computed once on first call)
         let sections = get_base_chunk_sections();
@@ -87,7 +88,7 @@ impl<'a> WorldEditor<'a> {
             other: FnvHashMap::default(),
         };
 
-        let chunk_nbt = create_chunk_nbt(&chunk_data);
+        let chunk_nbt = create_chunk_nbt(&chunk_data, bake_lighting);
 
         let mut ser_buffer = Vec::with_capacity(8192);
         fastnbt::to_writer(&mut ser_buffer, &chunk_nbt)?;
@@ -198,7 +199,7 @@ impl<'a> WorldEditor<'a> {
                     other: chunk_to_modify.other.clone(),
                 };
 
-                let chunk_nbt = create_chunk_nbt(&chunk);
+                let chunk_nbt = create_chunk_nbt(&chunk, self.bake_lighting);
                 ser_buffer.clear();
                 fastnbt::to_writer(&mut ser_buffer, &chunk_nbt)?;
                 region.write_chunk(chunk_x as usize, chunk_z as usize, &ser_buffer)?;
@@ -216,7 +217,8 @@ impl<'a> WorldEditor<'a> {
 
                 // If chunk doesn't exist, create it with base layer
                 if !chunk_exists {
-                    let ser_buffer = Self::create_base_chunk(abs_chunk_x, abs_chunk_z)?;
+                    let ser_buffer =
+                        Self::create_base_chunk(abs_chunk_x, abs_chunk_z, self.bake_lighting)?;
                     region.write_chunk(chunk_x as usize, chunk_z as usize, &ser_buffer)?;
                 }
             }
@@ -610,7 +612,7 @@ fn compute_lighting(
 /// DataVersion, Status, yPos, Heightmaps, biomes, structures, etc.
 /// Section range is determined dynamically: at minimum the vanilla range
 /// (Y=-4 to Y=19), extended upward/downward to cover any sections with content.
-fn create_chunk_nbt(chunk: &Chunk) -> HashMap<String, Value> {
+fn create_chunk_nbt(chunk: &Chunk, bake_lighting: bool) -> HashMap<String, Value> {
     // Index existing sections by Y for quick lookup
     let section_map: HashMap<i8, usize> = chunk
         .sections
@@ -637,13 +639,17 @@ fn create_chunk_nbt(chunk: &Chunk) -> HashMap<String, Value> {
         Value::List(vec![Value::String("minecraft:plains".to_string())]),
     )]));
 
-    // Bake lighting so isLightOn=1 chunks load lit (vanilla + off-disk Voxy/Chunky).
-    let lighting = compute_lighting(&chunk.sections, min_section_y, max_section_y);
+    // Bake lighting only when requested; otherwise leave it for the engine to relight on load.
+    let mut lighting = if bake_lighting {
+        compute_lighting(&chunk.sections, min_section_y, max_section_y)
+    } else {
+        Vec::new()
+    };
 
     // Build all sections in the determined range
     let sections: Vec<Value> = (min_section_y..=max_section_y)
-        .zip(lighting)
-        .map(|(y, (sky_light, block_light))| {
+        .enumerate()
+        .map(|(off, y)| {
             let mut section_nbt = if let Some(&idx) = section_map.get(&y) {
                 build_section_value(&chunk.sections[idx])
             } else {
@@ -663,14 +669,17 @@ fn create_chunk_nbt(chunk: &Chunk) -> HashMap<String, Value> {
                 ])
             };
             section_nbt.insert("biomes".to_string(), biome_value.clone());
-            section_nbt.insert(
-                "SkyLight".to_string(),
-                Value::ByteArray(ByteArray::new(sky_light)),
-            );
-            section_nbt.insert(
-                "BlockLight".to_string(),
-                Value::ByteArray(ByteArray::new(block_light)),
-            );
+            if bake_lighting {
+                let (sky_light, block_light) = std::mem::take(&mut lighting[off]);
+                section_nbt.insert(
+                    "SkyLight".to_string(),
+                    Value::ByteArray(ByteArray::new(sky_light)),
+                );
+                section_nbt.insert(
+                    "BlockLight".to_string(),
+                    Value::ByteArray(ByteArray::new(block_light)),
+                );
+            }
             Value::Compound(section_nbt)
         })
         .collect();
@@ -692,8 +701,7 @@ fn create_chunk_nbt(chunk: &Chunk) -> HashMap<String, Value> {
             "Status".to_string(),
             Value::String("minecraft:full".to_string()),
         ),
-        // Lighting baked above; mark valid.
-        ("isLightOn".to_string(), Value::Byte(1)),
+        ("isLightOn".to_string(), Value::Byte(bake_lighting as i8)),
         ("InhabitedTime".to_string(), Value::Long(0)),
         ("LastUpdate".to_string(), Value::Long(0)),
         ("sections".to_string(), Value::List(sections)),

--- a/src/world_editor/java.rs
+++ b/src/world_editor/java.rs
@@ -254,15 +254,25 @@ fn get_entity_coords(entity: &HashMap<String, Value>) -> Option<(i32, i32, i32)>
     Some((x, y, z))
 }
 
-// Light a block emits, 0 if none.
-fn block_light_emission(name: &str) -> u8 {
+// Reads a string blockstate property, if present.
+fn prop_str<'a>(props: Option<&'a Value>, key: &str) -> Option<&'a str> {
+    if let Some(Value::Compound(m)) = props {
+        if let Some(Value::String(s)) = m.get(key) {
+            return Some(s.as_str());
+        }
+    }
+    None
+}
+
+// Light a block emits, 0 if none. Honours the `lit` state where it matters.
+fn block_light_emission(name: &str, props: Option<&Value>) -> u8 {
+    let unlit = matches!(prop_str(props, "lit"), Some("false"));
     match name {
         "minecraft:beacon"
         | "minecraft:conduit"
         | "minecraft:end_gateway"
         | "minecraft:end_portal"
         | "minecraft:fire"
-        | "minecraft:campfire"
         | "minecraft:glowstone"
         | "minecraft:jack_o_lantern"
         | "minecraft:lantern"
@@ -272,13 +282,15 @@ fn block_light_emission(name: &str) -> u8 {
         | "minecraft:verdant_froglight"
         | "minecraft:sea_lantern"
         | "minecraft:shroomlight" => 15,
+        "minecraft:campfire" if !unlit => 15,
         "minecraft:end_rod" | "minecraft:torch" | "minecraft:wall_torch" => 14,
         "minecraft:crying_obsidian"
-        | "minecraft:soul_campfire"
         | "minecraft:soul_lantern"
         | "minecraft:soul_torch"
         | "minecraft:soul_wall_torch" => 10,
-        "minecraft:glow_lichen" | "minecraft:redstone_torch" | "minecraft:redstone_wall_torch" => 7,
+        "minecraft:soul_campfire" if !unlit => 10,
+        "minecraft:glow_lichen" => 7,
+        "minecraft:redstone_torch" | "minecraft:redstone_wall_torch" if !unlit => 7,
         "minecraft:sculk_catalyst" => 6,
         "minecraft:magma_block" => 3,
         "minecraft:brewing_stand" | "minecraft:brown_mushroom" => 1,
@@ -289,6 +301,9 @@ fn block_light_emission(name: &str) -> u8 {
 // Blocks that don't occlude skylight: air, glass, leaves, water/ice, plants, thin decor.
 fn is_light_transparent(name: &str) -> bool {
     let n = name.strip_prefix("minecraft:").unwrap_or(name);
+    if n == "tinted_glass" {
+        return false; // tinted glass blocks all light, unlike other glass
+    }
     if n.ends_with("air") || n.ends_with("leaves") || n.contains("glass") {
         return true;
     }
@@ -367,7 +382,7 @@ fn decode_section_light_props(section: &Section) -> (Vec<bool>, Vec<u8>) {
         .collect();
     let pal_emission: Vec<u8> = palette
         .iter()
-        .map(|p| block_light_emission(&p.name))
+        .map(|p| block_light_emission(&p.name, p.properties.as_ref()))
         .collect();
 
     let mut opaque = vec![false; 4096];
@@ -514,15 +529,7 @@ fn compute_lighting(
                     break;
                 }
                 sky[g] = 15;
-            }
-        }
-    }
-    for y in 0..height {
-        for z in 0..16usize {
-            for x in 0..16usize {
-                if sky[idx(x, y, z)] == 15 {
-                    sq.push_back((x, y, z, 15));
-                }
+                sq.push_back((x, y, z, 15));
             }
         }
     }

--- a/src/world_editor/java.rs
+++ b/src/world_editor/java.rs
@@ -958,3 +958,85 @@ fn value_to_i32(value: &Value) -> Option<i32> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::common::{Chunk, ChunkToModify};
+    use super::create_chunk_nbt;
+    use crate::block_definitions::GRASS_BLOCK;
+    use fastnbt::Value;
+    use fnv::FnvHashMap;
+    use std::collections::HashMap;
+
+    fn grass_chunk() -> Chunk {
+        let mut c = ChunkToModify::default();
+        for x in 0..16 {
+            for z in 0..16 {
+                c.set_block(x, -62, z, GRASS_BLOCK);
+            }
+        }
+        Chunk {
+            sections: c.sections().collect(),
+            x_pos: 0,
+            z_pos: 0,
+            is_light_on: 0,
+            other: FnvHashMap::default(),
+        }
+    }
+
+    fn sections(nbt: &HashMap<String, Value>) -> &Vec<Value> {
+        match &nbt["sections"] {
+            Value::List(v) => v,
+            _ => panic!("sections is not a list"),
+        }
+    }
+
+    #[test]
+    fn bake_lighting_writes_valid_light_arrays() {
+        let nbt = create_chunk_nbt(&grass_chunk(), true);
+        assert_eq!(nbt["isLightOn"], Value::Byte(1));
+        assert!(nbt.contains_key("Heightmaps"));
+        let secs = sections(&nbt);
+        assert_eq!(secs.len(), 24);
+        for s in secs {
+            let Value::Compound(m) = s else { panic!() };
+            for key in ["SkyLight", "BlockLight"] {
+                match &m[key] {
+                    Value::ByteArray(b) => assert_eq!(b.len(), 2048),
+                    _ => panic!("{key} is not a byte array"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn no_bake_lighting_omits_light_arrays() {
+        let nbt = create_chunk_nbt(&grass_chunk(), false);
+        assert_eq!(nbt["isLightOn"], Value::Byte(0));
+        for s in sections(&nbt) {
+            let Value::Compound(m) = s else { panic!() };
+            assert!(!m.contains_key("SkyLight"));
+            assert!(!m.contains_key("BlockLight"));
+        }
+    }
+
+    #[test]
+    fn all_air_chunk_is_fully_skylit() {
+        let chunk = Chunk {
+            sections: vec![],
+            x_pos: 0,
+            z_pos: 0,
+            is_light_on: 0,
+            other: FnvHashMap::default(),
+        };
+        let nbt = create_chunk_nbt(&chunk, true);
+        for s in sections(&nbt) {
+            let Value::Compound(m) = s else { panic!() };
+            let Value::ByteArray(b) = &m["SkyLight"] else {
+                panic!()
+            };
+            // 0xFF == two nibbles of 15 (full skylight)
+            assert!(b.iter().all(|&v| v == -1));
+        }
+    }
+}

--- a/src/world_editor/java.rs
+++ b/src/world_editor/java.rs
@@ -365,10 +365,11 @@ fn is_light_transparent(name: &str) -> bool {
     if n.ends_with("_block") || n.ends_with("_stem") {
         return false;
     }
+    // Slabs/stairs are left opaque: their solid half occludes light via shape.
     const SUB: &[&str] = &[
         "torch", "lantern", "sign", "rail", "carpet", "candle", "chain", "ladder", "banner",
         "sapling", "coral", "sprouts", "roots", "vine", "flower", "mushroom", "amethyst", "_bud",
-        "seagrass", "kelp", "petals",
+        "seagrass", "kelp", "petals", "fence", "wall", "_bars", "door",
     ];
     SUB.iter().any(|s| n.contains(s))
 }
@@ -486,13 +487,13 @@ fn compute_lighting(
     sections: &[Section],
     min_section_y: i8,
     max_section_y: i8,
-) -> HashMap<i8, (Vec<i8>, Vec<i8>)> {
+) -> Vec<(Vec<i8>, Vec<i8>)> {
     use std::collections::VecDeque;
 
     let num_sections = (max_section_y as i32 - min_section_y as i32 + 1).max(0) as usize;
     let height = num_sections * 16;
     if height == 0 {
-        return HashMap::new();
+        return Vec::new();
     }
     let idx = |x: usize, y: usize, z: usize| y * 256 + z * 16 + x;
 
@@ -500,6 +501,8 @@ fn compute_lighting(
     let mut emission = vec![0u8; height * 256];
 
     let sec_by_y: HashMap<i8, &Section> = sections.iter().map(|s| (s.y, s)).collect();
+    let mut htop = 0usize;
+    let mut any_opaque = false;
     for sy in min_section_y..=max_section_y {
         let Some(sec) = sec_by_y.get(&sy) else {
             continue;
@@ -513,17 +516,27 @@ fn compute_lighting(
                     let g = idx(x, base_y + ly, z);
                     opaque[g] = op[local];
                     emission[g] = em[local];
+                    if op[local] {
+                        any_opaque = true;
+                        htop = htop.max(base_y + ly);
+                    }
                 }
             }
         }
     }
 
-    // SkyLight: vertical cast then flood-fill.
+    // SkyLight: open sky above the highest opaque block is 15; only flood-fill the band below.
+    let top = if any_opaque {
+        (htop + 2).min(height)
+    } else {
+        0
+    };
     let mut sky = vec![0u8; height * 256];
+    sky[top * 256..].fill(15);
     let mut sq: VecDeque<(usize, usize, usize, u8)> = VecDeque::new();
     for z in 0..16usize {
         for x in 0..16usize {
-            for y in (0..height).rev() {
+            for y in (0..top).rev() {
                 let g = idx(x, y, z);
                 if opaque[g] {
                     break;
@@ -538,23 +551,18 @@ fn compute_lighting(
     // BlockLight: flood-fill from emitters.
     let mut block = vec![0u8; height * 256];
     let mut bq: VecDeque<(usize, usize, usize, u8)> = VecDeque::new();
-    for y in 0..height {
-        for z in 0..16usize {
-            for x in 0..16usize {
-                let g = idx(x, y, z);
-                if emission[g] > 0 {
-                    block[g] = emission[g];
-                    bq.push_back((x, y, z, emission[g]));
-                }
-            }
+    for g in 0..height * 256 {
+        if emission[g] > 0 {
+            block[g] = emission[g];
+            let rem = g % 256;
+            bq.push_back((rem % 16, g / 256, rem / 16, emission[g]));
         }
     }
     propagate_light(&mut block, &opaque, &mut bq, height);
 
-    // Pack each section.
-    let mut out = HashMap::new();
-    for sy in min_section_y..=max_section_y {
-        let base_y = ((sy as i32 - min_section_y as i32) * 16) as usize;
+    let mut out = Vec::with_capacity(num_sections);
+    for s in 0..num_sections {
+        let base_y = s * 16;
         let mut sl = vec![0i8; 2048];
         let mut bl = vec![0i8; 2048];
         for ly in 0..16usize {
@@ -567,7 +575,7 @@ fn compute_lighting(
                 }
             }
         }
-        out.insert(sy, (sl, bl));
+        out.push((sl, bl));
     }
     out
 }
@@ -610,7 +618,8 @@ fn create_chunk_nbt(chunk: &Chunk) -> HashMap<String, Value> {
 
     // Build all sections in the determined range
     let sections: Vec<Value> = (min_section_y..=max_section_y)
-        .map(|y| {
+        .zip(lighting)
+        .map(|(y, (sky_light, block_light))| {
             let mut section_nbt = if let Some(&idx) = section_map.get(&y) {
                 build_section_value(&chunk.sections[idx])
             } else {
@@ -630,16 +639,14 @@ fn create_chunk_nbt(chunk: &Chunk) -> HashMap<String, Value> {
                 ])
             };
             section_nbt.insert("biomes".to_string(), biome_value.clone());
-            if let Some((sky_light, block_light)) = lighting.get(&y) {
-                section_nbt.insert(
-                    "SkyLight".to_string(),
-                    Value::ByteArray(ByteArray::new(sky_light.clone())),
-                );
-                section_nbt.insert(
-                    "BlockLight".to_string(),
-                    Value::ByteArray(ByteArray::new(block_light.clone())),
-                );
-            }
+            section_nbt.insert(
+                "SkyLight".to_string(),
+                Value::ByteArray(ByteArray::new(sky_light)),
+            );
+            section_nbt.insert(
+                "BlockLight".to_string(),
+                Value::ByteArray(ByteArray::new(block_light)),
+            );
             Value::Compound(section_nbt)
         })
         .collect();

--- a/src/world_editor/java.rs
+++ b/src/world_editor/java.rs
@@ -374,27 +374,49 @@ fn is_light_transparent(name: &str) -> bool {
     SUB.iter().any(|s| n.contains(s))
 }
 
-// Per-cell opacity and emission for a section (YZX order, 4096 cells).
-fn decode_section_light_props(section: &Section) -> (Vec<bool>, Vec<u8>) {
+// Light a block removes: 0 passes, 1 attenuates (water/leaves/ice), 15 blocks.
+fn light_opacity(name: &str) -> u8 {
+    let n = name.strip_prefix("minecraft:").unwrap_or(name);
+    if n.ends_with("leaves")
+        || matches!(
+            n,
+            "water"
+                | "ice"
+                | "frosted_ice"
+                | "bubble_column"
+                | "kelp"
+                | "kelp_plant"
+                | "seagrass"
+                | "tall_seagrass"
+        )
+    {
+        return 1;
+    }
+    if is_light_transparent(name) {
+        0
+    } else {
+        15
+    }
+}
+
+// Per-cell light opacity and emission for a section (YZX order, 4096 cells).
+fn decode_section_light_props(section: &Section) -> (Vec<u8>, Vec<u8>) {
     let palette = &section.block_states.palette;
-    let pal_opaque: Vec<bool> = palette
-        .iter()
-        .map(|p| !is_light_transparent(&p.name))
-        .collect();
+    let pal_opacity: Vec<u8> = palette.iter().map(|p| light_opacity(&p.name)).collect();
     let pal_emission: Vec<u8> = palette
         .iter()
         .map(|p| block_light_emission(&p.name, p.properties.as_ref()))
         .collect();
 
-    let mut opaque = vec![false; 4096];
+    let mut opacity = vec![0u8; 4096];
     let mut emission = vec![0u8; 4096];
 
     match &section.block_states.data {
         None => {
-            let o = pal_opaque.first().copied().unwrap_or(false);
+            let o = pal_opacity.first().copied().unwrap_or(0);
             let e = pal_emission.first().copied().unwrap_or(0);
-            if o {
-                opaque.iter_mut().for_each(|v| *v = true);
+            if o > 0 {
+                opacity.iter_mut().for_each(|v| *v = o);
             }
             if e > 0 {
                 emission.iter_mut().for_each(|v| *v = e);
@@ -413,20 +435,20 @@ fn decode_section_light_props(section: &Section) -> (Vec<bool>, Vec<u8>) {
                 if long_idx < data.len() {
                     let pi = ((data[long_idx] as u64 >> off) & mask) as usize;
                     if pi < palette.len() {
-                        opaque[i] = pal_opaque[pi];
+                        opacity[i] = pal_opacity[pi];
                         emission[i] = pal_emission[pi];
                     }
                 }
             }
         }
     }
-    (opaque, emission)
+    (opacity, emission)
 }
 
-// Flood-fill light from the seeded queue, -1 per block, through non-opaque cells.
+// Flood-fill light from the seeded queue, -1 per block, through cells light can enter.
 fn propagate_light(
     light: &mut [u8],
-    opaque: &[bool],
+    opacity: &[u8],
     queue: &mut std::collections::VecDeque<(usize, usize, usize, u8)>,
     height: usize,
 ) {
@@ -443,7 +465,7 @@ fn propagate_light(
              light: &mut [u8],
              queue: &mut std::collections::VecDeque<(usize, usize, usize, u8)>| {
                 let g = idx(nx, ny, nz);
-                if !opaque[g] && light[g] < next {
+                if opacity[g] < 15 && light[g] < next {
                     light[g] = next;
                     queue.push_back((nx, ny, nz, next));
                 }
@@ -497,12 +519,12 @@ fn compute_lighting(
     }
     let idx = |x: usize, y: usize, z: usize| y * 256 + z * 16 + x;
 
-    let mut opaque = vec![false; height * 256];
+    let mut opacity = vec![0u8; height * 256];
     let mut emission = vec![0u8; height * 256];
 
     let sec_by_y: HashMap<i8, &Section> = sections.iter().map(|s| (s.y, s)).collect();
     let mut htop = 0usize;
-    let mut any_opaque = false;
+    let mut any_solid = false;
     for sy in min_section_y..=max_section_y {
         let Some(sec) = sec_by_y.get(&sy) else {
             continue;
@@ -514,10 +536,10 @@ fn compute_lighting(
                 for x in 0..16usize {
                     let local = ly * 256 + z * 16 + x;
                     let g = idx(x, base_y + ly, z);
-                    opaque[g] = op[local];
+                    opacity[g] = op[local];
                     emission[g] = em[local];
-                    if op[local] {
-                        any_opaque = true;
+                    if op[local] > 0 {
+                        any_solid = true;
                         htop = htop.max(base_y + ly);
                     }
                 }
@@ -525,28 +547,30 @@ fn compute_lighting(
         }
     }
 
-    // SkyLight: open sky above the highest opaque block is 15; only flood-fill the band below.
-    let top = if any_opaque {
-        (htop + 2).min(height)
-    } else {
-        0
-    };
+    // SkyLight: open sky above the highest non-transparent block is 15; flood-fill the band below.
+    let top = if any_solid { (htop + 2).min(height) } else { 0 };
     let mut sky = vec![0u8; height * 256];
     sky[top * 256..].fill(15);
     let mut sq: VecDeque<(usize, usize, usize, u8)> = VecDeque::new();
     for z in 0..16usize {
         for x in 0..16usize {
+            let mut level = 15u8;
             for y in (0..top).rev() {
                 let g = idx(x, y, z);
-                if opaque[g] {
+                if opacity[g] >= 15 {
                     break;
                 }
-                sky[g] = 15;
-                sq.push_back((x, y, z, 15));
+                sky[g] = level;
+                if level > 0 {
+                    sq.push_back((x, y, z, level));
+                }
+                if opacity[g] > 0 {
+                    level = level.saturating_sub(1);
+                }
             }
         }
     }
-    propagate_light(&mut sky, &opaque, &mut sq, height);
+    propagate_light(&mut sky, &opacity, &mut sq, height);
 
     // BlockLight: flood-fill from emitters.
     let mut block = vec![0u8; height * 256];
@@ -558,7 +582,7 @@ fn compute_lighting(
             bq.push_back((rem % 16, g / 256, rem / 16, emission[g]));
         }
     }
-    propagate_light(&mut block, &opaque, &mut bq, height);
+    propagate_light(&mut block, &opacity, &mut bq, height);
 
     let mut out = Vec::with_capacity(num_sections);
     for s in 0..num_sections {

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -142,6 +142,8 @@ pub struct WorldEditor<'a> {
     luanti_ground_level: i32,
     /// Luanti game pack
     luanti_game: LuantiGame,
+    /// Bake per-chunk lighting (Java) for off-disk LOD renderers; off by default.
+    bake_lighting: bool,
 }
 
 impl<'a> WorldEditor<'a> {
@@ -165,6 +167,7 @@ impl<'a> WorldEditor<'a> {
             luanti_spawn_point: None,
             luanti_ground_level: -62,
             luanti_game: LuantiGame::Mineclonia,
+            bake_lighting: false,
         }
     }
 
@@ -194,6 +197,7 @@ impl<'a> WorldEditor<'a> {
             luanti_spawn_point: None,
             luanti_ground_level: -62,
             luanti_game: LuantiGame::Mineclonia,
+            bake_lighting: false,
         }
     }
 
@@ -223,12 +227,18 @@ impl<'a> WorldEditor<'a> {
             luanti_spawn_point: spawn_point,
             luanti_ground_level: ground_level,
             luanti_game: game,
+            bake_lighting: false,
         }
     }
 
     /// Sets the ground reference for elevation-based block placement
     pub fn set_ground(&mut self, ground: Arc<Ground>) {
         self.ground = Some(ground);
+    }
+
+    /// Enables baking per-chunk lighting into Java chunks.
+    pub fn set_bake_lighting(&mut self, enabled: bool) {
+        self.bake_lighting = enabled;
     }
 
     /// Gets a reference to the ground data if available


### PR DESCRIPTION
Chunks were written as Status=full but without lighting, so off-disk LOD/pre-gen tools (Voxy, Chunky) rendered them dark until visited and relit in-game. Compute SkyLight (vertical cast + flood-fill) and BlockLight (flood-fill from emitters) per section and set isLightOn=1 so the light engine loads them as LIGHT_AND_DATA immediately.