### PR TITLE
ci: add duplicate issue finder (comment-only)

### DIFF
--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -1,0 +1,40 @@
+# Comments on newly opened issues with links to likely duplicates. Does not close or label them.
+name: Duplicate issue finder
+
+on:
+  issues:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Existing issue number to check for duplicates"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  dedupe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
+          claude_args: "--model sonnet"
+          prompt: |
+            A new GitHub issue was opened in ${{ github.repository }}: issue number ${{ github.event.issue.number || inputs.issue_number }}.
+            Find up to 3 existing issues that are genuine duplicates and, only if you find any, post one comment linking them.
+
+            Steps:
+            1. View it: `gh issue view ${{ github.event.issue.number || inputs.issue_number }} --repo ${{ github.repository }}`. If it is not a specific bug report or feature request (vague/positive feedback, a usage question, or spam), or it already has a comment from you listing duplicates, stop and do nothing.
+            2. Run several `gh search issues --repo ${{ github.repository }} "<keywords>"` queries with different keywords and phrasings from the issue. Include open and closed issues.
+            3. Keep only issues describing the same underlying bug or request; discard loose keyword-only matches and exclude the issue itself.
+            4. If at least one genuine duplicate remains, post exactly one comment with `gh issue comment ${{ github.event.issue.number || inputs.issue_number }} --repo ${{ github.repository }} --body "<body>"`, where <body> is "Found N possible duplicate issue(s):" followed by a numbered markdown list of the full issue URLs (max 3). If none remain, do nothing.
+
+            Use only the `gh` CLI. Do not edit files, and do not label, close, or react to issues.

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -1,4 +1,5 @@
 # Comments on newly opened issues with links to likely duplicates. Does not close or label them.
+# Auth: repo secret CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token` (uses a Pro/Max subscription).
 name: Duplicate issue finder
 
 on:
@@ -23,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: "*"
           claude_args: "--model sonnet"

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -1,5 +1,4 @@
 # Comments on newly opened issues with links to likely duplicates. Does not close or label them.
-# Auth: repo secret CLAUDE_CODE_OAUTH_TOKEN from `claude setup-token` (uses a Pro/Max subscription).
 name: Duplicate issue finder
 
 on:


### PR DESCRIPTION
Adds a GitHub Action that, when a new issue is opened, uses `anthropics/claude-code-action` to search existing issues and **comment with up to 3 likely duplicates** (with links). Modeled on the claude-code repo's dedupe workflow, trimmed to the minimum.

**Comment-only by design** — it does not label, close, or react to issues.

### Setup required (one-time, by the maintainer)
- Run `claude setup-token` locally (Claude Code v1.0.44+, signed in with a Pro/Max account) to mint a `CLAUDE_CODE_OAUTH_TOKEN`.
- Add it as a repo secret named **`CLAUDE_CODE_OAUTH_TOKEN`** (Settings → Secrets and variables → Actions).
- `GITHUB_TOKEN` is auto-provided; the workflow declares its own `issues: write`.

### Cost / auth
- Runs on a **Pro/Max subscription** via the OAuth token — no pay-as-you-go API credits. Consumes your subscription's usage limits (negligible at arnis's issue volume). The token is valid ~1 year; regenerate before expiry. (To bill the API instead, swap the input for `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`.)

### Testing (after merge + secret)
- Manual: **Actions → Duplicate issue finder → Run workflow**, enter an existing issue number. Good candidates sit in duplicate clusters, e.g. #1051 (rivers → should find #1066, #1049) or #1058 (buildings → #1043, #1011).
- Live: open a new test issue duplicating an existing one; the bot comments on open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)