### PR TITLE
feat(3d): add Christ the Redeemer manual-overlay model

### DIFF
--- a/assets/wikidata_3d_models_manual.json
+++ b/assets/wikidata_3d_models_manual.json
@@ -15,6 +15,18 @@
         { "y_max_frac": 0.95, "blocks": ["WAXED_OXIDIZED_COPPER"] },
         { "y_max_frac": 1.00, "hex": "F3E370" }
       ]
+    },
+    "Q79961": {
+      "label": "Christ the Redeemer",
+      "url": "https://arnismc.com/assets/3dmodels/christ_the_redeemer.stl",
+      "license": "CC BY 4.0",
+      "license_url": "https://creativecommons.org/licenses/by/4.0/",
+      "artist": "louis-e",
+      "height_m": 110.0,
+      "palette_layers": [
+        { "y_max_frac": 0.22, "blocks": ["MUD_BRICKS"] },
+        { "y_max_frac": 1.00, "blocks": ["LIGHT_GRAY_CONCRETE"] }
+      ]
     }
   }
 }


### PR DESCRIPTION
Hosts a custom STL at arnismc.com and maps it to OSM node 4919986733 (Cristo Redentor on Corcovado, wikidata=Q79961). Two-tone palette: MUD_BRICKS for the pedestal/chapel, LIGHT_GRAY_CONCRETE for the soapstone statue.