### PR TITLE
feat(gui): self-calibrating ETA, progress overhaul, --benchmark instrumentation

### DIFF
--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -6,7 +6,7 @@ use crate::floodfill_cache::{CoordinateBitmap, FloodFillCache};
 use crate::ground::Ground;
 use crate::ground_generation;
 use crate::osm_parser::{OutlineSuppression, ProcessedElement};
-use crate::progress::{emit_gui_progress_update, emit_show_in_folder};
+use crate::progress::{emit_gui_progress_update, emit_gui_progress_update_ex, emit_show_in_folder};
 #[cfg(feature = "gui")]
 use crate::telemetry::{send_log, LogLevel};
 use crate::tile;
@@ -309,8 +309,8 @@ pub fn generate_world_with_options(
     // Set ground reference in the editor to enable elevation-aware block placement
     editor.set_ground(Arc::clone(&ground));
 
-    println!("{} Processing terrain...", "[5/7]".bold());
-    emit_gui_progress_update(25.0, "Processing terrain...");
+    println!("{} Generating area...", "[5/7]".bold());
+    emit_gui_progress_update(20.0, "Generating area...");
 
     // Pre-compute all flood fills in parallel for better CPU utilization
     let mut flood_fill_cache = FloodFillCache::precompute(&elements, args.timeout.as_ref());
@@ -624,11 +624,11 @@ pub fn generate_world_with_options(
 
                 subway_points.extend(tile_subway_pts);
 
-                // Step 25%->70% per merged tile, throttled to whole-percent steps.
+                // Step 20%->70% per merged tile, throttled to whole-percent steps.
                 tiles_merged += 1;
-                let pct = 25.0 + (tiles_merged as f64 / total_tiles as f64) * 45.0;
+                let pct = 20.0 + (tiles_merged as f64 / total_tiles as f64) * 50.0;
                 if pct - last_emitted_pct >= 1.0 {
-                    emit_gui_progress_update(pct, "Processing area...");
+                    emit_gui_progress_update_ex(pct, "Generating area...", eviction_active);
                     last_emitted_pct = pct;
                 }
             }
@@ -647,7 +647,7 @@ pub fn generate_world_with_options(
             );
         }
 
-        emit_gui_progress_update(70.0, "");
+        emit_gui_progress_update_ex(70.0, "", eviction_active);
     } else {
         // Small area: sequential processing along the original code path.
         let elements_count: usize = elements.len();
@@ -657,8 +657,8 @@ pub fn generate_world_with_options(
             .unwrap()
             .progress_chars("█▓░"));
 
-        let progress_increment_prcs: f64 = 45.0 / elements_count as f64;
-        let mut current_progress_prcs: f64 = 25.0;
+        let progress_increment_prcs: f64 = 50.0 / elements_count as f64;
+        let mut current_progress_prcs: f64 = 20.0;
         let mut last_emitted_progress: f64 = current_progress_prcs;
         let desired_updates: u64 = 500;
         let pb_batch_size: u64 = (elements_count as u64 / desired_updates).max(1);

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -460,7 +460,7 @@ pub fn generate_world_with_options(
         let mut merge_dur = std::time::Duration::ZERO;
         let total_tiles = indexed_tiles.len().max(1);
         let mut tiles_merged = 0usize;
-        let mut last_emitted_pct = 25.0_f64;
+        let mut last_emitted_pct = 20.0_f64;
         for batch in indexed_tiles.chunks(tile_batch_size) {
             // Phase 1: process this batch of tiles in parallel
             let place_start = std::time::Instant::now();

--- a/src/elevation/mod.rs
+++ b/src/elevation/mod.rs
@@ -101,6 +101,7 @@ pub fn compute_grid_dims(bbox: &LLBBox, scale: f64) -> (usize, usize, usize, usi
 /// and coastal tile-boundary artifacts.
 ///
 /// The returned ElevationData contains heights in Minecraft Y coordinates.
+#[allow(clippy::too_many_arguments)]
 pub fn fetch_elevation_data(
     bbox: &LLBBox,
     scale: f64,
@@ -109,7 +110,9 @@ pub fn fetch_elevation_data(
     extended_max_y: i32,
     land_cover: Option<&mut LandCoverData>,
     aws_only: bool,
+    benchmark: bool,
 ) -> Result<ElevationData, Box<dyn std::error::Error>> {
+    let mut bench = crate::bench::Bench::new(benchmark);
     let (world_width, world_height, grid_width, grid_height) = compute_grid_dims(bbox, scale);
 
     // Select the best provider for this region. When `aws_only` is set the
@@ -119,7 +122,7 @@ pub fn fetch_elevation_data(
     let provider_name = provider.name();
     let is_fallback = provider_name == "aws";
 
-    emit_gui_progress_update(16.0, "Fetching elevation...");
+    emit_gui_progress_update(10.0, "Fetching elevation...");
 
     // Fetch raw elevation data in meters, falling back to AWS on regional provider failure
     let raw = match provider.fetch_raw(bbox, grid_width, grid_height) {
@@ -162,20 +165,25 @@ pub fn fetch_elevation_data(
                 ),
             );
             let fallback = providers::aws_terrain::AwsTerrain;
-            emit_gui_progress_update(16.0, "Regional provider failed, fetching from AWS...");
+            emit_gui_progress_update(10.0, "Regional provider failed, fetching from AWS...");
             fallback.fetch_raw(bbox, grid_width, grid_height)?
         }
         Err(e) => return Err(e),
     };
 
-    emit_gui_progress_update(17.0, "Processing elevation...");
+    bench.mark("elev_raw_fetch");
+    emit_gui_progress_update(12.0, "Processing elevation...");
 
     // Shared post-processing pipeline
     let mut height_grid = raw.heights_meters;
     filter_elevation_outliers(&mut height_grid);
+    bench.mark("elev_filter_outliers");
     repair_terrain_anomalies(&mut height_grid);
+    bench.mark("elev_repair_anomalies");
+    emit_gui_progress_update(14.0, "Processing elevation...");
     // Safety net: fill any remaining NaN from tile gaps or partial provider coverage
     fill_nan_values(&mut height_grid);
+    bench.mark("elev_fill_nan");
 
     // Land-cover-aware repair: built-up Gaussian smoothing targets urban
     // LiDAR/DSM classification errors, coastal pull-down flattens the
@@ -218,6 +226,8 @@ pub fn fetch_elevation_data(
             coastal_pull_cells,
         );
     }
+    bench.mark("elev_landcover_repair");
+    emit_gui_progress_update(16.0, "Processing elevation...");
 
     let mc_heights = scale_to_minecraft(
         &height_grid,
@@ -226,6 +236,7 @@ pub fn fetch_elevation_data(
         disable_height_limit,
         extended_max_y,
     );
+    bench.mark("elev_scale_to_mc");
 
     // Log min/max block heights
     let mut min_block_height = f64::MAX;
@@ -247,6 +258,8 @@ pub fn fetch_elevation_data(
         .into_iter()
         .map(|row| row.into_iter().map(|v| v as f32).collect())
         .collect();
+    bench.mark("elev_downcast");
+    emit_gui_progress_update(18.0, "Processing elevation...");
 
     Ok(ElevationData {
         heights: mc_heights_f32,

--- a/src/elevation/mod.rs
+++ b/src/elevation/mod.rs
@@ -219,11 +219,14 @@ pub fn fetch_elevation_data(
     };
 
     if let Some(lc) = land_cover {
+        // The land-cover Gaussian is the slowest elevation step on big areas;
+        // animate the bar across 14->16% as it runs instead of freezing.
         apply_land_cover_repair(
             &mut height_grid,
             lc,
             built_up_sigma_cells,
             coastal_pull_cells,
+            &|f| emit_gui_progress_update(14.0 + f * 2.0, "Processing elevation..."),
         );
     }
     bench.mark("elev_landcover_repair");

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -153,6 +153,7 @@ pub fn apply_land_cover_repair(
     land_cover: &mut LandCoverData,
     built_up_sigma_cells: f64,
     coastal_pull_distance_cells: u32,
+    report: &dyn Fn(f64),
 ) {
     let grid_h = heights.len();
     if grid_h == 0 {
@@ -199,11 +200,13 @@ pub fn apply_land_cover_repair(
     }
 
     // Smooth before pull; otherwise the Gaussian raises pulled cells back up.
+    // The Gaussian dominates this step's cost, so it drives the reported progress.
     smooth_built_up_gaussian(
         heights,
         &land_cover.grid,
         &is_water_surface,
         built_up_sigma_cells,
+        report,
     );
     if coastal_pull_distance_cells > 0 {
         pull_coastal_land_toward_water(heights, &is_water_surface, coastal_pull_distance_cells);
@@ -832,6 +835,7 @@ fn smooth_built_up_gaussian(
     lc_grid: &[Vec<u8>],
     is_water_surface: &[Vec<bool>],
     sigma_cells: f64,
+    report: &dyn Fn(f64),
 ) {
     const MIN_SIGMA: f64 = 1.5;
     if sigma_cells < MIN_SIGMA {
@@ -863,7 +867,8 @@ fn smooth_built_up_gaussian(
 
     // Blur the mask itself -> feathered weights with a smooth 0..1 falloff
     // across the built-up boundary. Without this we'd get a visible seam.
-    let feathered_mask = gaussian_blur_grid(&mask, sigma_cells);
+    // Mask blur is the first half of this step's progress, heights blur the second.
+    let feathered_mask = gaussian_blur_grid_reported(&mask, sigma_cells, &|f| report(0.5 * f));
     drop(mask);
 
     // Build the source for the heights blur with *water-surface* cells set
@@ -884,7 +889,8 @@ fn smooth_built_up_gaussian(
                 .collect()
         })
         .collect();
-    let blurred_heights = gaussian_blur_grid(&heights_for_blur, sigma_cells);
+    let blurred_heights =
+        gaussian_blur_grid_reported(&heights_for_blur, sigma_cells, &|f| report(0.5 + 0.5 * f));
     drop(heights_for_blur);
 
     // Blend through the feathered mask. Water-surface cells are skipped so
@@ -919,6 +925,20 @@ fn smooth_built_up_gaussian(
 /// Edges are handled by renormalizing weights over the valid samples so the
 /// blur doesn't darken the border of the grid.
 pub(crate) fn gaussian_blur_grid(grid: &[Vec<f64>], sigma: f64) -> Vec<Vec<f64>> {
+    gaussian_blur_grid_reported(grid, sigma, &|_| {})
+}
+
+/// Same blur and output as `gaussian_blur_grid`, but calls `report(fraction)`
+/// (0.0..1.0) a handful of times from the calling thread as it works. On a
+/// city-sized grid each pass takes seconds, so this lets a progress bar advance
+/// instead of freezing. Rows/columns are processed in chunks purely so progress
+/// can be reported between them — both axes stay fully independent, so the
+/// result is identical to processing them all at once.
+fn gaussian_blur_grid_reported(
+    grid: &[Vec<f64>],
+    sigma: f64,
+    report: &dyn Fn(f64),
+) -> Vec<Vec<f64>> {
     let kernel_size: usize = (sigma * 3.0).ceil() as usize * 2 + 1;
     let kernel = create_gaussian_kernel(kernel_size, sigma);
     let half = kernel_size as i32 / 2;
@@ -932,72 +952,88 @@ pub(crate) fn gaussian_blur_grid(grid: &[Vec<f64>], sigma: f64) -> Vec<Vec<f64>>
         return vec![Vec::new(); h];
     }
 
+    // ~10 chunks per pass: enough to animate the bar, few enough that the extra
+    // rayon barriers cost nothing measurable.
+    const CHUNKS: usize = 10;
+
     // Horizontal pass — rows are independent.
-    let after_h: Vec<Vec<f64>> = grid
-        .par_iter()
-        .map(|row| {
-            let row_len = row.len() as i32;
-            (0..row.len())
-                .map(|i| {
-                    let mut sum = 0.0;
-                    let mut wsum = 0.0;
-                    for (j, &k) in kernel.iter().enumerate() {
-                        let idx = i as i32 + j as i32 - half;
-                        if idx >= 0 && idx < row_len {
-                            let v = row[idx as usize];
-                            if v.is_finite() {
-                                sum += v * k;
-                                wsum += k;
+    let row_chunk = h.div_ceil(CHUNKS);
+    let mut after_h: Vec<Vec<f64>> = Vec::with_capacity(h);
+    for rows in grid.chunks(row_chunk) {
+        let mut part: Vec<Vec<f64>> = rows
+            .par_iter()
+            .map(|row| {
+                let row_len = row.len() as i32;
+                (0..row.len())
+                    .map(|i| {
+                        let mut sum = 0.0;
+                        let mut wsum = 0.0;
+                        for (j, &k) in kernel.iter().enumerate() {
+                            let idx = i as i32 + j as i32 - half;
+                            if idx >= 0 && idx < row_len {
+                                let v = row[idx as usize];
+                                if v.is_finite() {
+                                    sum += v * k;
+                                    wsum += k;
+                                }
                             }
                         }
-                    }
-                    if wsum > 0.0 {
-                        sum / wsum
-                    } else {
-                        f64::NAN
-                    }
-                })
-                .collect()
-        })
-        .collect();
+                        if wsum > 0.0 {
+                            sum / wsum
+                        } else {
+                            f64::NAN
+                        }
+                    })
+                    .collect()
+            })
+            .collect();
+        after_h.append(&mut part);
+        report(0.5 * (after_h.len() as f64 / h as f64));
+    }
 
     // Vertical pass — columns are independent. Work column-at-a-time to keep
     // memory access sequential within each parallel task.
-    let blurred_columns: Vec<Vec<f64>> = (0..w)
-        .into_par_iter()
-        .map(|x| {
-            let column: Vec<f64> = after_h.iter().map(|row| row[x]).collect();
-            let col_len = column.len() as i32;
-            (0..column.len())
-                .map(|y| {
-                    let mut sum = 0.0;
-                    let mut wsum = 0.0;
-                    for (j, &k) in kernel.iter().enumerate() {
-                        let idx = y as i32 + j as i32 - half;
-                        if idx >= 0 && idx < col_len {
-                            let v = column[idx as usize];
-                            if v.is_finite() {
-                                sum += v * k;
-                                wsum += k;
+    let col_chunk = w.div_ceil(CHUNKS);
+    let mut out: Vec<Vec<f64>> = vec![vec![0.0; w]; h];
+    let mut x0 = 0usize;
+    while x0 < w {
+        let x1 = (x0 + col_chunk).min(w);
+        let blurred: Vec<(usize, Vec<f64>)> = (x0..x1)
+            .into_par_iter()
+            .map(|x| {
+                let column: Vec<f64> = after_h.iter().map(|row| row[x]).collect();
+                let col_len = column.len() as i32;
+                let col: Vec<f64> = (0..column.len())
+                    .map(|y| {
+                        let mut sum = 0.0;
+                        let mut wsum = 0.0;
+                        for (j, &k) in kernel.iter().enumerate() {
+                            let idx = y as i32 + j as i32 - half;
+                            if idx >= 0 && idx < col_len {
+                                let v = column[idx as usize];
+                                if v.is_finite() {
+                                    sum += v * k;
+                                    wsum += k;
+                                }
                             }
                         }
-                    }
-                    if wsum > 0.0 {
-                        sum / wsum
-                    } else {
-                        f64::NAN
-                    }
-                })
-                .collect()
-        })
-        .collect();
-
-    // Transpose columns back to row-major.
-    let mut out: Vec<Vec<f64>> = vec![vec![0.0; w]; h];
-    for (x, col) in blurred_columns.into_iter().enumerate() {
-        for (y, v) in col.into_iter().enumerate() {
-            out[y][x] = v;
+                        if wsum > 0.0 {
+                            sum / wsum
+                        } else {
+                            f64::NAN
+                        }
+                    })
+                    .collect();
+                (x, col)
+            })
+            .collect();
+        for (x, col) in blurred {
+            for (y, v) in col.into_iter().enumerate() {
+                out[y][x] = v;
+            }
         }
+        x0 = x1;
+        report(0.5 + 0.5 * (x0 as f64 / w as f64));
     }
     out
 }

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -7,7 +7,6 @@ use crate::elevation::compute_grid_dims;
 use crate::elevation_data::{fetch_elevation_data, ElevationData};
 use crate::land_cover::{self, LandCoverData};
 use crate::osm_parser::ProcessedElement;
-use crate::progress::emit_gui_progress_update;
 #[cfg(feature = "gui")]
 use crate::telemetry::{send_log, LogLevel};
 use colored::Colorize;
@@ -52,6 +51,7 @@ impl Ground {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_enabled(
         bbox: &LLBBox,
         scale: f64,
@@ -60,7 +60,9 @@ impl Ground {
         disable_height_limit: bool,
         extended_max_y: i32,
         aws_only_elevation: bool,
+        benchmark: bool,
     ) -> Self {
+        let mut bench = crate::bench::Bench::new(benchmark);
         // Fetch land cover FIRST so we can feed it into the elevation
         // post-processing pipeline for land-cover-aware artifact repair.
         // The elevation grid is built from the same (bbox, scale) so both
@@ -77,6 +79,7 @@ impl Ground {
         } else {
             None
         };
+        bench.mark("elev_landcover_fetch");
 
         // Raise the floor for the deepest water carve (elevation path only).
         let water_floor = match &land_cover {
@@ -96,6 +99,7 @@ impl Ground {
             extended_max_y,
             land_cover.as_mut(),
             aws_only_elevation,
+            benchmark,
         ) {
             Ok(elevation_data) => Self {
                 elevation_enabled: true,
@@ -581,7 +585,6 @@ impl Ground {
 pub fn generate_ground_data(args: &Args) -> Ground {
     if args.terrain {
         println!("{} Fetching elevation...", "[3/7]".bold());
-        emit_gui_progress_update(15.0, "Fetching elevation...");
         let ground = Ground::new_enabled(
             &args.bbox,
             args.scale,
@@ -590,6 +593,7 @@ pub fn generate_ground_data(args: &Args) -> Ground {
             args.disable_height_limit,
             extended_max_y_for(args),
             args.aws_only_elevation,
+            args.benchmark,
         );
         if args.debug {
             ground.save_debug_image("elevation_debug");

--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -152,6 +152,29 @@ a:hover {
   margin-bottom: 5px;
 }
 
+/* Time-remaining centered on the bar. White to match the percentage label; a
+   text-shadow keeps it legible over the green fill and the lighter track. */
+.progress-eta-overlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+  color: #ffffff;
+  font-size: 0.85em;
+  line-height: 1;
+  font-weight: 700;
+  white-space: nowrap;
+  pointer-events: none;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.85), 0 0 2px rgba(0, 0, 0, 0.7);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.progress-eta-overlay.visible {
+  opacity: 1;
+}
+
 .world-name-label {
   font-size: 0.8em;
   color: #fecc44;
@@ -222,6 +245,7 @@ button:hover {
   background-color: #e0e0e0;
   border-radius: 10px;
   overflow: hidden;
+  position: relative;
 }
 
 #progress-detail {

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -61,6 +61,7 @@
             <div class="progress-row">
               <div class="progress-bar-container">
                 <div class="progress-bar" id="progress-bar"></div>
+                <span id="progress-eta" class="progress-eta-overlay" dir="ltr"></span>
               </div>
               <span id="progress-detail">0%</span>
             </div>

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -388,6 +388,199 @@ function registerMessageEvent() {
   });
 }
 
+// --- Self-calibrating, phase-aware ETA ------------------------------------
+// The single 0-100% progress is non-linear in time: it has fixed phase
+// breakpoints and the post-70% tail is ~instant under stream-to-disk but a real
+// save otherwise. So we model three time-bands, extrapolate the CURRENT band to
+// its own end from a least-squares rate, and budget the remaining bands via
+// per-regime time weights calibrated to this run. The backend tells us the
+// streaming regime via an optional `streaming` field (absent => non-streaming).
+// Starts once generation begins (progress >= ETA_START, downloads done) and
+// ticks down once a second so it reads like a live countdown.
+const ETA_START = 20; // generation/terrain begins here, downloads done
+const ETA_WINDOW_MS = 16000; // sliding window for the rate (wider = steadier)
+const ETA_MIN_MS = 700; // min window span before trusting a rate
+const ETA_MIN_SAMPLES = 4; // keep at least this many samples in the window
+const ETA_STALL_MS = 1500; // progress flat this long => freeze belief, keep ticking
+const ETA_MAX_S = 24 * 3600; // ignore absurd extrapolations
+const ETA_A_DOWN = 0.28; // smoothing when the estimate falls (gentle)
+const ETA_A_UP = 0.1; // smoothing when it rises (resist, stay calm)
+const ETA_RISE_ABS = 2; // shown rises by at most max(2s, 10%) per update
+const ETA_RISE_FRAC = 0.1; // => smooth, monotonic-feeling countdown
+
+// Progress bands [lo, hi) and per-regime RELATIVE time weights (not % widths).
+const ETA_PHASES = [
+  { id: "terrain", lo: 20, hi: 70 },
+  { id: "ground", lo: 70, hi: 90 },
+  { id: "save", lo: 90, hi: 100 },
+];
+const ETA_WPRIOR = { nonStreaming: [37, 2, 10], streaming: [60, 0.3, 0.2] };
+
+let eta = null;
+
+function etaPhaseIdx(p) {
+  for (let i = 0; i < ETA_PHASES.length; i++) if (p < ETA_PHASES[i].hi) return i;
+  return ETA_PHASES.length - 1;
+}
+
+// Least-squares slope of progress over the window -> %/sec (null if not rising).
+function etaLsRate(s) {
+  const n = s.length;
+  if (n < 2) return null;
+  let st = 0, sp = 0;
+  for (const x of s) { st += x.t; sp += x.p; }
+  const mt = st / n, mp = sp / n;
+  let num = 0, den = 0;
+  for (const x of s) { const d = x.t - mt; num += d * (x.p - mp); den += d * d; }
+  if (den <= 0) return null;
+  const slope = num / den;
+  return slope > 0 ? slope * 1000 : null;
+}
+
+function resetEta() {
+  if (eta && eta.tickHandle) clearInterval(eta.tickHandle);
+  eta = null;
+  const el = document.getElementById("progress-eta");
+  if (el) {
+    el.classList.remove("visible");
+    el.textContent = "";
+    el.removeAttribute("aria-label");
+  }
+}
+
+function formatEtaDuration(sec) {
+  sec = Math.max(0, Math.round(sec));
+  if (sec < 60) return `${sec}s`;
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  if (m < 60) return s ? `${m}m ${s}s` : `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+function renderEta() {
+  const el = document.getElementById("progress-eta");
+  if (!el) return;
+  // Show nothing until we actually have an estimate (no "…" placeholder).
+  if (!eta || eta.shown == null) {
+    el.classList.remove("visible");
+    el.textContent = "";
+    el.removeAttribute("aria-label");
+    return;
+  }
+  // Floor at 1s so it never reads "0s" before Done.
+  const value = formatEtaDuration(Math.max(1, eta.shown));
+  el.textContent = value; // duration only on the bar; no "~" prefix
+  // Screen-reader context (the visible pill is just the duration). Hardcoded
+  // English to match the rest of the progress messages, which aren't localized.
+  el.setAttribute("aria-label", `Time remaining: ${value}`);
+  el.classList.add("visible");
+}
+
+// Two-layer display: `est` is the belief, `shown` follows it but falls freely
+// and rises slowly, so the countdown never jumps upward jarringly.
+function etaReconcile() {
+  if (!eta || eta.est == null) return;
+  if (eta.shown == null || eta.est <= eta.shown) eta.shown = eta.est;
+  else
+    eta.shown = Math.min(
+      eta.est,
+      eta.shown + Math.max(ETA_RISE_ABS, eta.shown * ETA_RISE_FRAC)
+    );
+}
+
+// Counts the value down between progress events (and through the 70% stall).
+function etaTick() {
+  if (!eta || eta.est == null) return;
+  const now = performance.now();
+  const dt = (now - eta.lastTickAt) / 1000;
+  eta.lastTickAt = now;
+  eta.est = Math.max(0, eta.est - dt);
+  if (eta.shown != null) eta.shown = Math.max(0, eta.shown - dt);
+  etaReconcile();
+  renderEta();
+}
+
+function updateEta(progress, streaming) {
+  // Reset before the generation phases and once finished / on a new run.
+  if (progress < ETA_START || progress >= 100) {
+    resetEta();
+    return;
+  }
+  const now = performance.now();
+  if (!eta) {
+    eta = {
+      streamingKnown: false, wprior: ETA_WPRIOR.nonStreaming, phaseIdx: -1,
+      phaseStartT: now, phaseStartProgress: null, movedInPhase: false,
+      samples: [], doneSec: 0, doneWeight: 0, est: null, shown: null,
+      lastTickAt: now, lastProgress: null, lastIncreaseAt: now, tickHandle: null,
+    };
+  }
+  if (streaming != null && !eta.streamingKnown) {
+    eta.streamingKnown = true;
+    eta.wprior = streaming ? ETA_WPRIOR.streaming : ETA_WPRIOR.nonStreaming;
+  }
+
+  const idx = etaPhaseIdx(progress), ph = ETA_PHASES[idx];
+  if (idx !== eta.phaseIdx) {
+    // Bank the real duration (incl. any stall) of the phase we just left.
+    if (eta.phaseIdx >= 0) {
+      eta.doneSec += (now - eta.phaseStartT) / 1000;
+      eta.doneWeight += eta.wprior[eta.phaseIdx];
+      for (let k = eta.phaseIdx + 1; k < idx; k++) eta.doneWeight += eta.wprior[k];
+    }
+    eta.phaseIdx = idx;
+    eta.phaseStartT = now;
+    eta.samples = [];
+    eta.phaseStartProgress = progress;
+    eta.movedInPhase = false;
+  }
+
+  if (eta.lastProgress == null || progress > eta.lastProgress) eta.lastIncreaseAt = now;
+  eta.lastProgress = progress;
+  const stalled = now - eta.lastIncreaseAt > ETA_STALL_MS;
+
+  eta.samples.push({ t: now, p: progress });
+  // Drop the flat phase-start hold (e.g. precompute sitting at 25%) the first
+  // time progress actually moves, so the rate reflects real work, not setup.
+  if (!eta.movedInPhase && eta.phaseStartProgress != null && progress > eta.phaseStartProgress) {
+    eta.samples = [{ t: now, p: progress }];
+    eta.movedInPhase = true;
+  }
+  const cut = now - ETA_WINDOW_MS;
+  while (eta.samples.length > ETA_MIN_SAMPLES && eta.samples[0].t < cut) eta.samples.shift();
+  const span = now - eta.samples[0].t;
+  const rate = !stalled && span >= ETA_MIN_MS ? etaLsRate(eta.samples) : null;
+
+  const phaseElapsed = (now - eta.phaseStartT) / 1000;
+  let G = eta.doneWeight > 0 ? eta.doneSec / eta.doneWeight : null; // sec per prior-unit
+  let remCur = null;
+  if (rate) remCur = (ph.hi - progress) / rate;
+  else if (G != null) remCur = ((ph.hi - progress) / (ph.hi - ph.lo)) * eta.wprior[idx] * G;
+  if (G == null && remCur != null) G = (phaseElapsed + remCur) / eta.wprior[idx];
+  if (G != null) G = Math.min(1000, Math.max(0.02, G));
+
+  let raw = null;
+  if (ph.id === "save" && rate) {
+    raw = Math.max(0, remCur); // snap to the real region-write rate, no future term
+  } else if (remCur != null) {
+    raw = Math.max(0, remCur);
+    if (G != null) for (let j = idx + 1; j < ETA_PHASES.length; j++) raw += eta.wprior[j] * G;
+  }
+
+  if (!stalled && raw != null && isFinite(raw) && raw <= ETA_MAX_S) {
+    const a = eta.est == null || raw <= eta.est ? ETA_A_DOWN : ETA_A_UP;
+    eta.est = eta.est == null ? raw : a * raw + (1 - a) * eta.est;
+    eta.lastTickAt = now;
+  }
+  if (eta.est != null && !eta.tickHandle) {
+    eta.lastTickAt = now;
+    eta.tickHandle = setInterval(etaTick, 1000);
+  }
+  etaReconcile();
+  renderEta();
+}
+
 // Function to set up the progress bar listener
 function setupProgressListener() {
   const progressBar = document.getElementById("progress-bar");
@@ -395,11 +588,12 @@ function setupProgressListener() {
   const progressDetail = document.getElementById("progress-detail");
 
   window.__TAURI__.event.listen("progress-update", (event) => {
-    const { progress, message } = event.payload;
+    const { progress, message, streaming } = event.payload;
 
     if (progress != -1) {
       progressBar.style.width = `${progress}%`;
       progressDetail.textContent = `${Math.round(progress)}%`;
+      updateEta(progress, streaming);
     }
 
     if (message != "") {
@@ -409,9 +603,11 @@ function setupProgressListener() {
         progressInfo.style.color = "#fa7878";
         generationButtonEnabled = true;
         setWorldNameLabel("");
+        resetEta();
       } else if (message.startsWith("Done!")) {
         progressInfo.style.color = "#7bd864";
         generationButtonEnabled = true;
+        resetEta();
       } else {
         progressInfo.style.color = "#ececec";
       }
@@ -1418,6 +1614,7 @@ async function startGeneration() {
     });
 
     console.log("Generation process started.");
+    resetEta();
     generationButtonEnabled = false;
   } catch (error) {
     console.error("Error starting generation:", error);

--- a/src/gui/locales/ar.json
+++ b/src/gui/locales/ar.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "توسيع ارتفاع البناء",
   "aws_only_elevation": "تضاريس قديمة",
   "bake_lighting": "حساب الإضاءة مسبقًا",
-  "stream_to_disk": "وضع الذاكرة المنخفضة",
   "bedrock_auto_generated": "يتم إنشاء عالم Bedrock تلقائيًا",
   "save_path": "مسار الحفظ",
   "rotation_angle": "زاوية الدوران",

--- a/src/gui/locales/de.json
+++ b/src/gui/locales/de.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Bauhöhe erweitern",
   "aws_only_elevation": "Klassisches Terrain",
   "bake_lighting": "Licht vorberechnen",
-  "stream_to_disk": "Speichersparmodus",
   "bedrock_auto_generated": "Bedrock-Welt wird automatisch generiert",
   "save_path": "Speicherpfad",
   "rotation_angle": "Rotationswinkel",

--- a/src/gui/locales/en-US.json
+++ b/src/gui/locales/en-US.json
@@ -53,7 +53,6 @@
   "disable_height_limit": "Extend build height",
   "aws_only_elevation": "Legacy terrain",
   "bake_lighting": "Bake lighting",
-  "stream_to_disk": "Low memory mode",
   "bedrock_auto_generated": "Bedrock world is auto-generated",
   "save_path": "Save Path",
   "rotation_angle": "Rotation Angle",

--- a/src/gui/locales/es.json
+++ b/src/gui/locales/es.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Ampliar altura de construcción",
   "aws_only_elevation": "Terreno clásico",
   "bake_lighting": "Precalcular iluminación",
-  "stream_to_disk": "Modo de memoria reducida",
   "bedrock_auto_generated": "El mundo Bedrock se genera automáticamente",
   "save_path": "Ruta de guardado",
   "rotation_angle": "Ángulo de Rotación",

--- a/src/gui/locales/fi.json
+++ b/src/gui/locales/fi.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Laajenna rakennuskorkeutta",
   "aws_only_elevation": "Vanha maasto",
   "bake_lighting": "Esilaske valaistus",
-  "stream_to_disk": "Muistinsäästötila",
   "bedrock_auto_generated": "Bedrock-maailma luodaan automaattisesti",
   "save_path": "Tallennuspolku",
   "rotation_angle": "Kiertokulma",

--- a/src/gui/locales/fr-FR.json
+++ b/src/gui/locales/fr-FR.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Étendre la hauteur de construction",
   "aws_only_elevation": "Terrain hérité",
   "bake_lighting": "Précalculer l'éclairage",
-  "stream_to_disk": "Mode mémoire réduite",
   "bedrock_auto_generated": "Le monde Bedrock est généré automatiquement",
   "save_path": "Chemin de sauvegarde",
   "rotation_angle": "Angle de Rotation",

--- a/src/gui/locales/hu.json
+++ b/src/gui/locales/hu.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Építési magasság kiterjesztése",
   "aws_only_elevation": "Régi domborzat",
   "bake_lighting": "Megvilágítás előszámítása",
-  "stream_to_disk": "Memóriatakarékos mód",
   "bedrock_auto_generated": "A Bedrock világ automatikusan generálódik",
   "save_path": "Mentési útvonal",
   "rotation_angle": "Forgatási Szög",

--- a/src/gui/locales/ja.json
+++ b/src/gui/locales/ja.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "建築高さを拡張",
   "aws_only_elevation": "従来の地形",
   "bake_lighting": "ライティングをベイク",
-  "stream_to_disk": "低メモリモード",
   "bedrock_auto_generated": "Bedrock ワールドは自動生成されます",
   "save_path": "保存先",
   "rotation_angle": "回転角度",

--- a/src/gui/locales/ko.json
+++ b/src/gui/locales/ko.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "건축 높이 확장",
   "aws_only_elevation": "기존 지형",
   "bake_lighting": "조명 베이크",
-  "stream_to_disk": "저메모리 모드",
   "bedrock_auto_generated": "Bedrock 월드는 자동 생성됩니다",
   "save_path": "저장 경로",
   "rotation_angle": "회전 각도",

--- a/src/gui/locales/lt.json
+++ b/src/gui/locales/lt.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Praplėsti statybos aukštį",
   "aws_only_elevation": "Senasis reljefas",
   "bake_lighting": "Iš anksto apskaičiuoti apšvietimą",
-  "stream_to_disk": "Mažos atminties režimas",
   "bedrock_auto_generated": "Bedrock pasaulis generuojamas automatiškai",
   "save_path": "Išsaugojimo kelias",
   "rotation_angle": "Pasukimo Kampas",

--- a/src/gui/locales/lv.json
+++ b/src/gui/locales/lv.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Paplašināt būvniecības augstumu",
   "aws_only_elevation": "Mantotais reljefs",
   "bake_lighting": "Iepriekš aprēķināt apgaismojumu",
-  "stream_to_disk": "Zemas atmiņas režīms",
   "bedrock_auto_generated": "Bedrock pasaule tiek ģenerēta automātiski",
   "save_path": "Saglabāšanas ceļš",
   "rotation_angle": "Rotācijas Leņķis",

--- a/src/gui/locales/pl.json
+++ b/src/gui/locales/pl.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Rozszerz wysokość budowania",
   "aws_only_elevation": "Klasyczny teren",
   "bake_lighting": "Wstępne obliczanie oświetlenia",
-  "stream_to_disk": "Tryb oszczędzania pamięci",
   "bedrock_auto_generated": "Świat Bedrock jest generowany automatycznie",
   "save_path": "Ścieżka zapisu",
   "rotation_angle": "Kąt Obrotu",

--- a/src/gui/locales/pt-BR.json
+++ b/src/gui/locales/pt-BR.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Ampliar altura de construção",
   "aws_only_elevation": "Terreno antigo",
   "bake_lighting": "Pré-calcular iluminação",
-  "stream_to_disk": "Modo de baixa memória",
   "bedrock_auto_generated": "O mundo de bedrock é gerado automaticamente",
   "save_path": "Caminho de salvamento",
   "rotation_angle": "Ângulo de Rotação",

--- a/src/gui/locales/ru.json
+++ b/src/gui/locales/ru.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Расширить высоту строительства",
   "aws_only_elevation": "Устаревший рельеф",
   "bake_lighting": "Предрасчёт освещения",
-  "stream_to_disk": "Режим экономии памяти",
   "bedrock_auto_generated": "Мир Bedrock генерируется автоматически",
   "save_path": "Путь сохранения",
   "rotation_angle": "Угол Поворота",

--- a/src/gui/locales/sl.json
+++ b/src/gui/locales/sl.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Razširi višino gradnje",
   "aws_only_elevation": "Starejši teren",
   "bake_lighting": "Predizračun osvetlitve",
-  "stream_to_disk": "Način nizke porabe pomnilnika",
   "bedrock_auto_generated": "Bedrock svet je samodejno ustvarjen",
   "save_path": "Pot shranjevanja",
   "rotation_angle": "Kot zasuka",

--- a/src/gui/locales/sv.json
+++ b/src/gui/locales/sv.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Utöka byggnadshöjd",
   "aws_only_elevation": "Äldre terräng",
   "bake_lighting": "Förberäkna ljussättning",
-  "stream_to_disk": "Lågminnesläge",
   "bedrock_auto_generated": "Bedrock-världen genereras automatiskt",
   "save_path": "Sökväg",
   "rotation_angle": "Rotationsvinkel",

--- a/src/gui/locales/ua.json
+++ b/src/gui/locales/ua.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "Розширити висоту будівництва",
   "aws_only_elevation": "Застарілий рельєф",
   "bake_lighting": "Попередній розрахунок освітлення",
-  "stream_to_disk": "Режим економії пам'яті",
   "bedrock_auto_generated": "Bedrock світ генерується автоматично",
   "save_path": "Шлях збереження",
   "rotation_angle": "Кут Обертання",

--- a/src/gui/locales/zh-CN.json
+++ b/src/gui/locales/zh-CN.json
@@ -46,7 +46,6 @@
   "disable_height_limit": "扩展建造高度",
   "aws_only_elevation": "旧版地形",
   "bake_lighting": "烘焙光照",
-  "stream_to_disk": "低内存模式",
   "bedrock_auto_generated": "Bedrock 世界自动生成",
   "save_path": "存档路径",
   "rotation_angle": "旋转角度",

--- a/src/land_cover.rs
+++ b/src/land_cover.rs
@@ -149,7 +149,7 @@ pub fn fetch_land_cover_data(
     grid_height: usize,
 ) -> Option<LandCoverData> {
     println!("Fetching land cover data (ESA WorldCover 2021)...");
-    emit_gui_progress_update(18.0, "Fetching land cover...");
+    emit_gui_progress_update(9.0, "Detecting surface types...");
 
     let cache_dir = get_cache_dir();
     if !cache_dir.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ mod gui;
 mod progress {
     pub fn emit_gui_error(_message: &str) {}
     pub fn emit_gui_progress_update(_progress: f64, _message: &str) {}
+    pub fn emit_gui_progress_update_ex(_progress: f64, _message: &str, _streaming: bool) {}
     pub fn emit_map_preview_ready() {}
     pub fn emit_show_in_folder(_path: &str) {}
     pub fn is_running_with_gui() -> bool {
@@ -200,6 +201,10 @@ fn run_cli() {
         (world_path, None)
     };
 
+    // Top-level phase timer (active only under --benchmark). generate_world has
+    // its own internal Bench for the block-placement phases.
+    let mut bench = bench::Bench::new(args.benchmark);
+
     // Fetch data
     let raw_data = match &args.file {
         Some(file) => retrieve_data::fetch_data_from_file(file),
@@ -211,35 +216,40 @@ fn run_cli() {
         ),
     }
     .expect("Failed to fetch data");
+    bench.mark("osm_fetch");
+
+    // Fetch supplementary Overture Maps buildings right after the OSM download
+    // (it only needs the bbox); the dedup against OSM runs after parsing below.
+    println!("{} Fetching Overture Maps data...", "  [+]".bold());
+    let overture_elements = overture::fetch_overture_buildings(&args.bbox, args.scale, args.debug);
+    bench.mark("overture_fetch");
 
     let mut ground = ground::generate_ground_data(&args);
+    bench.mark("terrain_total");
 
     // Parse raw data
     let (mut parsed_elements, mut xzbbox, outline_suppression) =
         osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug, args.projection);
+    bench.mark("parse_osm");
 
-    // Fetch supplementary building data from Overture Maps
-    {
-        println!("{} Fetching Overture Maps data...", "  [+]".bold());
-        let overture_elements =
-            overture::fetch_overture_buildings(&args.bbox, args.scale, args.debug);
-        if !overture_elements.is_empty() {
-            let before_count = parsed_elements.len();
-            let unique_overture =
-                overture::deduplicate_against_osm(overture_elements, &parsed_elements);
-            parsed_elements.extend(unique_overture);
-            let added = parsed_elements.len() - before_count;
-            println!(
-                "  Added {} buildings from Overture Maps",
-                added.to_string().bright_white().bold()
-            );
-        } else {
-            println!("  No additional buildings from Overture Maps for this area");
-        }
+    // Merge the Overture buildings now that the OSM elements are parsed.
+    if !overture_elements.is_empty() {
+        let before_count = parsed_elements.len();
+        let unique_overture =
+            overture::deduplicate_against_osm(overture_elements, &parsed_elements);
+        parsed_elements.extend(unique_overture);
+        let added = parsed_elements.len() - before_count;
+        println!(
+            "  Added {} buildings from Overture Maps",
+            added.to_string().bright_white().bold()
+        );
+    } else {
+        println!("  No additional buildings from Overture Maps for this area");
     }
 
     parsed_elements
         .sort_by_key(|element: &osm_parser::ProcessedElement| osm_parser::get_priority(element));
+    bench.mark("sort_priority");
 
     // OSM water override first, then bridge repair handles remaining bridge-shadow cells.
     ground.apply_osm_water_override(&parsed_elements, &xzbbox);
@@ -250,6 +260,7 @@ fn run_cli() {
     if args.debug {
         ground.save_land_cover_debug_image("landcover_debug_post_bridge_repair");
     }
+    bench.mark("landcover_osm_repair");
 
     // Write the parsed OSM data to a file for inspection
     if args.debug {
@@ -270,6 +281,7 @@ fn run_cli() {
 
     // Transform map (parsed_elements). Operations are defined in a json file
     map_transformation::transform_map(&mut parsed_elements, &mut xzbbox, &mut ground);
+    bench.mark("transform_map");
 
     // Apply rotation if specified
     if args.rotation.abs() > f64::EPSILON {

--- a/src/map_transformation/transform_map.rs
+++ b/src/map_transformation/transform_map.rs
@@ -11,7 +11,7 @@ pub fn transform_map(
     ground: &mut Ground,
 ) {
     println!("{} Transforming map...", "[4/7]".bold());
-    emit_gui_progress_update(20.0, "Transforming map...");
+    emit_gui_progress_update(19.0, "Transforming map...");
 
     let opjson_string = include_str!("../../tests/map_transformation/example_transformations.json");
     let opjson = serde_json::from_str(opjson_string)
@@ -24,17 +24,7 @@ pub fn transform_map(
             panic!();
         });
 
-    let nop: usize = ops.len();
-
-    let progress_increment_prcs: f64 = 5.0 / nop as f64;
-
-    for (iop, op) in (1..).zip(ops) {
-        let current_progress_prcs = 20.0 + (iop as f64 * progress_increment_prcs);
-        //let message = format!("Applying operation: {}, {}/{}", op.repr(), iop, nop);
-        emit_gui_progress_update(current_progress_prcs, "");
-
+    for op in ops {
         op.operate(elements, xzbbox, ground);
     }
-
-    emit_gui_progress_update(25.0, "");
 }

--- a/src/osm_parser.rs
+++ b/src/osm_parser.rs
@@ -239,7 +239,6 @@ pub fn parse_osm_data(
 ) -> (Vec<ProcessedElement>, XZBBox, OutlineSuppression) {
     println!("{} Parsing data...", "[2/7]".bold());
     println!("Bounding box: {bbox:?}");
-    emit_gui_progress_update(5.0, "Parsing data...");
 
     // Deserialize the JSON data into the OSMData structure
     let data = SplitOsmData::from_raw_osm_data(osm_data);
@@ -437,7 +436,7 @@ pub fn parse_osm_data(
         }
     }
 
-    emit_gui_progress_update(14.0, "");
+    emit_gui_progress_update(18.5, "");
 
     drop(nodes_map);
     drop(ways_map);

--- a/src/overture.rs
+++ b/src/overture.rs
@@ -197,7 +197,7 @@ fn fetch_overture_buildings_inner(
         ))
         .build()?;
 
-    emit_gui_progress_update(14.5, "Fetching Overture Maps data...");
+    emit_gui_progress_update(6.0, "Adding extra buildings...");
 
     // List partition files whose geographic bounds overlap our bbox
     // (single ~230 KB STAC download instead of 512 HTTP requests)

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -64,7 +64,10 @@ pub fn emit_gui_progress_update_ex(progress: f64, message: &str, streaming: bool
             "streaming": streaming
         });
         if let Err(e) = window.emit("progress-update", payload) {
-            eprintln!("Failed to emit progress event: {}", e);
+            let error_msg = format!("Failed to emit progress event: {}", e);
+            eprintln!("{}", error_msg);
+            #[cfg(feature = "gui")]
+            send_log(LogLevel::Warning, &error_msg);
         }
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -21,15 +21,19 @@ pub fn is_running_with_gui() -> bool {
 }
 
 /// This code manages a multi-step process with a progress bar indicating the overall completion.
-/// The progress updates are mapped to specific steps in the pipeline:
+/// Percentages are monotonic in the ACTUAL execution order (download -> overture ->
+/// land cover -> elevation -> parse -> transform -> generate -> ground -> save):
 ///
-/// [1/7] Fetching data... - Starts at: 0% / Completes at: 5%
-/// [2/7] Parsing data... - Starts at: 5% / Completes at: 15%
-/// [3/7] Fetching elevation... - Starts at: 15% / Completes at: 20%
-/// [4/7] Transforming map... - Starts at: 20% / Completes at: 25%
-/// [5/7] Processing terrain... - Starts at: 25% / Completes at: 70%
-/// [6/7] Generating ground... - Starts at: 70% / Completes at: 90%
-/// [7/7] Saving world... - Starts at: 90% / Completes at: 100%
+/// Downloading map data...    1-5%
+/// Adding extra buildings...  6%        (Overture; fetched right after download)
+/// Detecting surface types... 9%        (land cover; skipped if disabled)
+/// Fetching elevation...      10%
+/// Processing elevation...    12-18%
+/// (parsing, silent)          18.5%
+/// Transforming map...        19%
+/// Generating area...         20-70%
+/// Generating ground...       70-90%
+/// Saving world...            90-100%
 ///
 /// The function `emit_gui_progress_update` is used to send real-time progress updates to the UI.
 pub fn emit_gui_progress_update(progress: f64, message: &str) {
@@ -44,6 +48,23 @@ pub fn emit_gui_progress_update(progress: f64, message: &str) {
             eprintln!("{}", error_msg);
             #[cfg(feature = "gui")]
             send_log(LogLevel::Warning, &error_msg);
+        }
+    }
+}
+
+/// Like `emit_gui_progress_update` but also carries the stream-to-disk regime so
+/// the GUI ETA can pick the right time-weight profile (the post-70% tail is
+/// ~instant when streaming, a real save otherwise). Additive payload field;
+/// only the two terrain emits use it, all other sites stay on the plain fn.
+pub fn emit_gui_progress_update_ex(progress: f64, message: &str, streaming: bool) {
+    if let Some(window) = get_main_window() {
+        let payload = json!({
+            "progress": progress,
+            "message": message,
+            "streaming": streaming
+        });
+        if let Err(e) = window.emit("progress-update", payload) {
+            eprintln!("Failed to emit progress event: {}", e);
         }
     }
 }

--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -45,7 +45,7 @@ fn download_with_reqwest(
 
     match response {
         Ok(resp) => {
-            emit_gui_progress_update(3.0, "Downloading data...");
+            emit_gui_progress_update(3.0, "");
             if resp.status().is_success() {
                 let text = resp.text()?;
                 if text.is_empty() {
@@ -129,7 +129,7 @@ pub fn fetch_data_from_overpass(
     save_file: Option<&str>,
 ) -> Result<OsmData, Box<dyn std::error::Error>> {
     println!("{} Fetching data...", "[1/7]".bold());
-    emit_gui_progress_update(1.0, "Fetching data...");
+    emit_gui_progress_update(1.0, "Downloading map data...");
 
     // List of Overpass API servers
     let arnis_api_server = "https://api.arnismc.com/overpass/api/interpreter";


### PR DESCRIPTION
GUI progress + ETA:
- Add a phase-aware "time remaining" estimate, shown as a white pill on the progress bar. It only runs during generation (>=20%); within the current phase it extrapolates the real rate (least-squares over a sliding window), budgets remaining phases by per-regime time-weights calibrated to this run, and snaps to the real save rate. Smoothed, monotonic countdown via a 1s tick.
- Additive `streaming` field on the progress-update payload (= eviction_active) via emit_gui_progress_update_ex, used only by the two terrain emits, so the ETA picks the right regime (the post-70% tail is ~instant under stream-to-disk but a real save otherwise). Graceful fallback when absent.

Progress messages/percentages (now monotonic in real execution order):
- Fetch Overture buildings right after the OSM download (dedup stays after parse). Download 1-5, Overture 6, surface types 9, elevation 10, elevation processing 12-18 (real progress), transform 19 (fixed), generating area 20-70, ground 70-90, save 90-100.
- Friendlier, deduplicated messages: "Downloading map data", "Adding extra buildings", "Detecting surface types", "Generating area".
- Drop the dead `stream_to_disk` locale key (removed low-memory-mode toggle).

--benchmark instrumentation (gated; no output or cost without the flag):
- Top-level per-phase marks + a per-step elevation breakdown. generation_time_ms and the peak-RSS marker are unchanged, so the PR benchmark CI is unaffected.