### PR TITLE
feat: aeroplanes on runways + marked, width-aware runways

### DIFF
--- a/src/element_processing/highways.rs
+++ b/src/element_processing/highways.rs
@@ -1518,30 +1518,123 @@ pub fn generate_siding(
     }
 }
 
-/// Generates an aeroway
+/// A centerline point with its segment's unit travel direction (`ux`, `uz`) and cumulative
+/// distance `s` (blocks) from the way start, used for dash phase.
+struct AerowayCenterPoint {
+    x: i32,
+    z: i32,
+    ux: f32,
+    uz: f32,
+    s: f32,
+}
+
+/// Runway centerline dash: stripe-on / stripe-off lengths in meters (scaled by `--scale`).
+const RUNWAY_DASH_ON_M: f32 = 10.0;
+const RUNWAY_DASH_OFF_M: f32 = 6.0;
+/// How far inside the runway edge (blocks) the solid white edge stripes sit.
+const RUNWAY_EDGE_INSET: f32 = 1.0;
+/// Half-width (metres) used when an aeroway has no `width=*` tag (~24 m strip).
+const AEROWAY_DEFAULT_HALF_M: f64 = 12.0;
+/// Clamp (metres) for `width=*`-derived half-widths — guards against absurd tags.
+const AEROWAY_MIN_HALF_M: f64 = 6.0;
+const AEROWAY_MAX_HALF_M: f64 = 40.0;
+
+/// True where a runway centerline dash is painted, given distance `s` (blocks) from the way start.
+fn runway_centerline_dash_on(s: f32, scale: f64) -> bool {
+    let on = (RUNWAY_DASH_ON_M * scale as f32).max(1.0);
+    let off = (RUNWAY_DASH_OFF_M * scale as f32).max(1.0);
+    (s % (on + off)) < on
+}
+
+/// Parses an OSM `width=*` value in metres (tolerates a trailing "m").
+fn parse_aeroway_width_m(tags: &HashMap<String, String>) -> Option<f64> {
+    let raw = tags.get("width")?;
+    let s = raw.trim().trim_end_matches('m').trim();
+    s.parse::<f64>().ok().filter(|v| v.is_finite() && *v > 0.0)
+}
+
+/// Renders an aeroway as a concrete strip with markings: runways get asphalt-gray with a dashed
+/// white centerline + white edge stripes, taxiways a lighter surface with a yellow centerline.
+/// No threshold "piano keys" — OSM splits runways into segments, so a per-way renderer can't tell
+/// a real end from an internal split.
 pub fn generate_aeroway(editor: &mut WorldEditor, way: &ProcessedWay, args: &Args) {
-    let mut previous_node: Option<(i32, i32)> = None;
-    let surface_block = LIGHT_GRAY_CONCRETE;
+    let aeroway = way.tags.get("aeroway").map(String::as_str);
+    let is_runway = aeroway == Some("runway");
+    let is_taxiway = aeroway == Some("taxiway");
 
-    for node in &way.nodes {
-        if let Some(prev) = previous_node {
-            let (x1, z1) = prev;
-            let x2 = node.x;
-            let z2 = node.z;
-            let points = bresenham_line(x1, 0, z1, x2, 0, z2);
-            let way_width: i32 = (12.0 * args.scale).ceil() as i32;
+    let base_block = if is_runway {
+        GRAY_CONCRETE
+    } else {
+        LIGHT_GRAY_CONCRETE
+    };
 
-            for (x, _, z) in points {
-                for dx in -way_width..=way_width {
-                    for dz in -way_width..=way_width {
-                        let set_x = x + dx;
-                        let set_z = z + dz;
-                        editor.set_block(surface_block, set_x, 0, set_z, None, None);
-                    }
-                }
+    // Half-width from the OSM `width=*` tag (metres, clamped to sane sizes); default when absent.
+    let half_m = parse_aeroway_width_m(&way.tags)
+        .map(|w| (w * 0.5).clamp(AEROWAY_MIN_HALF_M, AEROWAY_MAX_HALF_M))
+        .unwrap_or(AEROWAY_DEFAULT_HALF_M);
+    let half_width: i32 = (half_m * args.scale).round().max(1.0) as i32;
+
+    // Build the centerline once: bresenham per segment, consecutive duplicates dropped, with a
+    // running distance so dash phase and markings stay consistent across segments and regions.
+    let mut points: Vec<AerowayCenterPoint> = Vec::new();
+    let mut s_accum = 0.0_f32;
+    let mut last: Option<(i32, i32)> = None;
+    for pair in way.nodes.windows(2) {
+        let (x1, z1) = (pair[0].x, pair[0].z);
+        let (x2, z2) = (pair[1].x, pair[1].z);
+        let len = (((x2 - x1) as f32).hypot((z2 - z1) as f32)).max(1e-6);
+        let (ux, uz) = ((x2 - x1) as f32 / len, (z2 - z1) as f32 / len);
+        for (x, _, z) in bresenham_line(x1, 0, z1, x2, 0, z2) {
+            if last == Some((x, z)) {
+                continue;
+            }
+            if let Some((lx, lz)) = last {
+                s_accum += ((x - lx) as f32).hypot((z - lz) as f32);
+            }
+            points.push(AerowayCenterPoint {
+                x,
+                z,
+                ux,
+                uz,
+                s: s_accum,
+            });
+            last = Some((x, z));
+        }
+    }
+
+    // Pass 1: full surface, before markings. A runway's base may overwrite taxiway surface so it
+    // wins crossings regardless of element order; a taxiway's base only fills empty cells (`None`),
+    // so it never paints over a runway.
+    let runway_overwrites = [LIGHT_GRAY_CONCRETE, YELLOW_CONCRETE];
+    let base_over: Option<&[Block]> = is_runway.then_some(&runway_overwrites[..]);
+    for cp in &points {
+        for dx in -half_width..=half_width {
+            for dz in -half_width..=half_width {
+                editor.set_block(base_block, cp.x + dx, 0, cp.z + dz, base_over, None);
             }
         }
-        previous_node = Some((node.x, node.z));
+    }
+
+    // Pass 2: markings. `set_block` only overwrites a whitelisted block, so markings must list
+    // the base surface they replace — else pass 1 has claimed every cell and they're dropped.
+    let base_overwrite = [base_block];
+    let over_base = Some(&base_overwrite[..]);
+    for cp in &points {
+        // Perpendicular unit vector across the strip.
+        let (px, pz) = (-cp.uz, cp.ux);
+        if is_runway {
+            if runway_centerline_dash_on(cp.s, args.scale) {
+                editor.set_block(WHITE_CONCRETE, cp.x, 0, cp.z, over_base, None);
+            }
+            let off = (half_width as f32 - RUNWAY_EDGE_INSET).max(0.0);
+            for sign in [1.0_f32, -1.0] {
+                let ex = (cp.x as f32 + sign * px * off).round() as i32;
+                let ez = (cp.z as f32 + sign * pz * off).round() as i32;
+                editor.set_block(WHITE_CONCRETE, ex, 0, ez, over_base, None);
+            }
+        } else if is_taxiway {
+            editor.set_block(YELLOW_CONCRETE, cp.x, 0, cp.z, over_base, None);
+        }
     }
 }
 
@@ -1722,4 +1815,193 @@ pub fn collect_building_passage_coords(
     }
 
     bitmap
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runway_dash_alternates_on_and_off() {
+        // At scale 1: 10 blocks on, 6 off, repeating every 16.
+        assert!(runway_centerline_dash_on(0.0, 1.0));
+        assert!(runway_centerline_dash_on(9.0, 1.0));
+        assert!(!runway_centerline_dash_on(10.0, 1.0));
+        assert!(!runway_centerline_dash_on(15.0, 1.0));
+        assert!(
+            runway_centerline_dash_on(16.0, 1.0),
+            "pattern repeats at 16"
+        );
+        assert!(
+            runway_centerline_dash_on(160.0, 1.0),
+            "phase stays consistent far along"
+        );
+    }
+
+    #[test]
+    fn runway_dash_scales_with_world_scale() {
+        // At scale 2: 20 blocks on, 12 off.
+        assert!(runway_centerline_dash_on(19.0, 2.0));
+        assert!(!runway_centerline_dash_on(20.0, 2.0));
+    }
+
+    // --- Rendering regression tests: markings must actually overwrite the base surface. ---
+
+    use crate::coordinate_system::cartesian::XZBBox;
+    use crate::coordinate_system::geographic::LLBBox;
+    use crate::osm_parser::ProcessedNode;
+    use crate::world_editor::WorldEditor;
+    use clap::Parser as _;
+    use std::collections::HashMap as StdMap;
+    use std::path::PathBuf;
+
+    /// Builds an in-memory editor (never saved) over a 400×100 area at ground Y=0.
+    fn test_editor(xzbbox: &XZBBox) -> WorldEditor<'_> {
+        let llbbox = LLBBox::new(54.6, 9.9, 54.61, 9.91).unwrap();
+        WorldEditor::new(PathBuf::from("/dev/null/unused"), xzbbox, llbbox)
+    }
+
+    fn straight_aeroway(kind: &str) -> ProcessedWay {
+        let mut tags = StdMap::new();
+        tags.insert("aeroway".to_string(), kind.to_string());
+        ProcessedWay {
+            id: 1,
+            nodes: vec![
+                ProcessedNode {
+                    id: 1,
+                    tags: StdMap::new(),
+                    x: 10,
+                    z: 50,
+                },
+                ProcessedNode {
+                    id: 2,
+                    tags: StdMap::new(),
+                    x: 390,
+                    z: 50,
+                },
+            ],
+            tags,
+        }
+    }
+
+    #[test]
+    fn runway_paints_white_centerline_and_edges_over_gray() {
+        let args = Args::parse_from(["arnis", "--bbox", "1,2,3,4"].iter());
+        let xzbbox = XZBBox::rect_from_xz_lengths(400.0, 100.0).unwrap();
+        let mut editor = test_editor(&xzbbox);
+
+        generate_aeroway(&mut editor, &straight_aeroway("runway"), &args);
+
+        // Centerline at the way start (s=0, dash on) is white; a dash-gap cell stays gray.
+        assert!(
+            editor.check_for_block(10, 0, 50, Some(&[WHITE_CONCRETE])),
+            "centerline dash"
+        );
+        assert!(
+            editor.check_for_block(22, 0, 50, Some(&[GRAY_CONCRETE])),
+            "dash gap stays asphalt"
+        );
+        // Solid white edge stripe one block inside the 12-wide half (z = 50 ± 11).
+        assert!(
+            editor.check_for_block(10, 0, 39, Some(&[WHITE_CONCRETE])),
+            "left edge stripe"
+        );
+        assert!(
+            editor.check_for_block(10, 0, 61, Some(&[WHITE_CONCRETE])),
+            "right edge stripe"
+        );
+        // Plain surface between centerline and edge is asphalt gray.
+        assert!(
+            editor.check_for_block(10, 0, 45, Some(&[GRAY_CONCRETE])),
+            "asphalt base"
+        );
+    }
+
+    #[test]
+    fn taxiway_paints_yellow_centerline_over_light_gray() {
+        let args = Args::parse_from(["arnis", "--bbox", "1,2,3,4"].iter());
+        let xzbbox = XZBBox::rect_from_xz_lengths(400.0, 100.0).unwrap();
+        let mut editor = test_editor(&xzbbox);
+
+        generate_aeroway(&mut editor, &straight_aeroway("taxiway"), &args);
+
+        assert!(
+            editor.check_for_block(10, 0, 50, Some(&[YELLOW_CONCRETE])),
+            "yellow centerline"
+        );
+        assert!(
+            editor.check_for_block(10, 0, 45, Some(&[LIGHT_GRAY_CONCRETE])),
+            "light-gray base"
+        );
+        // Taxiways get no white edge stripes.
+        assert!(
+            !editor.check_for_block(10, 0, 39, Some(&[WHITE_CONCRETE])),
+            "no edge stripe"
+        );
+    }
+
+    #[test]
+    fn runway_width_tag_widens_the_strip() {
+        let args = Args::parse_from(["arnis", "--bbox", "1,2,3,4"].iter());
+        let xzbbox = XZBBox::rect_from_xz_lengths(400.0, 100.0).unwrap();
+        let mut editor = test_editor(&xzbbox);
+
+        let mut way = straight_aeroway("runway");
+        way.tags.insert("width".to_string(), "60".to_string());
+        generate_aeroway(&mut editor, &way, &args);
+
+        // 60 m wide ⇒ half-width 30: asphalt reaches z=70 and the edge stripe sits at z=50+29.
+        assert!(
+            editor.check_for_block(10, 0, 70, Some(&[GRAY_CONCRETE])),
+            "widened asphalt"
+        );
+        assert!(
+            editor.check_for_block(10, 0, 79, Some(&[WHITE_CONCRETE])),
+            "edge stripe at width/2-1"
+        );
+    }
+
+    #[test]
+    fn runway_overrides_a_crossing_taxiway_regardless_of_order() {
+        let args = Args::parse_from(["arnis", "--bbox", "1,2,3,4"].iter());
+        let xzbbox = XZBBox::rect_from_xz_lengths(400.0, 100.0).unwrap();
+        let mut editor = test_editor(&xzbbox);
+
+        // Process the taxiway FIRST — the order that used to leak taxiway surface onto the runway.
+        let mut tags = StdMap::new();
+        tags.insert("aeroway".to_string(), "taxiway".to_string());
+        let taxiway = ProcessedWay {
+            id: 2,
+            nodes: vec![
+                ProcessedNode {
+                    id: 3,
+                    tags: StdMap::new(),
+                    x: 200,
+                    z: 10,
+                },
+                ProcessedNode {
+                    id: 4,
+                    tags: StdMap::new(),
+                    x: 200,
+                    z: 90,
+                },
+            ],
+            tags,
+        };
+        generate_aeroway(&mut editor, &taxiway, &args);
+        generate_aeroway(&mut editor, &straight_aeroway("runway"), &args);
+
+        // The crossing cell belongs to the runway, not the taxiway.
+        assert!(
+            editor.check_for_block(200, 0, 50, Some(&[GRAY_CONCRETE])),
+            "runway wins crossing"
+        );
+        assert!(!editor.check_for_block(200, 0, 50, Some(&[YELLOW_CONCRETE])));
+        assert!(!editor.check_for_block(200, 0, 50, Some(&[LIGHT_GRAY_CONCRETE])));
+        // Away from the runway the taxiway is untouched.
+        assert!(
+            editor.check_for_block(200, 0, 20, Some(&[YELLOW_CONCRETE])),
+            "taxiway intact off-runway"
+        );
+    }
 }

--- a/src/models_3d/custom/mod.rs
+++ b/src/models_3d/custom/mod.rs
@@ -1,4 +1,5 @@
 //! Arnis-hosted archetype models triggered by OSM tags (stadiums, etc.).
 
 pub(crate) mod client;
+pub(crate) mod plane;
 pub(crate) mod stadium;

--- a/src/models_3d/custom/plane.rs
+++ b/src/models_3d/custom/plane.rs
@@ -1,0 +1,738 @@
+//! Aeroplane archetype: planes parked on runways / long straight taxiways, plus one climbing off
+//! the end of long runways.
+//!
+//! OSM splits runways and taxiways (`aeroway=runway`/`taxiway`) into multiple centerline ways with
+//! no relation linking them, so we merge same-kind segments by shared end nodes + near-collinear
+//! bearing and treat each merged run as one strip. Aprons/gates (where planes really park) are
+//! polygons, not centerlines, so taxiway parking on straight runs is the next-best proxy.
+
+use crate::args::Args;
+use crate::deterministic_rng::element_rng;
+use crate::models_3d::custom::client;
+use crate::models_3d::voxelize::{glb_model_bbox, voxelize_glb, WorldTransform};
+use crate::osm_parser::ProcessedElement;
+use crate::world_editor::WorldEditor;
+use colored::Colorize;
+use rand::Rng;
+use std::collections::HashMap;
+
+const MODEL_URL: &str = "https://arnismc.com/assets/3dmodels/plane.glb";
+const CACHE_FILE: &str = "plane.glb";
+
+/// Length the plane is voxelized to. Asset convention: nose-tail +Z, wingspan X, up Y; uniform scale.
+const PLANE_LENGTH_M: f64 = 90.0;
+/// Nose-up tilt for the climbing-out plane.
+const ASCENDING_PITCH_DEG: f64 = 12.0;
+/// Runways at least this long always get a plane climbing off one end.
+const ASCENDING_MIN_LENGTH_M: f64 = 1500.0;
+/// Climb-out height above ground = this fraction of a plane-length, plus `ASCENDING_EXTRA_ELEV_M`.
+const ASCENDING_ELEV_FACTOR: f64 = 0.45;
+/// Flat extra climb-out height (metres) on top of the proportional part.
+const ASCENDING_EXTRA_ELEV_M: f64 = 20.0;
+/// Per-runway chance of a plane parked on the centerline.
+const RUNWAY_PARK_PROBABILITY: f64 = 0.4;
+/// Per-taxiway chance of a taxiing plane — lower than runways, which are far fewer.
+const TAXIWAY_PARK_PROBABILITY: f64 = 0.15;
+/// A parked plane needs a strip at least this long so it sits fully between the ends.
+const PARKED_MIN_LENGTH_M: f64 = 120.0;
+/// Above this length an aeroway is almost certainly mis-tagged (a whole airfield); skip it.
+const MAX_AEROWAY_LENGTH_M: f64 = 8000.0;
+/// Two segments sharing an end node merge only if their bearings differ by less than this.
+const COLLINEAR_TOL_RAD: f64 = 0.349; // ~20°
+/// Straightness cap (perpendicular / long extent); stricter for curvy taxiways than runways.
+const RUNWAY_MAX_PERP_RATIO: f64 = 0.5;
+const TAXIWAY_MAX_PERP_RATIO: f64 = 0.12;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PlaneKind {
+    Parked,
+    Ascending,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AerowayKind {
+    Runway,
+    Taxiway,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Bbox {
+    min_x: i32,
+    min_z: i32,
+    max_x: i32,
+    max_z: i32,
+}
+
+#[derive(Clone, Debug)]
+struct Placement {
+    rep_id: u64,
+    kind: PlaneKind,
+    anchor_x: i32,
+    anchor_z: i32,
+    /// World yaw (degrees) that aligns the model's +Z nose with the aeroway direction.
+    yaw_degrees: f64,
+    pitch_degrees: f64,
+    elevation_blocks: i32,
+    footprint: Bbox,
+}
+
+pub struct PrescanResult {
+    placements: Vec<Placement>,
+    model_bytes: Option<Vec<u8>>,
+}
+
+impl PrescanResult {
+    pub fn placement_count(&self) -> usize {
+        self.placements.len()
+    }
+}
+
+pub fn prescan(elements: &[ProcessedElement], args_scale: f64) -> PrescanResult {
+    let aeroways = collect_aeroways(elements);
+    let placements = build_placements(&aeroways, args_scale);
+    if placements.is_empty() {
+        return PrescanResult {
+            placements,
+            model_bytes: None,
+        };
+    }
+
+    match client::fetch_glb(MODEL_URL, CACHE_FILE) {
+        Ok(b) => PrescanResult {
+            placements,
+            model_bytes: Some(b),
+        },
+        Err(e) => {
+            eprintln!(
+                "{} plane model fetch failed ({MODEL_URL}): {e}",
+                "Warning:".yellow().bold()
+            );
+            PrescanResult {
+                placements: Vec::new(),
+                model_bytes: None,
+            }
+        }
+    }
+}
+
+pub fn place_plane_models(editor: &mut WorldEditor, args: &Args, prescan: &PrescanResult) {
+    if prescan.placements.is_empty() {
+        return;
+    }
+    let Some(model_bytes) = prescan.model_bytes.as_deref() else {
+        return;
+    };
+
+    let (model_min, model_max) = match glb_model_bbox(model_bytes) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("{} plane GLB bbox failed: {e}", "Warning:".yellow().bold());
+            return;
+        }
+    };
+    // Nose-tail runs along +Z in the asset; uniform scale keeps the plane's proportions.
+    let model_len = model_max[2] - model_min[2];
+    if model_len < 1e-3 {
+        eprintln!(
+            "{} plane GLB has degenerate length",
+            "Warning:".yellow().bold()
+        );
+        return;
+    }
+    let target_len_blocks = (PLANE_LENGTH_M * args.scale) as f32;
+    let intrinsic_scale = (target_len_blocks / model_len) as f64;
+
+    println!(
+        "{} Placing {} plane model{}...",
+        "  [+]".bold(),
+        prescan.placements.len(),
+        if prescan.placements.len() == 1 {
+            ""
+        } else {
+            "s"
+        }
+    );
+
+    let mut parked = 0usize;
+    let mut climbing = 0usize;
+    let mut total_voxels = 0usize;
+
+    for p in &prescan.placements {
+        let ground_y = lowest_ground_in_bbox(editor, &p.footprint);
+
+        let transform = WorldTransform::new(
+            0.0,
+            intrinsic_scale,
+            [0.0, 0.0, 0.0],
+            1.0,
+            p.yaw_degrees,
+            p.anchor_x as f32,
+            ground_y as f32,
+            p.anchor_z as f32,
+        )
+        .pitched(p.pitch_degrees);
+
+        let mut voxels = match voxelize_glb(model_bytes, transform) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!(
+                    "{} plane (OSM {}) voxelization failed: {e}",
+                    "Warning:".yellow().bold(),
+                    p.rep_id
+                );
+                continue;
+            }
+        };
+
+        // Lift so the lowest voxel rests at ground + elevation (0 = wheels on the runway).
+        if let Some(min_y) = voxels.iter().map(|(q, _)| q[1]).min() {
+            let dy = (ground_y + p.elevation_blocks) - min_y;
+            if dy != 0 {
+                for (pos, _) in voxels.iter_mut() {
+                    pos[1] += dy;
+                }
+            }
+        }
+
+        for ([x, y, z], block) in &voxels {
+            editor.set_block_absolute(*block, *x, *y, *z, None, None);
+        }
+        total_voxels += voxels.len();
+        match p.kind {
+            PlaneKind::Parked => parked += 1,
+            PlaneKind::Ascending => climbing += 1,
+        }
+    }
+
+    println!(
+        "  Placed {} plane model{} ({parked} parked, {climbing} climbing; {total_voxels} blocks)",
+        (parked + climbing).to_string().bright_white().bold(),
+        if parked + climbing == 1 { "" } else { "s" },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Aeroway extraction + merging
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+struct Seg {
+    way_id: u64,
+    kind: AerowayKind,
+    first_node: u64,
+    last_node: u64,
+    points: Vec<(f64, f64)>,
+    /// Undirected bearing in [0, π).
+    angle: f64,
+}
+
+#[derive(Clone, Debug)]
+struct AerowayStrip {
+    /// Smallest OSM way id in the merged group — a stable seed for deterministic placement.
+    rep_id: u64,
+    kind: AerowayKind,
+    centroid: (f64, f64),
+    /// Unit vector along the long axis.
+    dir: (f64, f64),
+    length_blocks: f64,
+    perp_blocks: f64,
+    /// Min/max projection of the points onto `dir`, measured from `centroid`.
+    min_a: f64,
+    max_a: f64,
+}
+
+fn collect_aeroways(elements: &[ProcessedElement]) -> Vec<AerowayStrip> {
+    let segs: Vec<Seg> = elements
+        .iter()
+        .filter_map(extract_aeroway_segment)
+        .collect();
+    if segs.is_empty() {
+        return Vec::new();
+    }
+
+    let mut uf = UnionFind::new(segs.len());
+    let mut endpoint_map: HashMap<u64, Vec<usize>> = HashMap::new();
+    for (i, s) in segs.iter().enumerate() {
+        endpoint_map.entry(s.first_node).or_default().push(i);
+        endpoint_map.entry(s.last_node).or_default().push(i);
+    }
+    for ids in endpoint_map.values() {
+        for a in 0..ids.len() {
+            for b in (a + 1)..ids.len() {
+                let (ia, ib) = (ids[a], ids[b]);
+                // Same kind only — a taxiway meeting a runway end-on must not fuse.
+                if segs[ia].kind == segs[ib].kind && collinear(segs[ia].angle, segs[ib].angle) {
+                    uf.union(ia, ib);
+                }
+            }
+        }
+    }
+
+    let mut groups: HashMap<usize, Vec<usize>> = HashMap::new();
+    for i in 0..segs.len() {
+        groups.entry(uf.find(i)).or_default().push(i);
+    }
+    groups
+        .values()
+        .filter_map(|g| strip_from_group(&segs, g))
+        .collect()
+}
+
+fn extract_aeroway_segment(element: &ProcessedElement) -> Option<Seg> {
+    let ProcessedElement::Way(w) = element else {
+        return None;
+    };
+    let kind = match w.tags.get("aeroway").map(|s| s.as_str()) {
+        Some("runway") => AerowayKind::Runway,
+        Some("taxiway") => AerowayKind::Taxiway,
+        _ => return None,
+    };
+    // Skip area representations — we only place planes along linear centerlines.
+    if w.tags.get("area").map(|s| s.as_str()) == Some("yes") {
+        return None;
+    }
+    if w.nodes.len() < 2 {
+        return None;
+    }
+    let first = &w.nodes[0];
+    let last = &w.nodes[w.nodes.len() - 1];
+    if first.id == last.id {
+        return None; // closed loop = area, not a centerline
+    }
+    let dx = last.x as f64 - first.x as f64;
+    let dz = last.z as f64 - first.z as f64;
+    if dx == 0.0 && dz == 0.0 {
+        return None;
+    }
+    Some(Seg {
+        way_id: w.id,
+        kind,
+        first_node: first.id,
+        last_node: last.id,
+        points: w.nodes.iter().map(|n| (n.x as f64, n.z as f64)).collect(),
+        angle: dz.atan2(dx).rem_euclid(std::f64::consts::PI),
+    })
+}
+
+/// True when two undirected bearings in [0, π) are within `COLLINEAR_TOL_RAD`.
+fn collinear(a: f64, b: f64) -> bool {
+    let d = (a - b).abs();
+    d.min(std::f64::consts::PI - d) < COLLINEAR_TOL_RAD
+}
+
+fn strip_from_group(segs: &[Seg], group: &[usize]) -> Option<AerowayStrip> {
+    let mut pts: Vec<(f64, f64)> = Vec::new();
+    let mut rep_id = u64::MAX;
+    for &i in group {
+        rep_id = rep_id.min(segs[i].way_id);
+        pts.extend_from_slice(&segs[i].points);
+    }
+    // All segments in a merged group share a kind (the merge rule enforces it).
+    let kind = segs[group[0]].kind;
+    principal_geom(&pts, rep_id, kind)
+}
+
+/// PCA on the merged point cloud: long-axis direction, length, perpendicular extent.
+fn principal_geom(points: &[(f64, f64)], rep_id: u64, kind: AerowayKind) -> Option<AerowayStrip> {
+    if points.len() < 2 {
+        return None;
+    }
+    let n = points.len() as f64;
+    let cx = points.iter().map(|p| p.0).sum::<f64>() / n;
+    let cz = points.iter().map(|p| p.1).sum::<f64>() / n;
+    let (mut cxx, mut cxz, mut czz) = (0.0_f64, 0.0_f64, 0.0_f64);
+    for &(x, z) in points {
+        let dx = x - cx;
+        let dz = z - cz;
+        cxx += dx * dx;
+        cxz += dx * dz;
+        czz += dz * dz;
+    }
+
+    let theta = 0.5 * (2.0 * cxz).atan2(cxx - czz);
+    let (mut s, mut c) = theta.sin_cos();
+    let extent = |s: f64, c: f64| {
+        let (mut lo, mut hi) = (f64::INFINITY, f64::NEG_INFINITY);
+        for &(x, z) in points {
+            let v = (x - cx) * c + (z - cz) * s;
+            lo = lo.min(v);
+            hi = hi.max(v);
+        }
+        (lo, hi)
+    };
+
+    let (mut min_a, mut max_a) = extent(s, c);
+    let (mut min_p, mut max_p) = extent(c, -s); // perpendicular axis
+                                                // `theta` may land on the short axis; flip to the longer one so `dir` is nose-tail.
+    if (max_p - min_p) > (max_a - min_a) {
+        let (ns, nc) = (c, -s);
+        s = ns;
+        c = nc;
+        std::mem::swap(&mut min_a, &mut min_p);
+        std::mem::swap(&mut max_a, &mut max_p);
+    }
+
+    let length = max_a - min_a;
+    if length <= 0.0 {
+        return None;
+    }
+    Some(AerowayStrip {
+        rep_id,
+        kind,
+        centroid: (cx, cz),
+        dir: (c, s),
+        length_blocks: length,
+        perp_blocks: max_p - min_p,
+        min_a,
+        max_a,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Placement decisions
+// ---------------------------------------------------------------------------
+
+fn build_placements(strips: &[AerowayStrip], scale: f64) -> Vec<Placement> {
+    let mut out = Vec::new();
+    let plane_len_blocks = PLANE_LENGTH_M * scale;
+
+    for strip in strips {
+        let length_m = strip.length_blocks / scale;
+        let perp_ratio = strip.perp_blocks / strip.length_blocks;
+        let (park_probability, max_perp_ratio) = match strip.kind {
+            AerowayKind::Runway => (RUNWAY_PARK_PROBABILITY, RUNWAY_MAX_PERP_RATIO),
+            AerowayKind::Taxiway => (TAXIWAY_PARK_PROBABILITY, TAXIWAY_MAX_PERP_RATIO),
+        };
+        if length_m > MAX_AEROWAY_LENGTH_M || perp_ratio > max_perp_ratio {
+            continue;
+        }
+        let yaw = yaw_for_dir(strip.dir);
+        let mut rng = element_rng(strip.rep_id);
+
+        // Climbing plane: runways only (nothing takes off from a taxiway), off the far end.
+        if strip.kind == AerowayKind::Runway && length_m >= ASCENDING_MIN_LENGTH_M {
+            let (ax, az) = axis_point(strip, strip.max_a);
+            let elev = ((plane_len_blocks * ASCENDING_ELEV_FACTOR + ASCENDING_EXTRA_ELEV_M * scale)
+                .round() as i32)
+                .max(1);
+            out.push(Placement {
+                rep_id: strip.rep_id,
+                kind: PlaneKind::Ascending,
+                anchor_x: ax,
+                anchor_z: az,
+                yaw_degrees: yaw,
+                pitch_degrees: ASCENDING_PITCH_DEG,
+                elevation_blocks: elev,
+                footprint: footprint_around(ax, az, plane_len_blocks),
+            });
+        }
+
+        // Parked/taxiing plane on the centerline, sitting fully between the ends.
+        if length_m >= PARKED_MIN_LENGTH_M && rng.random_bool(park_probability) {
+            let half = plane_len_blocks * 0.5;
+            let lo = strip.min_a + half;
+            let hi = strip.max_a - half;
+            if hi > lo {
+                let a = lo + (hi - lo) * rng.random_range(0.0..1.0);
+                let (px, pz) = axis_point(strip, a);
+                out.push(Placement {
+                    rep_id: strip.rep_id,
+                    kind: PlaneKind::Parked,
+                    anchor_x: px,
+                    anchor_z: pz,
+                    yaw_degrees: yaw,
+                    pitch_degrees: 0.0,
+                    elevation_blocks: 0,
+                    footprint: footprint_around(px, pz, plane_len_blocks),
+                });
+            }
+        }
+    }
+
+    out
+}
+
+/// World yaw (degrees) so the model's +Z nose points along `dir`. A +Z vertex maps under the
+/// world yaw to (-sin β, cos β); solving for (dir.x, dir.z) gives β = atan2(-dir.x, dir.z).
+fn yaw_for_dir(dir: (f64, f64)) -> f64 {
+    (-dir.0).atan2(dir.1).to_degrees()
+}
+
+fn axis_point(strip: &AerowayStrip, a: f64) -> (i32, i32) {
+    (
+        (strip.centroid.0 + a * strip.dir.0).round() as i32,
+        (strip.centroid.1 + a * strip.dir.1).round() as i32,
+    )
+}
+
+fn footprint_around(x: i32, z: i32, plane_len_blocks: f64) -> Bbox {
+    let r = (plane_len_blocks * 0.5).ceil() as i32 + 4;
+    Bbox {
+        min_x: x - r,
+        min_z: z - r,
+        max_x: x + r,
+        max_z: z + r,
+    }
+}
+
+/// Min ground Y across the footprint, sampled on a stride for ~16×16 samples.
+fn lowest_ground_in_bbox(editor: &WorldEditor, bbox: &Bbox) -> i32 {
+    let dx = bbox.max_x - bbox.min_x;
+    let dz = bbox.max_z - bbox.min_z;
+    let stride = (dx.max(dz) / 16).clamp(1, 8);
+    let mut lowest = i32::MAX;
+    let mut x = bbox.min_x;
+    while x <= bbox.max_x {
+        let mut z = bbox.min_z;
+        while z <= bbox.max_z {
+            lowest = lowest.min(editor.get_ground_level(x, z));
+            z += stride;
+        }
+        x += stride;
+    }
+    for (x, z) in [
+        (bbox.min_x, bbox.min_z),
+        (bbox.max_x, bbox.min_z),
+        (bbox.min_x, bbox.max_z),
+        (bbox.max_x, bbox.max_z),
+    ] {
+        lowest = lowest.min(editor.get_ground_level(x, z));
+    }
+    if lowest == i32::MAX {
+        editor.get_ground_level((bbox.min_x + bbox.max_x) / 2, (bbox.min_z + bbox.max_z) / 2)
+    } else {
+        lowest
+    }
+}
+
+struct UnionFind {
+    parent: Vec<usize>,
+}
+
+impl UnionFind {
+    fn new(n: usize) -> Self {
+        Self {
+            parent: (0..n).collect(),
+        }
+    }
+    fn find(&mut self, x: usize) -> usize {
+        let mut root = x;
+        while self.parent[root] != root {
+            root = self.parent[root];
+        }
+        let mut cur = x;
+        while self.parent[cur] != root {
+            let next = self.parent[cur];
+            self.parent[cur] = root;
+            cur = next;
+        }
+        root
+    }
+    fn union(&mut self, a: usize, b: usize) {
+        let (ra, rb) = (self.find(a), self.find(b));
+        if ra != rb {
+            self.parent[ra] = rb;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::osm_parser::{ProcessedNode, ProcessedWay};
+    use std::collections::HashMap as StdMap;
+
+    fn runway_tags() -> StdMap<String, String> {
+        let mut t = StdMap::new();
+        t.insert("aeroway".to_string(), "runway".to_string());
+        t
+    }
+
+    fn mk_node(id: u64, x: i32, z: i32) -> ProcessedNode {
+        ProcessedNode {
+            id,
+            tags: StdMap::new(),
+            x,
+            z,
+        }
+    }
+
+    fn runway_way(id: u64, nodes: Vec<ProcessedNode>) -> ProcessedElement {
+        ProcessedElement::Way(ProcessedWay {
+            id,
+            nodes,
+            tags: runway_tags(),
+        })
+    }
+
+    fn taxiway_way(id: u64, nodes: Vec<ProcessedNode>) -> ProcessedElement {
+        let mut tags = StdMap::new();
+        tags.insert("aeroway".to_string(), "taxiway".to_string());
+        ProcessedElement::Way(ProcessedWay { id, nodes, tags })
+    }
+
+    #[test]
+    fn merges_collinear_split_segments() {
+        // Two halves of one 200-block runway, sharing the middle node id (5).
+        let a = runway_way(1, vec![mk_node(4, 0, 0), mk_node(5, 100, 0)]);
+        let b = runway_way(2, vec![mk_node(5, 100, 0), mk_node(6, 200, 0)]);
+        let runways = collect_aeroways(&[a, b]);
+        assert_eq!(runways.len(), 1, "split runway should merge into one");
+        assert!((runways[0].length_blocks - 200.0).abs() < 1e-6);
+        assert_eq!(runways[0].rep_id, 1);
+    }
+
+    #[test]
+    fn does_not_merge_crossing_segments() {
+        // Horizontal + vertical sharing node id 5: a crossing, not a continuation.
+        let a = runway_way(1, vec![mk_node(4, 0, 0), mk_node(5, 100, 0)]);
+        let b = runway_way(2, vec![mk_node(5, 100, 0), mk_node(6, 100, 100)]);
+        let runways = collect_aeroways(&[a, b]);
+        assert_eq!(runways.len(), 2, "crossing runways must stay separate");
+    }
+
+    #[test]
+    fn geometry_direction_is_long_axis() {
+        // A Z-aligned runway: long axis must come back as ~(0, ±1), not the short X axis.
+        let rw = runway_way(7, vec![mk_node(1, 0, -150), mk_node(2, 0, 150)]);
+        let runways = collect_aeroways(&[rw]);
+        assert_eq!(runways.len(), 1);
+        let g = &runways[0];
+        assert!((g.length_blocks - 300.0).abs() < 1e-6);
+        assert!(
+            g.dir.0.abs() < 1e-6 && g.dir.1.abs() > 0.99,
+            "dir = {:?}",
+            g.dir
+        );
+    }
+
+    #[test]
+    fn yaw_points_nose_along_runway() {
+        // +Z direction needs zero yaw; +X needs -90°.
+        assert!((yaw_for_dir((0.0, 1.0))).abs() < 1e-6);
+        assert!((yaw_for_dir((1.0, 0.0)) - (-90.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn long_runway_always_gets_a_climbing_plane() {
+        // 2000 blocks @ scale 1 = 2000 m >= 1500 m threshold.
+        let rw = runway_way(11, vec![mk_node(1, 0, 0), mk_node(2, 2000, 0)]);
+        let runways = collect_aeroways(&[rw]);
+        let placements = build_placements(&runways, 1.0);
+        assert!(placements
+            .iter()
+            .any(|p| p.kind == PlaneKind::Ascending && p.pitch_degrees > 0.0));
+    }
+
+    #[test]
+    fn short_runway_gets_no_climbing_plane() {
+        // 800 m < 1500 m.
+        let rw = runway_way(13, vec![mk_node(1, 0, 0), mk_node(2, 800, 0)]);
+        let runways = collect_aeroways(&[rw]);
+        let placements = build_placements(&runways, 1.0);
+        assert!(!placements.iter().any(|p| p.kind == PlaneKind::Ascending));
+    }
+
+    #[test]
+    fn tiny_runway_never_parks_a_plane() {
+        // 40 m < PARKED_MIN_LENGTH_M; no parked plane regardless of the RNG roll.
+        let rw = runway_way(17, vec![mk_node(1, 0, 0), mk_node(2, 40, 0)]);
+        let runways = collect_aeroways(&[rw]);
+        let placements = build_placements(&runways, 1.0);
+        assert!(placements.is_empty());
+    }
+
+    #[test]
+    fn parked_placement_is_deterministic_and_on_runway() {
+        // Find an id whose roll succeeds, on a 300 m runway (no ascending consumes RNG first).
+        let id = (1u64..10_000)
+            .find(|&i| element_rng(i).random_bool(RUNWAY_PARK_PROBABILITY))
+            .expect("some id should roll a parked plane");
+        let rw = runway_way(id, vec![mk_node(1, 0, 0), mk_node(2, 300, 0)]);
+        let runways = collect_aeroways(&[rw]);
+        let placements = build_placements(&runways, 1.0);
+        let parked: Vec<_> = placements
+            .iter()
+            .filter(|p| p.kind == PlaneKind::Parked)
+            .collect();
+        assert_eq!(
+            parked.len(),
+            1,
+            "rolled id should produce exactly one parked plane"
+        );
+        let half = (PLANE_LENGTH_M * 0.5) as i32;
+        assert!(
+            parked[0].anchor_x >= half && parked[0].anchor_x <= 300 - half,
+            "parked plane must sit fully on the runway, x = {}",
+            parked[0].anchor_x
+        );
+        assert_eq!(parked[0].pitch_degrees, 0.0);
+        assert_eq!(parked[0].elevation_blocks, 0);
+    }
+
+    #[test]
+    fn area_runways_are_ignored() {
+        let mut tags = runway_tags();
+        tags.insert("area".to_string(), "yes".to_string());
+        let area = ProcessedElement::Way(ProcessedWay {
+            id: 99,
+            nodes: vec![
+                mk_node(1, 0, 0),
+                mk_node(2, 60, 0),
+                mk_node(3, 60, 20),
+                mk_node(4, 0, 20),
+            ],
+            tags,
+        });
+        assert!(collect_aeroways(&[area]).is_empty());
+    }
+
+    #[test]
+    fn taxiway_and_runway_do_not_merge_end_on() {
+        // A taxiway meeting a runway at a shared, collinear end node must stay a separate strip.
+        let runway = runway_way(1, vec![mk_node(4, 0, 0), mk_node(5, 100, 0)]);
+        let taxiway = taxiway_way(2, vec![mk_node(5, 100, 0), mk_node(6, 200, 0)]);
+        let strips = collect_aeroways(&[runway, taxiway]);
+        assert_eq!(strips.len(), 2, "different kinds must not fuse");
+        assert!(strips.iter().any(|s| s.kind == AerowayKind::Runway));
+        assert!(strips.iter().any(|s| s.kind == AerowayKind::Taxiway));
+    }
+
+    #[test]
+    fn taxiway_never_gets_a_climbing_plane() {
+        // A 2 km straight taxiway: parking is allowed, climbing is not.
+        let id = (1u64..10_000)
+            .find(|&i| element_rng(i).random_bool(TAXIWAY_PARK_PROBABILITY))
+            .expect("some id should roll a taxiing plane");
+        let tw = taxiway_way(id, vec![mk_node(1, 0, 0), mk_node(2, 2000, 0)]);
+        let strips = collect_aeroways(&[tw]);
+        let placements = build_placements(&strips, 1.0);
+        assert!(!placements.iter().any(|p| p.kind == PlaneKind::Ascending));
+        assert!(placements.iter().any(|p| p.kind == PlaneKind::Parked));
+    }
+
+    #[test]
+    fn curved_taxiway_is_rejected_for_parking() {
+        // A single L-shaped taxiway way is long enough but far too bent; its perpendicular
+        // spread blows past the taxiway straightness cap, so no plane is parked on it.
+        let bent = taxiway_way(
+            1,
+            vec![
+                mk_node(10, 0, 0),
+                mk_node(11, 200, 0),
+                mk_node(12, 200, 200),
+            ],
+        );
+        let strips = collect_aeroways(&[bent]);
+        assert_eq!(strips.len(), 1);
+        let perp_ratio = strips[0].perp_blocks / strips[0].length_blocks;
+        assert!(
+            perp_ratio > TAXIWAY_MAX_PERP_RATIO,
+            "L-bend perp_ratio {perp_ratio:.3} should exceed the cap"
+        );
+        assert!(
+            build_placements(&strips, 1.0).is_empty(),
+            "a bent taxiway should not park a plane"
+        );
+    }
+}

--- a/src/models_3d/custom/plane.rs
+++ b/src/models_3d/custom/plane.rs
@@ -158,7 +158,9 @@ pub fn place_plane_models(editor: &mut WorldEditor, args: &Args, prescan: &Presc
     let mut total_voxels = 0usize;
 
     for p in &prescan.placements {
-        let ground_y = lowest_ground_in_bbox(editor, &p.footprint);
+        let fp = &p.footprint;
+        let ground_y =
+            crate::models_3d::lowest_ground_in_bbox(editor, fp.min_x, fp.min_z, fp.max_x, fp.max_z);
 
         let transform = WorldTransform::new(
             0.0,
@@ -472,36 +474,6 @@ fn footprint_around(x: i32, z: i32, plane_len_blocks: f64) -> Bbox {
         min_z: z - r,
         max_x: x + r,
         max_z: z + r,
-    }
-}
-
-/// Min ground Y across the footprint, sampled on a stride for ~16×16 samples.
-fn lowest_ground_in_bbox(editor: &WorldEditor, bbox: &Bbox) -> i32 {
-    let dx = bbox.max_x - bbox.min_x;
-    let dz = bbox.max_z - bbox.min_z;
-    let stride = (dx.max(dz) / 16).clamp(1, 8);
-    let mut lowest = i32::MAX;
-    let mut x = bbox.min_x;
-    while x <= bbox.max_x {
-        let mut z = bbox.min_z;
-        while z <= bbox.max_z {
-            lowest = lowest.min(editor.get_ground_level(x, z));
-            z += stride;
-        }
-        x += stride;
-    }
-    for (x, z) in [
-        (bbox.min_x, bbox.min_z),
-        (bbox.max_x, bbox.min_z),
-        (bbox.min_x, bbox.max_z),
-        (bbox.max_x, bbox.max_z),
-    ] {
-        lowest = lowest.min(editor.get_ground_level(x, z));
-    }
-    if lowest == i32::MAX {
-        editor.get_ground_level((bbox.min_x + bbox.max_x) / 2, (bbox.min_z + bbox.max_z) / 2)
-    } else {
-        lowest
     }
 }
 

--- a/src/models_3d/custom/stadium.rs
+++ b/src/models_3d/custom/stadium.rs
@@ -330,7 +330,9 @@ pub fn place_stadium_models(editor: &mut WorldEditor, args: &Args, prescan: &Pre
             (-center_z, center_x)
         };
 
-        let ground_y = lowest_ground_in_bbox(editor, &placement.footprint);
+        let fp = &placement.footprint;
+        let ground_y =
+            crate::models_3d::lowest_ground_in_bbox(editor, fp.min_x, fp.min_z, fp.max_x, fp.max_z);
 
         let transform = WorldTransform::with_world_scale_xyz(
             intrinsic_yaw_deg,
@@ -498,35 +500,6 @@ fn principal_axis(points: &[(i32, i32)]) -> Option<(f64, f64, f64)> {
         Some((ext_a, ext_p, theta))
     } else {
         Some((ext_p, ext_a, theta + std::f64::consts::FRAC_PI_2))
-    }
-}
-
-fn lowest_ground_in_bbox(editor: &WorldEditor, bbox: &Bbox) -> i32 {
-    let dx = bbox.max_x - bbox.min_x;
-    let dz = bbox.max_z - bbox.min_z;
-    let stride = (dx.max(dz) / 16).clamp(1, 8);
-    let mut lowest = i32::MAX;
-    let mut x = bbox.min_x;
-    while x <= bbox.max_x {
-        let mut z = bbox.min_z;
-        while z <= bbox.max_z {
-            lowest = lowest.min(editor.get_ground_level(x, z));
-            z += stride;
-        }
-        x += stride;
-    }
-    for (x, z) in [
-        (bbox.min_x, bbox.min_z),
-        (bbox.max_x, bbox.min_z),
-        (bbox.min_x, bbox.max_z),
-        (bbox.max_x, bbox.max_z),
-    ] {
-        lowest = lowest.min(editor.get_ground_level(x, z));
-    }
-    if lowest == i32::MAX {
-        editor.get_ground_level((bbox.min_x + bbox.max_x) / 2, (bbox.min_z + bbox.max_z) / 2)
-    } else {
-        lowest
     }
 }
 

--- a/src/models_3d/mod.rs
+++ b/src/models_3d/mod.rs
@@ -10,6 +10,42 @@ pub(crate) mod wikidata;
 pub use pipeline::Models3dPipeline;
 
 use crate::elevation::cache::{clear_cache_dir, CacheClearStats};
+use crate::world_editor::WorldEditor;
+
+/// Minimum ground Y across an XZ bbox: stride-sampled for ~16×16 samples plus explicit corners.
+/// Shared by every model placer so they all snap to identical terrain.
+pub(crate) fn lowest_ground_in_bbox(
+    editor: &WorldEditor,
+    min_x: i32,
+    min_z: i32,
+    max_x: i32,
+    max_z: i32,
+) -> i32 {
+    let stride = ((max_x - min_x).max(max_z - min_z) / 16).clamp(1, 8);
+    let mut lowest = i32::MAX;
+    let mut x = min_x;
+    while x <= max_x {
+        let mut z = min_z;
+        while z <= max_z {
+            lowest = lowest.min(editor.get_ground_level(x, z));
+            z += stride;
+        }
+        x += stride;
+    }
+    for (x, z) in [
+        (min_x, min_z),
+        (max_x, min_z),
+        (min_x, max_z),
+        (max_x, max_z),
+    ] {
+        lowest = lowest.min(editor.get_ground_level(x, z));
+    }
+    if lowest == i32::MAX {
+        editor.get_ground_level((min_x + max_x) / 2, (min_z + max_z) / 2)
+    } else {
+        lowest
+    }
+}
 
 /// Clears on-disk caches for every 3D-model fetcher.
 pub fn clear_model_caches() -> CacheClearStats {

--- a/src/models_3d/pipeline.rs
+++ b/src/models_3d/pipeline.rs
@@ -10,6 +10,7 @@ pub struct Models3dPipeline {
     three_dmr: three_dmr::PrescanResult,
     wikidata: wikidata::PrescanResult,
     stadium: custom::stadium::PrescanResult,
+    plane: custom::plane::PrescanResult,
     union_suppressed: HashSet<(&'static str, u64)>,
 }
 
@@ -30,10 +31,14 @@ impl Models3dPipeline {
         let stadium = custom::stadium::prescan(elements, &combined, args.scale);
         combined.extend(stadium.suppressed_ids.iter().copied());
 
+        // Planes are decorative props placed on runways; they suppress nothing.
+        let plane = custom::plane::prescan(elements, args.scale);
+
         Self {
             three_dmr,
             wikidata,
             stadium,
+            plane,
             union_suppressed: combined,
         }
     }
@@ -51,6 +56,9 @@ impl Models3dPipeline {
         }
         if self.stadium.placement_count() > 0 {
             custom::stadium::place_stadium_models(editor, args, &self.stadium);
+        }
+        if self.plane.placement_count() > 0 {
+            custom::plane::place_plane_models(editor, args, &self.plane);
         }
     }
 }

--- a/src/models_3d/three_dmr/placement.rs
+++ b/src/models_3d/three_dmr/placement.rs
@@ -176,7 +176,9 @@ pub fn place_three_dmr_models(editor: &mut WorldEditor, args: &Args, prescan: &P
             continue;
         };
 
-        let ground_y = lowest_ground_in_bbox(editor, &placement.footprint);
+        let fp = &placement.footprint;
+        let ground_y =
+            crate::models_3d::lowest_ground_in_bbox(editor, fp.min_x, fp.min_z, fp.max_x, fp.max_z);
 
         let transform = WorldTransform::new(
             info.rotation,
@@ -264,37 +266,6 @@ fn centroid<I: Iterator<Item = (i32, i32)>>(coords: I) -> Option<(i32, i32)> {
         None
     } else {
         Some(((sx / count) as i32, (sz / count) as i32))
-    }
-}
-
-/// Min ground Y across the bbox, sampled on a stride for ~16×16 samples.
-fn lowest_ground_in_bbox(editor: &WorldEditor, bbox: &Bbox) -> i32 {
-    let dx = bbox.max_x - bbox.min_x;
-    let dz = bbox.max_z - bbox.min_z;
-    let stride = (dx.max(dz) / 16).clamp(1, 8);
-    let mut lowest = i32::MAX;
-    let mut x = bbox.min_x;
-    while x <= bbox.max_x {
-        let mut z = bbox.min_z;
-        while z <= bbox.max_z {
-            lowest = lowest.min(editor.get_ground_level(x, z));
-            z += stride;
-        }
-        x += stride;
-    }
-    // Sample corners explicitly so we never miss an extreme edge.
-    for (x, z) in [
-        (bbox.min_x, bbox.min_z),
-        (bbox.max_x, bbox.min_z),
-        (bbox.min_x, bbox.max_z),
-        (bbox.max_x, bbox.max_z),
-    ] {
-        lowest = lowest.min(editor.get_ground_level(x, z));
-    }
-    if lowest == i32::MAX {
-        editor.get_ground_level((bbox.min_x + bbox.max_x) / 2, (bbox.min_z + bbox.max_z) / 2)
-    } else {
-        lowest
     }
 }
 

--- a/src/models_3d/voxelize.rs
+++ b/src/models_3d/voxelize.rs
@@ -24,6 +24,9 @@ pub struct WorldTransform {
     intrinsic_tx: f32,
     intrinsic_ty: f32,
     intrinsic_tz: f32,
+    /// Model-space pitch about X (identity when sin=0), applied before scale/yaw.
+    pitch_cos: f32,
+    pitch_sin: f32,
     world_scale: [f32; 3],
     world_rot_cos: f32,
     world_rot_sin: f32,
@@ -77,6 +80,8 @@ impl WorldTransform {
             intrinsic_tx: intrinsic_translation[0] as f32,
             intrinsic_ty: intrinsic_translation[1] as f32,
             intrinsic_tz: intrinsic_translation[2] as f32,
+            pitch_cos: 1.0,
+            pitch_sin: 0.0,
             world_scale,
             world_rot_cos: wt.cos(),
             world_rot_sin: wt.sin(),
@@ -86,11 +91,23 @@ impl WorldTransform {
         }
     }
 
+    /// Tilts the model nose-up by `pitch_degrees` about X, so a +Z forward axis climbs into +Y.
+    pub fn pitched(mut self, pitch_degrees: f64) -> Self {
+        let p = (pitch_degrees as f32).to_radians();
+        self.pitch_cos = p.cos();
+        self.pitch_sin = p.sin();
+        self
+    }
+
     #[inline]
     fn apply(&self, p: [f32; 3]) -> [f32; 3] {
-        let sx = p[0] * self.intrinsic_scale;
-        let sy = p[1] * self.intrinsic_scale;
-        let sz = p[2] * self.intrinsic_scale;
+        // Model-space pitch about X: +Z forward tilts up into +Y. Identity when pitch_sin == 0.
+        let px = p[0];
+        let py = p[1] * self.pitch_cos + p[2] * self.pitch_sin;
+        let pz = -p[1] * self.pitch_sin + p[2] * self.pitch_cos;
+        let sx = px * self.intrinsic_scale;
+        let sy = py * self.intrinsic_scale;
+        let sz = pz * self.intrinsic_scale;
         let r1x = sx * self.intrinsic_rot_cos - sz * self.intrinsic_rot_sin + self.intrinsic_tx;
         let r1y = sy + self.intrinsic_ty;
         let r1z = sx * self.intrinsic_rot_sin + sz * self.intrinsic_rot_cos + self.intrinsic_tz;
@@ -438,6 +455,39 @@ mod tests {
         );
         let out = t.apply([1.0, 1.0, 1.0]);
         assert_eq!(out, [3.0, 5.0, 7.0]);
+    }
+
+    #[test]
+    fn pitch_identity_when_unset() {
+        // Default transform must behave exactly as before (no tilt).
+        let t = make_identity();
+        let out = t.apply([0.0, 0.0, 1.0]);
+        assert!((out[0]).abs() < 1e-5 && (out[1]).abs() < 1e-5 && (out[2] - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn pitch_90_lifts_forward_axis_up() {
+        // A +Z nose vertex pitched 90° nose-up lands on +Y.
+        let t = make_identity().pitched(90.0);
+        let out = t.apply([0.0, 0.0, 1.0]);
+        assert!(out[0].abs() < 1e-5, "got {out:?}");
+        assert!((out[1] - 1.0).abs() < 1e-5, "got {out:?}");
+        assert!(out[2].abs() < 1e-5, "got {out:?}");
+    }
+
+    #[test]
+    fn pitch_positive_raises_nose_partially() {
+        // A modest nose-up pitch gives the +Z nose a positive Y and shorter Z.
+        let t = make_identity().pitched(30.0);
+        let out = t.apply([0.0, 0.0, 1.0]);
+        assert!(out[1] > 0.0, "nose should rise, got {out:?}");
+        assert!(
+            out[2] > 0.0 && out[2] < 1.0,
+            "nose Z should shorten, got {out:?}"
+        );
+        // Tail (-Z) drops below the pitch axis.
+        let tail = t.apply([0.0, 0.0, -1.0]);
+        assert!(tail[1] < 0.0, "tail should drop, got {tail:?}");
     }
 
     #[test]

--- a/src/models_3d/wikidata/placement.rs
+++ b/src/models_3d/wikidata/placement.rs
@@ -249,7 +249,9 @@ pub fn place_wikidata_models(editor: &mut WorldEditor, args: &Args, prescan: &Pr
             continue;
         };
 
-        let ground_y = lowest_ground_in_bbox(editor, &placement.footprint);
+        let fp = &placement.footprint;
+        let ground_y =
+            crate::models_3d::lowest_ground_in_bbox(editor, fp.min_x, fp.min_z, fp.max_x, fp.max_z);
 
         let mut voxels = if is_glb(bytes) {
             match voxelize_glb_for_placement(bytes, placement, args, ground_y) {
@@ -938,35 +940,6 @@ fn osm_bbox(element: &ProcessedElement) -> Option<Bbox> {
         max_x,
         max_z,
     })
-}
-
-fn lowest_ground_in_bbox(editor: &WorldEditor, bbox: &Bbox) -> i32 {
-    let dx = bbox.max_x - bbox.min_x;
-    let dz = bbox.max_z - bbox.min_z;
-    let stride = (dx.max(dz) / 16).clamp(1, 8);
-    let mut lowest = i32::MAX;
-    let mut x = bbox.min_x;
-    while x <= bbox.max_x {
-        let mut z = bbox.min_z;
-        while z <= bbox.max_z {
-            lowest = lowest.min(editor.get_ground_level(x, z));
-            z += stride;
-        }
-        x += stride;
-    }
-    for (x, z) in [
-        (bbox.min_x, bbox.min_z),
-        (bbox.max_x, bbox.min_z),
-        (bbox.min_x, bbox.max_z),
-        (bbox.max_x, bbox.max_z),
-    ] {
-        lowest = lowest.min(editor.get_ground_level(x, z));
-    }
-    if lowest == i32::MAX {
-        editor.get_ground_level((bbox.min_x + bbox.max_x) / 2, (bbox.min_z + bbox.max_z) / 2)
-    } else {
-        lowest
-    }
 }
 
 fn parse_direction(raw: &str) -> Option<f64> {


### PR DESCRIPTION
Adds decorative aeroplanes at airports and gives runways/taxiways a proper marked surface. Requires `--use_3d` (on by default).

## Planes (`models_3d/custom/plane.rs`)
- **Parked plane** on a runway centerline (deterministic ~40% per runway) and on long, straight taxiways (~15%), sitting fully between the ends.
- **Climbing plane** pitched nose-up and elevated off the far end of every runway ≥1500 m — runways only (you don't take off from a taxiway).
- Scaled to a fixed ~90 m airliner (uniform scale preserves proportions); yaw derived from the runway/taxiway geometry (rotation already baked into node coords).
- OSM splits one physical runway into several ways with no relation linking them, so same-kind segments are **merged** by shared end nodes + near-collinear bearing before length/direction are computed. Aprons/gates are polygons (out of scope), so straight taxiway runs are the next-best parking proxy.

### Supporting change
- `WorldTransform` gains an optional model-space **pitch** about X (identity by default → stadium/3DMR unaffected), which is what lets the climbing plane tilt nose-up.

## Runway/taxiway rendering (`element_processing/highways.rs`)
- Honours the OSM `width=*` tag (clamped to sane sizes, default when absent) — previously every aeroway was a fixed-width strip.
- **Runways**: asphalt-gray surface, dashed white centerline, solid white edge stripes.
- **Taxiways**: lighter surface with a yellow centerline.
- Runways overwrite taxiway surface, so a runway **wins at crossings regardless of element processing order**.
- No threshold "piano keys": a per-way renderer can't distinguish a real runway end from an OSM split, so they'd be scattered.

## Tests
- 12 unit tests for segment merging (incl. split-vs-crossing, runway/taxiway don't fuse), geometry/yaw, placement gating, taxiway straightness, and deterministic parking.
- 3 `WorldTransform` pitch tests.
- 6 aeroway tests, including **in-memory rendering regressions** that assert markings actually land (white over gray, yellow over light-gray), width widens the strip, and a runway overrides a crossing taxiway processed first.

`cargo fmt`, `cargo clippy --all-targets` (clean), and the full suite (179 passing) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)