### PR TITLE
perf(world_editor): single-traversal write on the default no-override path

### DIFF
--- a/src/world_editor/common.rs
+++ b/src/world_editor/common.rs
@@ -489,6 +489,45 @@ impl WorldToModify {
         }
     }
 
+    /// Like [`set_block_if_absent`] but also persists optional NBT properties.
+    #[inline]
+    pub fn set_with_props_if_absent(
+        &mut self,
+        x: i32,
+        y: i32,
+        z: i32,
+        block_with_props: BlockWithProperties,
+    ) {
+        let chunk_x: i32 = x >> 4;
+        let chunk_z: i32 = z >> 4;
+        let region_x: i32 = chunk_x >> 5;
+        let region_z: i32 = chunk_z >> 5;
+
+        let region = self.regions.entry((region_x, region_z)).or_default();
+        let chunk = region
+            .chunks
+            .entry((chunk_x & 31, chunk_z & 31))
+            .or_default();
+
+        let y = y.clamp(MIN_Y, MAX_Y);
+        let section_idx: i8 = (y >> 4) as i8;
+        let section = chunk.sections.entry(section_idx).or_default();
+
+        let local_x = (x & 15) as u8;
+        let local_y = (y & 15) as u8;
+        let local_z = (z & 15) as u8;
+        let idx = SectionToModify::index(local_x, local_y, local_z);
+
+        if section.storage.get(idx) == AIR {
+            section.storage.set(idx, block_with_props.block);
+            if let Some(props) = block_with_props.properties {
+                section.properties.insert(idx, props);
+            } else {
+                section.properties.remove(&idx);
+            }
+        }
+    }
+
     /// Fill an entire column (single x, z) from y_min to y_max with the same block,
     /// resolving region/chunk only once.  Used by ground generation.
     #[inline]

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -889,6 +889,13 @@ impl<'a> WorldEditor<'a> {
             return;
         }
 
+        // None/None is the dominant pattern; skip the redundant get_block() read.
+        if override_whitelist.is_none() && override_blacklist.is_none() {
+            self.world
+                .set_with_props_if_absent(x, absolute_y, z, block_with_props);
+            return;
+        }
+
         let should_insert = if let Some(existing_block) = self.world.get_block(x, absolute_y, z) {
             // Check against whitelist and blacklist
             if let Some(whitelist) = override_whitelist {


### PR DESCRIPTION
`set_block(..., None, None)` is the dominant write pattern across all element processors (~240 callsites). It currently goes through `get_block()` followed by `set_block_with_properties()`, descending the region/chunk/section `FnvHashMap` hierarchy twice per write.

This PR adds `WorldToModify::set_with_props_if_absent`, a single-traversal variant that does one `entry().or_default()` descent and checks `section.storage.get(idx) == AIR` directly. The `None/None` branch of `set_block_with_properties_absolute` routes to it via an early-return. The whitelist/blacklist slow path is untouched. Same pattern as the existing `set_block_if_absent` used by `ground_generation`.

`SectionToModify::get_block` returns `None` iff `storage.get(idx) == AIR`, so the condition checked is identical to the old path. Behaviour is preserved, only the number of map lookups is halved.

Benchmarked on Munich centre (`48.125768,11.552296,48.148565,11.593838`) with `--terrain --benchmark --file` over cached OSM data, release build, 5 runs each:

| | Mean | Median |
|---|---|---|
| Before | 9925 ms | 9916 ms |
| After  | 9480 ms | 9441 ms |
| Delta  | **-445 ms (-4.5%)** | **-475 ms (-4.8%)** |

All five after-runs were faster than all five before-runs.