### PR TITLE
ci: build a self-contained Linux AppImage in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
             target: x86_64-pc-windows-msvc
             binary_name: arnis.exe
             asset_name: arnis-windows.exe
-          - os: ubuntu-latest
+          - os: ubuntu-22.04  # Oldest supported base for AppImage glibc/WebKitGTK compatibility
             target: x86_64-unknown-linux-gnu
             binary_name: arnis
             asset_name: arnis-linux
@@ -40,7 +40,18 @@ jobs:
     - name: Install dependencies
       run: cargo fetch
 
+    - name: Install Tauri CLI
+      if: runner.os == 'Linux'
+      run: cargo install tauri-cli --version "^2.0" --locked
+
+    - name: Build with AppImage bundle (Linux)
+      if: runner.os == 'Linux'
+      env:
+        APPIMAGE_EXTRACT_AND_RUN: 1  # Avoids FUSE requirement on CI runners
+      run: cargo tauri build --target ${{ matrix.target }} --bundles appimage
+
     - name: Build
+      if: runner.os != 'Linux'
       run: cargo build --release --target ${{ matrix.target }}
 
     - name: Rename binary for release
@@ -53,6 +64,13 @@ jobs:
     - name: Package binary as tar.gz (preserves executable permission)
       if: matrix.os != 'windows-latest'
       run: tar -czf target/release/${{ matrix.asset_name }}.tar.gz -C target/release ${{ matrix.asset_name }}
+
+    - name: Package AppImage as tar.gz (Linux, preserves executable permission)
+      if: runner.os == 'Linux'
+      run: |
+        mv target/${{ matrix.target }}/release/bundle/appimage/*.AppImage target/release/arnis-linux.AppImage
+        chmod +x target/release/arnis-linux.AppImage
+        tar -czf target/release/arnis-linux-appimage.tar.gz -C target/release arnis-linux.AppImage
 
     - name: Install Windows SDK
       if: matrix.os == 'windows-latest'
@@ -87,6 +105,13 @@ jobs:
       with:
         name: ${{ matrix.os }}-${{ matrix.target }}-build
         path: target/release/${{ matrix.asset_name }}${{ matrix.os != 'windows-latest' && '.tar.gz' || '' }}
+
+    - name: Upload AppImage artifact
+      if: runner.os == 'Linux'
+      uses: actions/upload-artifact@v7
+      with:
+        name: linux-appimage-build
+        path: target/release/arnis-linux-appimage.tar.gz
 
   create-universal-macos:
     needs: build
@@ -137,7 +162,13 @@ jobs:
     - name: Download Linux build artifact
       uses: actions/download-artifact@v8
       with:
-        name: ubuntu-latest-x86_64-unknown-linux-gnu-build
+        name: ubuntu-22.04-x86_64-unknown-linux-gnu-build
+        path: ./builds/linux
+
+    - name: Download Linux AppImage artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: linux-appimage-build
         path: ./builds/linux
 
     - name: Download macOS universal build artifact
@@ -152,6 +183,7 @@ jobs:
         files: |
           builds/windows/arnis-windows.exe
           builds/linux/arnis-linux.tar.gz
+          builds/linux/arnis-linux-appimage.tar.gz
           builds/macos/arnis-mac-universal.tar.gz
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -33,6 +33,7 @@
       "assets/icons/32x32.png",
       "assets/icons/128x128.png",
       "assets/icons/128x128@2x.png",
+      "assets/icons/icon.png",
       "assets/icons/icon.icns",
       "assets/icons/icon.ico"
     ],


### PR DESCRIPTION
Adds an AppImage as a Linux release artifact so the app runs without a system-installed WebKitGTK 4.1, which is unavailable or hard to find on some distros (e.g. Fedora). Closes the gap behind issue #925.

- Build the Linux target with the Tauri bundler (cargo tauri build --bundles appimage) instead of cargo build, reusing the existing bundle config. The same build still yields the bare binary tarball.
- Pin the Linux build to ubuntu-22.04 for a stable glibc/WebKitGTK base.
- Ship the AppImage as arnis-linux-appimage.tar.gz so the executable bit survives download (extract and run, no chmod), matching the bare binary.
- Add icon.png to the bundle icons.