### PR TITLE
fix(gui): stop false 'Not enough disk space' on a bogus 0-byte reading (#824)

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -966,7 +966,9 @@ fn gui_start_generation(
                         Some(parent) => p = parent,
                         // No existing ancestor (e.g. a bare relative path): probe
                         // the current dir so the query always hits a real path.
-                        None => break std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+                        None => {
+                            break std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+                        }
                     }
                 }
             };

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -958,13 +958,17 @@ fn gui_start_generation(
             // error or a 0/undeterminable result as "can't tell" and proceed (#824).
             let probe_path = {
                 let mut p = check_path.as_path();
-                while !p.exists() {
+                loop {
+                    if p.exists() {
+                        break p.to_path_buf();
+                    }
                     match p.parent() {
                         Some(parent) => p = parent,
-                        None => break,
+                        // No existing ancestor (e.g. a bare relative path): probe
+                        // the current dir so the query always hits a real path.
+                        None => break std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
                     }
                 }
-                p.to_path_buf()
             };
             match fs2::available_space(&probe_path) {
                 Ok(available) if available > 0 && available < MIN_DISK_SPACE_BYTES => {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -952,18 +952,32 @@ fn gui_start_generation(
                 // For Bedrock, check current directory where .mcworld will be created
                 std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
             };
-            match fs2::available_space(&check_path) {
-                Ok(available) if available < MIN_DISK_SPACE_BYTES => {
+            // Probe the nearest existing ancestor: a missing or space-containing
+            // path otherwise confuses the Windows volume lookup, which then reports
+            // 0 bytes free. Only block on a confident positive reading; treat an
+            // error or a 0/undeterminable result as "can't tell" and proceed (#824).
+            let probe_path = {
+                let mut p = check_path.as_path();
+                while !p.exists() {
+                    match p.parent() {
+                        Some(parent) => p = parent,
+                        None => break,
+                    }
+                }
+                p.to_path_buf()
+            };
+            match fs2::available_space(&probe_path) {
+                Ok(available) if available > 0 && available < MIN_DISK_SPACE_BYTES => {
                     let error_msg = "Not enough disk space available.".to_string();
                     eprintln!("{error_msg}");
                     emit_gui_error(&error_msg);
                     return Err(error_msg);
                 }
+                Ok(_) => {} // Sufficient, or 0/undeterminable: don't false-block
                 Err(e) => {
                     // Log warning but don't block generation if we can't check space
                     eprintln!("Warning: Could not check disk space: {e}");
                 }
-                _ => {} // Sufficient space available
             }
 
             // Acquire session lock for Java worlds only


### PR DESCRIPTION
## Problem

Users with plenty of free space (one reporter had ~20 GB) hit **"Error! Not enough disk space available."** and couldn't generate. A folder name containing a space was reported to trigger it, with renaming to `_` as the workaround.

## Root cause

The pre-check blocked on **any** `fs2::available_space` reading under the 3 GB minimum — including a bogus `0`. `fs2`'s Windows path (`GetVolumePathNameW` → `GetDiskFreeSpaceW`) can return `Ok(0)` from a confused/empty volume lookup (e.g. when the probed path isn't a clean existing directory), and the zero-inclusive predicate treated that as "disk full." 20 GB free can never legitimately produce `Ok(<3GB)`, so the block could only have come from a bogus `0`.

## Fix

- Probe the **nearest existing ancestor** of the target path before querying, so a missing/quirky leaf path can't confuse the volume lookup.
- Only hard-block on a **confident positive** reading (`available > 0 && available < 3 GB`). Treat `0` and errors as undeterminable and proceed — the write path still surfaces real out-of-space errors (`is_disk_full_error`).

Verified: `cargo build --release`, `clippy --all-targets`, and `fmt --check` all clean. This is the only `fs2::available_space` call in the codebase.

Closes #824