### PR TITLE
Fix PR Benchmark to measure the PR head

### DIFF
--- a/.github/workflows/pr-benchmark.yml
+++ b/.github/workflows/pr-benchmark.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
   issue_comment:
     types: [created]
 
@@ -19,7 +19,13 @@ jobs:
        contains(github.event.comment.body, 'retrigger-benchmark'))
     runs-on: ubuntu-latest
     steps:
+      # Check out the PR head so comment-triggered runs benchmark the PR, not main.
       - uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number || github.event.issue.number }}/head
+      - name: Resolve benchmarked commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/setup-arnis-linux
         with:
           gui-deps: "false"
@@ -60,6 +66,8 @@ jobs:
 
       - name: Format duration and generate summary
         id: comment_body
+        env:
+          COMMIT_SHA: ${{ steps.commit.outputs.sha }}
         run: |
           duration=${{ steps.end_time.outputs.duration }}
           minutes=$((duration / 60))
@@ -127,7 +135,7 @@ jobs:
             echo ""
             echo "📈 Compared against baseline: **${baseline_time}s** time, **${baseline_mem} MB** memory"
             echo "🧮 Delta: **${diff}s** time, **${mem_diff} MB** memory"
-            echo "🔢 Commit: [\`${GITHUB_SHA:0:7}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA})"
+            echo "🔢 Commit: [\`${COMMIT_SHA:0:7}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${COMMIT_SHA})"
             echo ""
             echo "${verdict}"
             echo "${mem_verdict}"


### PR DESCRIPTION
The `PR Benchmark` workflow currently:
- only triggers on `opened`/`reopened` (not `synchronize`), so pushes to an open PR are never benchmarked, and
- on the `retrigger-benchmark` comment it checks out the default branch (no PR ref), so it benchmarks `main` instead of the PR.

This adds the `synchronize` trigger and checks out `refs/pull/<n>/head` for both `pull_request` and `issue_comment` events, and reports the actually-benchmarked commit SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)