### PR TITLE
fix(datapack): support Minecraft 1.21.4 through 26.1.x

### DIFF
--- a/assets/minecraft/datapack_tall/overlay_2601/data/minecraft/dimension_type/overworld.json
+++ b/assets/minecraft/datapack_tall/overlay_2601/data/minecraft/dimension_type/overworld.json
@@ -1,0 +1,40 @@
+{
+  "ambient_light": 0.0,
+  "attributes": {
+    "minecraft:audio/ambient_sounds": {
+      "mood": { "block_search_extent": 8, "offset": 2.0, "sound": "minecraft:ambient.cave", "tick_delay": 6000 }
+    },
+    "minecraft:audio/background_music": {
+      "creative": { "max_delay": 24000, "min_delay": 12000, "sound": "minecraft:music.creative" },
+      "default": { "max_delay": 24000, "min_delay": 12000, "sound": "minecraft:music.game" }
+    },
+    "minecraft:gameplay/bed_rule": {
+      "can_set_spawn": "always",
+      "can_sleep": "when_dark",
+      "error_message": { "translate": "block.minecraft.bed.no_sleep" }
+    },
+    "minecraft:gameplay/nether_portal_spawns_piglin": true,
+    "minecraft:gameplay/respawn_anchor_works": false,
+    "minecraft:visual/ambient_light_color": "#0a0a0a",
+    "minecraft:visual/cloud_color": "#ccffffff",
+    "minecraft:visual/cloud_height": 192.33,
+    "minecraft:visual/fog_color": "#c0d8ff",
+    "minecraft:visual/sky_color": "#78a7ff"
+  },
+  "coordinate_scale": 1.0,
+  "default_clock": "minecraft:overworld",
+  "has_ceiling": false,
+  "has_ender_dragon_fight": false,
+  "has_skylight": true,
+  "height": 4064,
+  "infiniburn": "#minecraft:infiniburn_overworld",
+  "logical_height": 4064,
+  "min_y": -2032,
+  "monster_spawn_block_light_limit": 0,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "max_inclusive": 7,
+    "min_inclusive": 0
+  },
+  "timelines": "#minecraft:in_overworld"
+}

--- a/assets/minecraft/datapack_tall/overlay_attributes/data/minecraft/dimension_type/overworld.json
+++ b/assets/minecraft/datapack_tall/overlay_attributes/data/minecraft/dimension_type/overworld.json
@@ -1,0 +1,37 @@
+{
+  "ambient_light": 0.0,
+  "attributes": {
+    "minecraft:audio/ambient_sounds": {
+      "mood": { "block_search_extent": 8, "offset": 2.0, "sound": "minecraft:ambient.cave", "tick_delay": 6000 }
+    },
+    "minecraft:audio/background_music": {
+      "creative": { "max_delay": 24000, "min_delay": 12000, "sound": "minecraft:music.creative" },
+      "default": { "max_delay": 24000, "min_delay": 12000, "sound": "minecraft:music.game" }
+    },
+    "minecraft:gameplay/bed_rule": {
+      "can_set_spawn": "always",
+      "can_sleep": "when_dark",
+      "error_message": { "translate": "block.minecraft.bed.no_sleep" }
+    },
+    "minecraft:gameplay/nether_portal_spawns_piglin": true,
+    "minecraft:gameplay/respawn_anchor_works": false,
+    "minecraft:visual/cloud_color": "#ccffffff",
+    "minecraft:visual/cloud_height": 192.33,
+    "minecraft:visual/fog_color": "#c0d8ff",
+    "minecraft:visual/sky_color": "#78a7ff"
+  },
+  "coordinate_scale": 1.0,
+  "has_ceiling": false,
+  "has_skylight": true,
+  "height": 4064,
+  "infiniburn": "#minecraft:infiniburn_overworld",
+  "logical_height": 4064,
+  "min_y": -2032,
+  "monster_spawn_block_light_limit": 0,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "max_inclusive": 7,
+    "min_inclusive": 0
+  },
+  "timelines": "#minecraft:in_overworld"
+}

--- a/assets/minecraft/datapack_tall/pack.mcmeta
+++ b/assets/minecraft/datapack_tall/pack.mcmeta
@@ -1,9 +1,25 @@
 {
   "pack": {
-    "pack_format": 61,
     "description": "Arnis extended build height",
-    "supported_formats": { "min_inclusive": 61, "max_inclusive": 88 },
-    "min_format": 61,
-    "max_format": 88
+    "pack_format": 61,
+    "supported_formats": { "min_inclusive": 61, "max_inclusive": 101 },
+    "min_format": [61, 0],
+    "max_format": [101, 2147483647]
+  },
+  "overlays": {
+    "entries": [
+      {
+        "formats": { "min_inclusive": 90, "max_inclusive": 100 },
+        "min_format": [90, 0],
+        "max_format": [100, 2147483647],
+        "directory": "overlay_attributes"
+      },
+      {
+        "formats": { "min_inclusive": 101, "max_inclusive": 101 },
+        "min_format": [101, 0],
+        "max_format": [101, 2147483647],
+        "directory": "overlay_2601"
+      }
+    ]
   }
 }

--- a/assets/minecraft/datapack_tall/pack.mcmeta
+++ b/assets/minecraft/datapack_tall/pack.mcmeta
@@ -1,6 +1,9 @@
 {
   "pack": {
     "pack_format": 61,
-    "description": "Arnis extended build height (1.21.4)"
+    "description": "Arnis extended build height",
+    "supported_formats": { "min_inclusive": 61, "max_inclusive": 9999 },
+    "min_format": 61,
+    "max_format": 9999
   }
 }

--- a/assets/minecraft/datapack_tall/pack.mcmeta
+++ b/assets/minecraft/datapack_tall/pack.mcmeta
@@ -2,8 +2,8 @@
   "pack": {
     "pack_format": 61,
     "description": "Arnis extended build height",
-    "supported_formats": { "min_inclusive": 61, "max_inclusive": 9999 },
+    "supported_formats": { "min_inclusive": 61, "max_inclusive": 88 },
     "min_format": 61,
-    "max_format": 9999
+    "max_format": 88
   }
 }

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -159,7 +159,7 @@
         <div class="settings-row">
           <label for="disable-height-limit-toggle">
             <span data-localize="disable_height_limit">Extend build height</span>
-            <span class="tooltip-icon" data-tooltip="Bundles a pack that raises the build height for 1:1 terrain. Java 1.21.4+ / Bedrock 1.21.40+ (experimental, no Realms)">?</span>
+            <span class="tooltip-icon" data-tooltip="Bundles a pack that raises the build height for 1:1 terrain. Works on Java 1.21.4+ and Bedrock 1.21.40+ (experimental; not Realms-compatible).">?</span>
           </label>
           <div class="settings-control">
             <input type="checkbox" id="disable-height-limit-toggle" name="disable-height-limit-toggle">

--- a/src/world_utils.rs
+++ b/src/world_utils.rs
@@ -232,26 +232,47 @@ pub const TALL_DATAPACK_NAME: &str = "arnis_tall";
 
 /// Install the bundled tall-world datapack into a Java world and register it
 /// in `level.dat`'s `Data.DataPacks.Enabled` so it auto-activates on first
-/// load. Pack assets target Minecraft 1.21.4 (matching the bundled level.dat
-/// template) — older clients will refuse to load the world.
+/// load. The base `data/` tree uses the legacy flat dimension_type schema
+/// (formats 61-88, i.e. 1.21.4-1.21.10); overlays carry the attributes schema
+/// for 1.21.11-era (formats 90-100) and 26.1.x (format 101.x), since the
+/// schema is mutually incompatible across those eras.
 pub fn install_tall_datapack(world_path: &Path) -> Result<(), String> {
     const PACK_MCMETA: &[u8] = include_bytes!("../assets/minecraft/datapack_tall/pack.mcmeta");
     const OVERWORLD_JSON: &[u8] = include_bytes!(
         "../assets/minecraft/datapack_tall/data/minecraft/dimension_type/overworld.json"
     );
+    const OVERLAY_ATTRIBUTES_JSON: &[u8] = include_bytes!(
+        "../assets/minecraft/datapack_tall/overlay_attributes/data/minecraft/dimension_type/overworld.json"
+    );
+    const OVERLAY_2601_JSON: &[u8] = include_bytes!(
+        "../assets/minecraft/datapack_tall/overlay_2601/data/minecraft/dimension_type/overworld.json"
+    );
 
     let dp_root = world_path.join("datapacks").join(TALL_DATAPACK_NAME);
-    let dim_dir = dp_root
-        .join("data")
-        .join("minecraft")
-        .join("dimension_type");
-    fs::create_dir_all(&dim_dir)
-        .map_err(|e| format!("Failed to create datapack directories: {e}"))?;
+
+    // (overlay directory, embedded bytes); empty directory = base data/ tree.
+    let dim_files: [(&str, &[u8]); 3] = [
+        ("", OVERWORLD_JSON),
+        ("overlay_attributes", OVERLAY_ATTRIBUTES_JSON),
+        ("overlay_2601", OVERLAY_2601_JSON),
+    ];
+    for (overlay, bytes) in dim_files {
+        let mut dim_dir = dp_root.clone();
+        if !overlay.is_empty() {
+            dim_dir.push(overlay);
+        }
+        let dim_dir = dim_dir
+            .join("data")
+            .join("minecraft")
+            .join("dimension_type");
+        fs::create_dir_all(&dim_dir)
+            .map_err(|e| format!("Failed to create datapack directories: {e}"))?;
+        fs::write(dim_dir.join("overworld.json"), bytes)
+            .map_err(|e| format!("Failed to write overworld.json: {e}"))?;
+    }
 
     fs::write(dp_root.join("pack.mcmeta"), PACK_MCMETA)
         .map_err(|e| format!("Failed to write pack.mcmeta: {e}"))?;
-    fs::write(dim_dir.join("overworld.json"), OVERWORLD_JSON)
-        .map_err(|e| format!("Failed to write overworld.json: {e}"))?;
 
     register_tall_datapack_in_level_dat(world_path)?;
 


### PR DESCRIPTION
## Problem

The tall-world datapack (`arnis_tall`) overrode `minecraft:overworld` with the **1.21.4 flat** `dimension_type` schema. Minecraft 26.1 rejects this during registry loading — `has_ender_dragon_fight` is now a required field and the schema moved to a new `attributes` system, dropping the old flat fields. Result: a hard crash, world won't load (#1061).

## Fix

There are **three** schema eras, so a single override can't satisfy all of them. The pack now uses overlays:

| Versions | pack_format | Tree |
|---|---|---|
| 1.21.4 – 1.21.10 | 61–88 | base `data/` (flat schema) |
| 1.21.11-era | 90–100 | `overlay_attributes/` (attributes, no dragon) |
| 26.1.x | 101.x | `overlay_2601/` (attributes + `has_ender_dragon_fight`) |

- Each `overworld.json` is byte-identical to that version's **vanilla** file except `min_y=-2032 / height=4064 / logical_height=4064`.
- `pack.mcmeta` carries both legacy (`pack_format`/`supported_formats`) and new (`min_format`/`max_format`) keys — required while the pack still supports format 61 < 82 — and routes each client to the right overlay.
- `install_tall_datapack` now writes all three files into every generated world.
- GUI tooltip wording clarified.

## Verification

- All JSON valid; `cargo build --release` + `cargo clippy --all-targets` clean.
- End-to-end generation confirms all four files land in `datapacks/arnis_tall/`.
- **Confirmed loading in Minecraft 26.1.2.**

Worlds are still generated at the 1.21.4 data version (the floor), so 1.21.x users open directly and 26.1 users get the normal upgrade prompt. Snapshot-only formats 99–100 are intentionally not covered; all releases are.

Closes #1061