### PR TITLE
fix: drop overflowing corner-coordinate sums (i32 add-overflow crash)

### DIFF
--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -1723,7 +1723,7 @@ fn build_wall_ring(
     building_passages: &CoordinateBitmap,
 ) -> (Vec<(i32, i32)>, i32) {
     let mut previous_node: Option<(i32, i32)> = None;
-    // Count of corner nodes added; the caller only needs to know the ring is non-empty.
+    // Count of generated wall coordinates; the caller only needs to know the ring is non-empty.
     let mut corner_count: i32 = 0;
     let mut current_building: Vec<(i32, i32)> = Vec::new();
 

--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -1721,9 +1721,10 @@ fn build_wall_ring(
     args: &Args,
     has_sloped_roof: bool,
     building_passages: &CoordinateBitmap,
-) -> (Vec<(i32, i32)>, (i32, i32, i32)) {
+) -> (Vec<(i32, i32)>, i32) {
     let mut previous_node: Option<(i32, i32)> = None;
-    let mut corner_addup: (i32, i32, i32) = (0, 0, 0);
+    // Count of corner nodes added; the caller only needs to know the ring is non-empty.
+    let mut corner_count: i32 = 0;
     let mut current_building: Vec<(i32, i32)> = Vec::new();
 
     let passage_height = BUILDING_PASSAGE_HEIGHT.min(config.building_height);
@@ -1834,14 +1835,14 @@ fn build_wall_ring(
                 }
 
                 current_building.push((bx, bz));
-                corner_addup = (corner_addup.0 + bx, corner_addup.1 + bz, corner_addup.2 + 1);
+                corner_count += 1;
             }
         }
 
         previous_node = Some((x, z));
     }
 
-    (current_building, corner_addup)
+    (current_building, corner_count)
 }
 
 /// Generates special doors for garages (double door) and sheds (single door)
@@ -4151,7 +4152,7 @@ pub fn generate_buildings(
             config.condition,
             BuildingCondition::Construction | BuildingCondition::Ruined
         );
-    let (wall_outline, corner_addup) = build_wall_ring(
+    let (wall_outline, corner_count) = build_wall_ring(
         editor,
         &element.nodes,
         &config,
@@ -4212,7 +4213,7 @@ pub fn generate_buildings(
     };
 
     // Generate floors and ceilings
-    if corner_addup != (0, 0, 0) {
+    if corner_count > 0 {
         generate_floors_and_ceilings(
             editor,
             &cached_floor_area,

--- a/src/element_processing/leisure.rs
+++ b/src/element_processing/leisure.rs
@@ -18,7 +18,7 @@ pub fn generate_leisure(
 ) {
     if let Some(leisure_type) = element.tags.get("leisure") {
         let mut previous_node: Option<(i32, i32)> = None;
-        let mut corner_addup: (i32, i32, i32) = (0, 0, 0);
+        let mut corner_count: i32 = 0;
         let mut current_leisure: Vec<(i32, i32)> = vec![];
 
         // Determine block type based on leisure type
@@ -71,15 +71,13 @@ pub fn generate_leisure(
                 }
 
                 current_leisure.push((node.x, node.z));
-                corner_addup.0 += node.x;
-                corner_addup.1 += node.z;
-                corner_addup.2 += 1;
+                corner_count += 1;
             }
             previous_node = Some((node.x, node.z));
         }
 
         // Flood-fill the interior of the leisure area using cache
-        if corner_addup != (0, 0, 0) {
+        if corner_count > 0 {
             let filled_area = flood_fill_cache.get_or_compute(element, args.timeout.as_ref());
 
             // Use deterministic RNG seeded by element ID for consistent results across region boundaries

--- a/src/element_processing/natural.rs
+++ b/src/element_processing/natural.rs
@@ -91,7 +91,7 @@ pub fn generate_natural(
             }
         } else {
             let mut previous_node: Option<(i32, i32)> = None;
-            let mut corner_addup: (i32, i32, i32) = (0, 0, 0);
+            let mut corner_count: i32 = 0;
             let mut current_natural: Vec<(i32, i32)> = vec![];
             let binding: String = "".to_string();
 
@@ -171,14 +171,14 @@ pub fn generate_natural(
                     }
 
                     current_natural.push((x, z));
-                    corner_addup = (corner_addup.0 + x, corner_addup.1 + z, corner_addup.2 + 1);
+                    corner_count += 1;
                 }
 
                 previous_node = Some((x, z));
             }
 
             // If there are natural nodes, flood-fill the area using cache
-            if corner_addup != (0, 0, 0) {
+            if corner_count > 0 {
                 let filled_area = flood_fill_cache.get_or_compute(way, args.timeout.as_ref());
 
                 let trees_ok_to_generate: Vec<TreeType> = {


### PR DESCRIPTION
build_wall_ring (and the identical copy-pasted pattern in leisure.rs and natural.rs) summed corner x/z coordinates into an i32 accumulator only to test it `!= (0,0,0)`. On buildings/areas with many nodes or large coordinates (far from origin / web-mercator global coords) the sum overflows i32, and with `overflow-checks = true` in the release profile that panics.

The sums were never read for a value, so replace the tuple with a plain corner count and a `count > 0` non-empty check. Fixes the reported crash and the same latent overflow in leisure.rs and natural.rs.