### PR TITLE
Prepare v2.9.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "arnis"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "base64 0.22.1",
  "bedrockrs_level",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arnis"
-version = "2.8.0"
+version = "2.9.0"
 edition = "2021"
 description = "Arnis - Generate real life cities in Minecraft"
 homepage = "https://github.com/louis-e/arnis"

--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Arnis",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "identifier": "com.louisdev.arnis",
   "build": {
     "frontendDist": "src/gui"


### PR DESCRIPTION
Version bump 2.8.0 → 2.9.0 (Mosaic Update) ahead of the release.

- `Cargo.toml`, `tauri.conf.json`, `Cargo.lock` (arnis package) → 2.9.0

`cargo build --release`, `cargo test` (211 pass), `cargo clippy --all-targets`, and `cargo fmt --check` all pass clean on main.