### PR TITLE
ci: harden + fix duplicate issue finder (sandbox tools)

### DIFF
--- a/.github/scripts/comment-on-duplicates.sh
+++ b/.github/scripts/comment-on-duplicates.sh
@@ -8,14 +8,26 @@ base="$(jq -r '.issue.number // .inputs.issue_number // empty' "${GITHUB_EVENT_P
 [[ "$base" =~ ^[0-9]+$ ]] || { echo "no triggering issue number in event payload" >&2; exit 1; }
 
 (($# >= 1 && $# <= 3)) || { echo "pass 1-3 duplicate issue numbers" >&2; exit 1; }
+
+# Validate, then drop the triggering issue itself and any repeats — never rely on the prompt for this.
+dups=()
 for d in "$@"; do
   [[ "$d" =~ ^[0-9]+$ ]] || { echo "not an issue number: $d" >&2; exit 1; }
+  [[ "$d" == "$base" ]] && continue
+  [[ " ${dups[*]-} " == *" $d "* ]] && continue
+  dups+=("$d")
 done
 
-if (($# == 1)); then header="Found 1 possible duplicate issue:"; else header="Found $# possible duplicate issues:"; fi
+if ((${#dups[@]} == 0)); then
+  echo "no duplicates to post after excluding the issue itself; doing nothing"
+  exit 0
+fi
+
+count=${#dups[@]}
+if ((count == 1)); then header="Found 1 possible duplicate issue:"; else header="Found $count possible duplicate issues:"; fi
 body="$header"$'\n\n'
 i=1
-for d in "$@"; do
+for d in "${dups[@]}"; do
   body+="${i}. https://github.com/${repo}/issues/${d}"$'\n'
   ((i++))
 done

--- a/.github/scripts/comment-on-duplicates.sh
+++ b/.github/scripts/comment-on-duplicates.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Posts a fixed "possible duplicates" comment on the triggering issue. Args: 1-3 issue numbers.
+# The base issue is read from the event payload, so a hijacked prompt can't retarget it.
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
+base="$(jq -r '.issue.number // .inputs.issue_number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")"
+[[ "$base" =~ ^[0-9]+$ ]] || { echo "no triggering issue number in event payload" >&2; exit 1; }
+
+(($# >= 1 && $# <= 3)) || { echo "pass 1-3 duplicate issue numbers" >&2; exit 1; }
+for d in "$@"; do
+  [[ "$d" =~ ^[0-9]+$ ]] || { echo "not an issue number: $d" >&2; exit 1; }
+done
+
+if (($# == 1)); then header="Found 1 possible duplicate issue:"; else header="Found $# possible duplicate issues:"; fi
+body="$header"$'\n\n'
+i=1
+for d in "$@"; do
+  body+="${i}. https://github.com/${repo}/issues/${d}"$'\n'
+  ((i++))
+done
+
+gh issue comment "$base" --repo "$repo" --body "$body"

--- a/.github/scripts/dedupe-gh.sh
+++ b/.github/scripts/dedupe-gh.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Read-only gh wrapper for the duplicate finder: only issue lookups and searches are allowed.
+set -euo pipefail
+case "${1:-} ${2:-}" in
+  "issue view" | "issue list" | "search issues")
+    exec gh "$@"
+    ;;
+  *)
+    echo "dedupe-gh.sh: only 'issue view', 'issue list', 'search issues' allowed (got: $*)" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -22,19 +22,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: "*"
-          claude_args: "--model sonnet"
+          # Tools locked to the two wrapper scripts (read-only search/view + fixed-format poster) so a hijacked prompt can't run arbitrary commands or post arbitrary text.
+          claude_args: "--model sonnet --allowedTools Bash(./.github/scripts/dedupe-gh.sh:*),Bash(./.github/scripts/comment-on-duplicates.sh:*)"
           prompt: |
             A new GitHub issue was opened in ${{ github.repository }}: issue number ${{ github.event.issue.number || inputs.issue_number }}.
-            Find up to 3 existing issues that are genuine duplicates and, only if you find any, post one comment linking them.
+            Find up to 3 existing issues that are genuine duplicates and, only if you find any, comment with links.
+
+            Use ONLY these two scripts (no raw gh, no other tools, no file edits):
+            - `./.github/scripts/dedupe-gh.sh issue view <number>` — view an issue (append --comments to see comments)
+            - `./.github/scripts/dedupe-gh.sh search issues "<query>" --repo ${{ github.repository }}` — search issues
+            - `./.github/scripts/comment-on-duplicates.sh <dup1> [dup2] [dup3]` — post the duplicates comment on this issue
 
             Steps:
-            1. View it: `gh issue view ${{ github.event.issue.number || inputs.issue_number }} --repo ${{ github.repository }}`. If it is not a specific bug report or feature request (vague/positive feedback, a usage question, or spam), or it already has a comment from you listing duplicates, stop and do nothing.
-            2. Run several `gh search issues --repo ${{ github.repository }} "<keywords>"` queries with different keywords and phrasings from the issue. Include open and closed issues.
-            3. Keep only issues describing the same underlying bug or request; discard loose keyword-only matches and exclude the issue itself.
-            4. If at least one genuine duplicate remains, post exactly one comment with `gh issue comment ${{ github.event.issue.number || inputs.issue_number }} --repo ${{ github.repository }} --body "<body>"`, where <body> is "Found N possible duplicate issue(s):" followed by a numbered markdown list of the full issue URLs (max 3). If none remain, do nothing.
-
-            Use only the `gh` CLI. Do not edit files, and do not label, close, or react to issues.
+            1. View issue ${{ github.event.issue.number || inputs.issue_number }}. If it is not a specific bug report or feature request (vague/positive feedback, a question, or spam), or it already has a duplicates comment, stop and do nothing.
+            2. Run several search queries with different keywords/phrasings from the issue (include open and closed issues).
+            3. Keep only issues describing the same underlying bug or request; exclude the issue itself and discard loose keyword matches. If none remain, stop and do nothing.
+            4. Otherwise, run the comment script with up to 3 duplicate issue numbers.


### PR DESCRIPTION
Follow-up to the duplicate finder. Two problems in one fix:

**Bug:** the first run (#1076) posted nothing — the log shows `permission_denials_count: 21`. `claude-code-action` doesn't auto-allow `gh`/Bash in CI without an allowlist, so every search and comment call was denied.

**Hardening:** with `allowed_non_write_users: '*'`, untrusted issue text reaches the model. Rather than hand it raw `gh`, tools are now locked to two wrapper scripts via `--allowedTools`:
- `.github/scripts/dedupe-gh.sh` — read-only `gh` (only `issue view`/`issue list`/`search issues`).
- `.github/scripts/comment-on-duplicates.sh` — posts the fixed "Found N possible duplicate issue(s)" comment; the **target issue is read from the event payload**, so a hijacked prompt can't retarget it, post arbitrary text, close/label issues, or exfiltrate the token.

Also passes `GH_TOKEN` so the scripts' `gh` calls are authenticated.

Net: this both **unblocks** the bot (the scripts are now the only — and allowed — tools) and **sandboxes** it.

### Testing (after merge)
Actions → "Duplicate issue finder" → Run workflow on an existing issue in a known cluster:
- #1051 (rivers) → expect #1066, #1049
- #1058 (buildings) → expect #1043, #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)