### PR TITLE
Performance: trim Overpass query, add CPU-usage control, and opt-in pipelined tile merge

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -40,6 +40,12 @@ pub struct Args {
     #[arg(long, default_value_t = 1.0)]
     pub scale: f64,
 
+    /// Percentage of CPU cores to use for world generation (10-100).
+    /// Higher values spawn more worker threads: faster generation, but the
+    /// system stays less responsive. Overridden by the RAYON_NUM_THREADS env var.
+    #[arg(long, default_value_t = 90)]
+    pub cpu_percent: u8,
+
     /// Projection mode for coordinate mapping
     /// local: each generation starts at Minecraft (0,0) (default)
     /// web_mercator: global projection for multi-generation worlds
@@ -192,6 +198,11 @@ pub fn validate_args(args: &Args) -> Result<(), String> {
     // Validate rotation angle range (also rejects NaN and infinity)
     if !args.rotation.is_finite() || args.rotation < -90.0 || args.rotation > 90.0 {
         return Err("Rotation angle must be between -90 and 90 degrees.".to_string());
+    }
+
+    // Validate CPU usage percentage
+    if args.cpu_percent < 10 || args.cpu_percent > 100 {
+        return Err("CPU usage percent (--cpu-percent) must be between 10 and 100.".to_string());
     }
 
     Ok(())

--- a/src/args.rs
+++ b/src/args.rs
@@ -46,6 +46,12 @@ pub struct Args {
     #[arg(long, default_value_t = 90)]
     pub cpu_percent: u8,
 
+    /// Overlap each tile batch's merge with the next batch's placement so worker
+    /// cores aren't idle during merges (faster on large areas; output unchanged).
+    /// Also enabled by the ARNIS_PIPELINE_MERGE env var.
+    #[arg(long, default_value_t = false)]
+    pub pipeline_merge: bool,
+
     /// Projection mode for coordinate mapping
     /// local: each generation starts at Minecraft (0,0) (default)
     /// web_mercator: global projection for multi-generation worlds

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -10,7 +10,7 @@ use crate::progress::{emit_gui_progress_update, emit_gui_progress_update_ex, emi
 #[cfg(feature = "gui")]
 use crate::telemetry::{send_log, LogLevel};
 use crate::tile;
-use crate::world_editor::{FlushWorker, WorldEditor, WorldFormat};
+use crate::world_editor::{FlushWorker, WorldEditor, WorldFormat, WorldToModify};
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
@@ -531,10 +531,12 @@ fn generate_world_inner(
         let total_tiles = indexed_tiles.len().max(1);
         let mut tiles_merged = 0usize;
         let mut last_emitted_pct = 20.0_f64;
-        for batch in indexed_tiles.chunks(tile_batch_size) {
-            // Phase 1: process this batch of tiles in parallel
-            let place_start = std::time::Instant::now();
-            let batch_results: Vec<_> = batch
+
+        // Phase 1 (parallel): place one batch of tiles into independent tile editors.
+        // Pure function of immutable inputs — never touches the shared `editor`, so it
+        // can run concurrently with a Phase-2 merge of an earlier batch.
+        let place_batch = |batch: &[(usize, &tile::TileBounds)]| {
+            batch
                 .par_iter()
                 .map(|&(tile_idx, tile_bounds)| {
                     // max_* are exclusive; rect_from_min_max treats max as inclusive,
@@ -638,71 +640,112 @@ fn generate_world_inner(
                         tile_road_overrides,
                     )
                 })
-                .collect();
-            place_dur += place_start.elapsed();
+                .collect::<Vec<_>>()
+        };
 
-            let merge_start = std::time::Instant::now();
-            // Phase 2: merge this batch's results into the main editor (sequential).
-            // batch_results is dropped after this loop, freeing memory before next batch.
-            for (tile_idx, tile_world, tile_subway_pts, tile_road_overrides) in batch_results {
-                editor.merge_world(
-                    tile_world,
-                    tiles[tile_idx].min_x,
-                    tiles[tile_idx].min_z,
-                    tiles[tile_idx].max_x - 1,
-                    tiles[tile_idx].max_z - 1,
-                );
-                // Carry road-surface overrides to the main editor so the post-merge 3D-model
-                // pass stays road-aware. Under eviction keep only the deferred 3D regions'
-                // overrides (the rest are evicted; this caps the extra resident RAM).
-                if eviction_active {
-                    editor.merge_road_surface_overrides_in_regions(
-                        tile_road_overrides,
-                        &model_regions,
+        // Phase 2 (sequential): merge a batch's tile results into the shared `editor`,
+        // in the batch's authoritative order. This is the only writer of `editor` and
+        // the eviction bookkeeping, so the merge order is fixed regardless of whether a
+        // placement is overlapping — output stays bit-exact.
+        let mut merge_batch =
+            |batch_results: Vec<(usize, WorldToModify, Vec<(i32, i32)>, fnv::FnvHashMap<(i32, i32), i32>)>|
+             -> Result<(), String> {
+                for (tile_idx, tile_world, tile_subway_pts, tile_road_overrides) in batch_results {
+                    editor.merge_world(
+                        tile_world,
+                        tiles[tile_idx].min_x,
+                        tiles[tile_idx].min_z,
+                        tiles[tile_idx].max_x - 1,
+                        tiles[tile_idx].max_z - 1,
                     );
-                } else {
-                    editor.merge_road_surface_overrides(tile_road_overrides);
-                }
+                    // Carry road-surface overrides to the main editor so the post-merge 3D-model
+                    // pass stays road-aware. Under eviction keep only the deferred 3D regions'
+                    // overrides (the rest are evicted; this caps the extra resident RAM).
+                    if eviction_active {
+                        editor.merge_road_surface_overrides_in_regions(
+                            tile_road_overrides,
+                            &model_regions,
+                        );
+                    } else {
+                        editor.merge_road_surface_overrides(tile_road_overrides);
+                    }
 
-                if eviction_active {
-                    // This tile contributes to its own region and its 8 neighbours;
-                    // flush each non-deferred region whose contributors are all merged.
-                    // (Subways are carved in-tile above, so they don't defer regions.)
-                    let rt = region_of_tile[tile_idx];
-                    for dz in -1..=1 {
-                        for dx in -1..=1 {
-                            let d = (rt.0 + dx, rt.1 + dz);
-                            if let Some(c) = remaining.get_mut(&d) {
-                                *c -= 1;
-                                if *c == 0
-                                    && !evicted_regions.contains(&d)
-                                    && !model_regions.contains(&d)
-                                {
-                                    if hash_check {
-                                        hash_acc = hash_acc
-                                            .wrapping_add(editor.region_content_hash(d.0, d.1));
+                    if eviction_active {
+                        // This tile contributes to its own region and its 8 neighbours;
+                        // flush each non-deferred region whose contributors are all merged.
+                        // (Subways are carved in-tile above, so they don't defer regions.)
+                        let rt = region_of_tile[tile_idx];
+                        for dz in -1..=1 {
+                            for dx in -1..=1 {
+                                let d = (rt.0 + dx, rt.1 + dz);
+                                if let Some(c) = remaining.get_mut(&d) {
+                                    *c -= 1;
+                                    if *c == 0
+                                        && !evicted_regions.contains(&d)
+                                        && !model_regions.contains(&d)
+                                    {
+                                        if hash_check {
+                                            hash_acc = hash_acc.wrapping_add(
+                                                editor.region_content_hash(d.0, d.1),
+                                            );
+                                        }
+                                        if let Some(w) = flush_worker.as_ref() {
+                                            editor.flush_region_via(w, d.0, d.1)?;
+                                        }
+                                        evicted_regions.insert(d);
                                     }
-                                    if let Some(w) = flush_worker.as_ref() {
-                                        editor.flush_region_via(w, d.0, d.1)?;
-                                    }
-                                    evicted_regions.insert(d);
                                 }
                             }
                         }
                     }
+
+                    subway_points.extend(tile_subway_pts);
+
+                    // Step 20%->70% per merged tile, throttled to whole-percent steps.
+                    tiles_merged += 1;
+                    let pct = 20.0 + (tiles_merged as f64 / total_tiles as f64) * 50.0;
+                    if pct - last_emitted_pct >= 1.0 {
+                        emit_gui_progress_update_ex(pct, "Generating area...", eviction_active);
+                        last_emitted_pct = pct;
+                    }
                 }
+                Ok(())
+            };
 
-                subway_points.extend(tile_subway_pts);
-
-                // Step 20%->70% per merged tile, throttled to whole-percent steps.
-                tiles_merged += 1;
-                let pct = 20.0 + (tiles_merged as f64 / total_tiles as f64) * 50.0;
-                if pct - last_emitted_pct >= 1.0 {
-                    emit_gui_progress_update_ex(pct, "Generating area...", eviction_active);
-                    last_emitted_pct = pct;
+        // Opt-in (ARNIS_PIPELINE_MERGE): overlap the serial merge of batch N with the
+        // parallel placement of batch N+1 via rayon::join, so worker cores aren't idle
+        // during merges. Merge order is unchanged (in-order, batch by batch), so output
+        // is bit-exact vs. the default path — verify with --benchmark + ARNIS_BLOCK_HASH.
+        if std::env::var_os("ARNIS_PIPELINE_MERGE").is_some() {
+            let loop_start = std::time::Instant::now();
+            let mut pending: Option<Vec<_>> = None;
+            for batch in indexed_tiles.chunks(tile_batch_size) {
+                if let Some(prev) = pending.take() {
+                    // Place this batch while the previous batch merges.
+                    let (this_results, merge_res) =
+                        rayon::join(|| place_batch(batch), || merge_batch(prev));
+                    merge_res?;
+                    pending = Some(this_results);
+                } else {
+                    pending = Some(place_batch(batch));
                 }
             }
-            merge_dur += merge_start.elapsed();
+            if let Some(prev) = pending.take() {
+                merge_batch(prev)?;
+            }
+            // Overlapped: report wall-clock as placement, merge folded in.
+            place_dur = loop_start.elapsed();
+        } else {
+            // Default: place a batch, then merge it, repeat (cores idle during merge).
+            for batch in indexed_tiles.chunks(tile_batch_size) {
+                let place_start = std::time::Instant::now();
+                let batch_results = place_batch(batch);
+                place_dur += place_start.elapsed();
+
+                let merge_start = std::time::Instant::now();
+                merge_batch(batch_results)?;
+                merge_dur += merge_start.elapsed();
+            }
         }
         bench.report("element_placement", place_dur);
         bench.report("tile_merge", merge_dur);

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -647,70 +647,74 @@ fn generate_world_inner(
         // in the batch's authoritative order. This is the only writer of `editor` and
         // the eviction bookkeeping, so the merge order is fixed regardless of whether a
         // placement is overlapping — output stays bit-exact.
-        let mut merge_batch =
-            |batch_results: Vec<(usize, WorldToModify, Vec<(i32, i32)>, fnv::FnvHashMap<(i32, i32), i32>)>|
-             -> Result<(), String> {
-                for (tile_idx, tile_world, tile_subway_pts, tile_road_overrides) in batch_results {
-                    editor.merge_world(
-                        tile_world,
-                        tiles[tile_idx].min_x,
-                        tiles[tile_idx].min_z,
-                        tiles[tile_idx].max_x - 1,
-                        tiles[tile_idx].max_z - 1,
+        #[allow(clippy::type_complexity)]
+        let mut merge_batch = |batch_results: Vec<(
+            usize,
+            WorldToModify,
+            Vec<(i32, i32)>,
+            fnv::FnvHashMap<(i32, i32), i32>,
+        )>|
+         -> Result<(), String> {
+            for (tile_idx, tile_world, tile_subway_pts, tile_road_overrides) in batch_results {
+                editor.merge_world(
+                    tile_world,
+                    tiles[tile_idx].min_x,
+                    tiles[tile_idx].min_z,
+                    tiles[tile_idx].max_x - 1,
+                    tiles[tile_idx].max_z - 1,
+                );
+                // Carry road-surface overrides to the main editor so the post-merge 3D-model
+                // pass stays road-aware. Under eviction keep only the deferred 3D regions'
+                // overrides (the rest are evicted; this caps the extra resident RAM).
+                if eviction_active {
+                    editor.merge_road_surface_overrides_in_regions(
+                        tile_road_overrides,
+                        &model_regions,
                     );
-                    // Carry road-surface overrides to the main editor so the post-merge 3D-model
-                    // pass stays road-aware. Under eviction keep only the deferred 3D regions'
-                    // overrides (the rest are evicted; this caps the extra resident RAM).
-                    if eviction_active {
-                        editor.merge_road_surface_overrides_in_regions(
-                            tile_road_overrides,
-                            &model_regions,
-                        );
-                    } else {
-                        editor.merge_road_surface_overrides(tile_road_overrides);
-                    }
+                } else {
+                    editor.merge_road_surface_overrides(tile_road_overrides);
+                }
 
-                    if eviction_active {
-                        // This tile contributes to its own region and its 8 neighbours;
-                        // flush each non-deferred region whose contributors are all merged.
-                        // (Subways are carved in-tile above, so they don't defer regions.)
-                        let rt = region_of_tile[tile_idx];
-                        for dz in -1..=1 {
-                            for dx in -1..=1 {
-                                let d = (rt.0 + dx, rt.1 + dz);
-                                if let Some(c) = remaining.get_mut(&d) {
-                                    *c -= 1;
-                                    if *c == 0
-                                        && !evicted_regions.contains(&d)
-                                        && !model_regions.contains(&d)
-                                    {
-                                        if hash_check {
-                                            hash_acc = hash_acc.wrapping_add(
-                                                editor.region_content_hash(d.0, d.1),
-                                            );
-                                        }
-                                        if let Some(w) = flush_worker.as_ref() {
-                                            editor.flush_region_via(w, d.0, d.1)?;
-                                        }
-                                        evicted_regions.insert(d);
+                if eviction_active {
+                    // This tile contributes to its own region and its 8 neighbours;
+                    // flush each non-deferred region whose contributors are all merged.
+                    // (Subways are carved in-tile above, so they don't defer regions.)
+                    let rt = region_of_tile[tile_idx];
+                    for dz in -1..=1 {
+                        for dx in -1..=1 {
+                            let d = (rt.0 + dx, rt.1 + dz);
+                            if let Some(c) = remaining.get_mut(&d) {
+                                *c -= 1;
+                                if *c == 0
+                                    && !evicted_regions.contains(&d)
+                                    && !model_regions.contains(&d)
+                                {
+                                    if hash_check {
+                                        hash_acc = hash_acc
+                                            .wrapping_add(editor.region_content_hash(d.0, d.1));
                                     }
+                                    if let Some(w) = flush_worker.as_ref() {
+                                        editor.flush_region_via(w, d.0, d.1)?;
+                                    }
+                                    evicted_regions.insert(d);
                                 }
                             }
                         }
                     }
-
-                    subway_points.extend(tile_subway_pts);
-
-                    // Step 20%->70% per merged tile, throttled to whole-percent steps.
-                    tiles_merged += 1;
-                    let pct = 20.0 + (tiles_merged as f64 / total_tiles as f64) * 50.0;
-                    if pct - last_emitted_pct >= 1.0 {
-                        emit_gui_progress_update_ex(pct, "Generating area...", eviction_active);
-                        last_emitted_pct = pct;
-                    }
                 }
-                Ok(())
-            };
+
+                subway_points.extend(tile_subway_pts);
+
+                // Step 20%->70% per merged tile, throttled to whole-percent steps.
+                tiles_merged += 1;
+                let pct = 20.0 + (tiles_merged as f64 / total_tiles as f64) * 50.0;
+                if pct - last_emitted_pct >= 1.0 {
+                    emit_gui_progress_update_ex(pct, "Generating area...", eviction_active);
+                    last_emitted_pct = pct;
+                }
+            }
+            Ok(())
+        };
 
         // Opt-in (ARNIS_PIPELINE_MERGE): overlap the serial merge of batch N with the
         // parallel placement of batch N+1 via rayon::join, so worker cores aren't idle

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -253,7 +253,77 @@ fn should_stream_to_disk(num_regions: usize) -> bool {
 }
 
 /// Generate world with explicit format options (used by GUI for Bedrock support)
+/// Public entry point. Runs the whole generation inside a dedicated rayon
+/// thread pool sized to the user's CPU budget (`args.cpu_percent`).
+///
+/// A *scoped* pool is used instead of reconfiguring the global one because
+/// rayon's global pool can only be built once per process (it's already built
+/// at startup), so a per-run scoped pool is the only way to let the setting
+/// take effect on every generation without restarting the app. Every nested
+/// `par_iter` inside `generate_world_inner` (tile placement, region saving,
+/// flood-fill precompute, …) automatically runs on this pool via `install`.
+///
+/// `RAYON_NUM_THREADS`, if set, wins (power-user / benchmark override). If the
+/// pool can't be built we fall back to running on the global pool.
 pub fn generate_world_with_options(
+    elements: Vec<ProcessedElement>,
+    xzbbox: XZBBox,
+    llbbox: LLBBox,
+    ground: Ground,
+    args: &Args,
+    options: GenerationOptions,
+    outline_suppression: OutlineSuppression,
+) -> Result<PathBuf, String> {
+    let target_threads = generation_thread_count(args.cpu_percent);
+
+    match rayon::ThreadPoolBuilder::new()
+        .num_threads(target_threads)
+        .thread_name(|i| format!("arnis-gen-{i}"))
+        .build()
+    {
+        Ok(pool) => pool.install(move || {
+            generate_world_inner(
+                elements,
+                xzbbox,
+                llbbox,
+                ground,
+                args,
+                options,
+                outline_suppression,
+            )
+        }),
+        Err(_) => generate_world_inner(
+            elements,
+            xzbbox,
+            llbbox,
+            ground,
+            args,
+            options,
+            outline_suppression,
+        ),
+    }
+}
+
+/// Resolve the worker-thread count for generation from a CPU percentage.
+/// `RAYON_NUM_THREADS` overrides the percentage when set; otherwise the count
+/// is `round(cores * percent/100)`, clamped to at least 1.
+fn generation_thread_count(cpu_percent: u8) -> usize {
+    if let Some(n) = std::env::var("RAYON_NUM_THREADS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+    {
+        return n;
+    }
+
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    let fraction = f64::from(cpu_percent.clamp(10, 100)) / 100.0;
+    ((cores as f64 * fraction).round() as usize).max(1)
+}
+
+fn generate_world_inner(
     elements: Vec<ProcessedElement>,
     xzbbox: XZBBox,
     llbbox: LLBBox,

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -716,11 +716,14 @@ fn generate_world_inner(
             Ok(())
         };
 
-        // Opt-in (ARNIS_PIPELINE_MERGE): overlap the serial merge of batch N with the
-        // parallel placement of batch N+1 via rayon::join, so worker cores aren't idle
-        // during merges. Merge order is unchanged (in-order, batch by batch), so output
-        // is bit-exact vs. the default path — verify with --benchmark + ARNIS_BLOCK_HASH.
-        if std::env::var_os("ARNIS_PIPELINE_MERGE").is_some() {
+        // Opt-in (GUI "Faster merge" toggle / --pipeline-merge / ARNIS_PIPELINE_MERGE env):
+        // overlap the serial merge of batch N with the parallel placement of batch N+1 via
+        // rayon::join, so worker cores aren't idle during merges. Merge order is unchanged
+        // (in-order, batch by batch), so output is bit-exact vs. the default path — verify
+        // with --benchmark + ARNIS_BLOCK_HASH.
+        let pipeline_merge =
+            args.pipeline_merge || std::env::var_os("ARNIS_PIPELINE_MERGE").is_some();
+        if pipeline_merge {
             let loop_start = std::time::Instant::now();
             let mut pending: Option<Vec<_>> = None;
             for batch in indexed_tiles.chunks(tile_batch_size) {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -854,6 +854,7 @@ fn gui_start_generation(
     world_format: String,
     rotation_angle: f64,
     cpu_percent: u8,
+    pipeline_merge: bool,
 ) -> Result<(), String> {
     use progress::emit_gui_error;
     use LLBBox;
@@ -1105,6 +1106,7 @@ fn gui_start_generation(
                 downloader: "requests".to_string(),
                 scale: world_scale,
                 cpu_percent: cpu_percent.clamp(10, 100),
+                pipeline_merge,
                 projection: crate::projection::ProjectionKind::Local,
                 ground_level,
                 terrain: terrain_enabled,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -853,6 +853,7 @@ fn gui_start_generation(
     telemetry_consent: bool,
     world_format: String,
     rotation_angle: f64,
+    cpu_percent: u8,
 ) -> Result<(), String> {
     use progress::emit_gui_error;
     use LLBBox;
@@ -1103,6 +1104,7 @@ fn gui_start_generation(
                 luanti: world_format == WorldFormat::LuantiWorld,
                 downloader: "requests".to_string(),
                 scale: world_scale,
+                cpu_percent: cpu_percent.clamp(10, 100),
                 projection: crate::projection::ProjectionKind::Local,
                 ground_level,
                 terrain: terrain_enabled,

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -79,6 +79,30 @@
         </div>
 
         <div class="settings-scrollable">
+        <!-- Performance (top-level, not in a section) -->
+        <!-- CPU Usage Slider -->
+        <div class="settings-row">
+          <label for="cpu-usage-slider">
+            <span data-localize="cpu_usage">CPU Usage</span>
+            <span class="tooltip-icon" data-tooltip="Percentage of CPU cores used during world generation. Higher = more worker threads and faster generation, but a less responsive system. Double-click to reset.">?</span>
+          </label>
+          <div class="settings-control">
+            <input type="range" id="cpu-usage-slider" name="cpu-usage-slider" min="10" max="100" step="1" value="90">
+            <span id="cpu-usage-value">90%</span>
+          </div>
+        </div>
+
+        <!-- Faster Merge (pipelined) Toggle -->
+        <div class="settings-row">
+          <label for="pipeline-merge-toggle">
+            <span data-localize="pipeline_merge">Faster merge (beta)</span>
+            <span class="tooltip-icon" data-tooltip="Overlap each tile batch's merge with the next batch's placement so CPU cores aren't idle during merges. Faster on large areas; output is identical. Experimental.">?</span>
+          </label>
+          <div class="settings-control">
+            <input type="checkbox" id="pipeline-merge-toggle" name="pipeline-merge-toggle">
+          </div>
+        </div>
+
         <!-- Section: Generation -->
         <div class="settings-section-header" data-localize="settings_section_generation">Generation</div>
 
@@ -188,17 +212,6 @@
           </div>
         </div>
 
-        <!-- Faster Merge (pipelined) Toggle -->
-        <div class="settings-row">
-          <label for="pipeline-merge-toggle">
-            <span data-localize="pipeline_merge">Faster merge (beta)</span>
-            <span class="tooltip-icon" data-tooltip="Overlap each tile batch's merge with the next batch's placement so CPU cores aren't idle during merges. Faster on large areas; output is identical. Experimental.">?</span>
-          </label>
-          <div class="settings-control">
-            <input type="checkbox" id="pipeline-merge-toggle" name="pipeline-merge-toggle">
-          </div>
-        </div>
-
         <!-- World Scale Slider -->
         <div class="settings-row">
           <label for="scale-value-slider">
@@ -208,18 +221,6 @@
           <div class="settings-control">
             <input type="range" id="scale-value-slider" name="scale-value-slider" min="0.30" max="2.5" step="0.1" value="1">
             <span id="slider-value">1.00</span>
-          </div>
-        </div>
-
-        <!-- CPU Usage Slider -->
-        <div class="settings-row">
-          <label for="cpu-usage-slider">
-            <span data-localize="cpu_usage">CPU Usage</span>
-            <span class="tooltip-icon" data-tooltip="Percentage of CPU cores used during world generation. Higher = more worker threads and faster generation, but a less responsive system. Double-click to reset.">?</span>
-          </label>
-          <div class="settings-control">
-            <input type="range" id="cpu-usage-slider" name="cpu-usage-slider" min="10" max="100" step="1" value="90">
-            <span id="cpu-usage-value">90%</span>
           </div>
         </div>
 

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -188,6 +188,17 @@
           </div>
         </div>
 
+        <!-- Faster Merge (pipelined) Toggle -->
+        <div class="settings-row">
+          <label for="pipeline-merge-toggle">
+            <span data-localize="pipeline_merge">Faster merge (beta)</span>
+            <span class="tooltip-icon" data-tooltip="Overlap each tile batch's merge with the next batch's placement so CPU cores aren't idle during merges. Faster on large areas; output is identical. Experimental.">?</span>
+          </label>
+          <div class="settings-control">
+            <input type="checkbox" id="pipeline-merge-toggle" name="pipeline-merge-toggle">
+          </div>
+        </div>
+
         <!-- World Scale Slider -->
         <div class="settings-row">
           <label for="scale-value-slider">

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -200,6 +200,18 @@
           </div>
         </div>
 
+        <!-- CPU Usage Slider -->
+        <div class="settings-row">
+          <label for="cpu-usage-slider">
+            <span data-localize="cpu_usage">CPU Usage</span>
+            <span class="tooltip-icon" data-tooltip="Percentage of CPU cores used during world generation. Higher = more worker threads and faster generation, but a less responsive system. Double-click to reset.">?</span>
+          </label>
+          <div class="settings-control">
+            <input type="range" id="cpu-usage-slider" name="cpu-usage-slider" min="10" max="100" step="10" value="90">
+            <span id="cpu-usage-value">90%</span>
+          </div>
+        </div>
+
         <!-- Rotation Angle -->
         <div class="settings-row">
           <label for="rotation-angle-input">

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -218,7 +218,7 @@
             <span class="tooltip-icon" data-tooltip="Percentage of CPU cores used during world generation. Higher = more worker threads and faster generation, but a less responsive system. Double-click to reset.">?</span>
           </label>
           <div class="settings-control">
-            <input type="range" id="cpu-usage-slider" name="cpu-usage-slider" min="10" max="100" step="10" value="90">
+            <input type="range" id="cpu-usage-slider" name="cpu-usage-slider" min="10" max="100" step="1" value="90">
             <span id="cpu-usage-value">90%</span>
           </div>
         </div>

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -104,6 +104,7 @@ async function applyLocalization(localization) {
     "#world-name-label[data-placeholder]": "no_world_generated_yet",
     "h2[data-localize='customization_settings']": "customization_settings",
     "span[data-localize='world_scale']": "world_scale",
+    "span[data-localize='cpu_usage']": "cpu_usage",
     "span[data-localize='custom_bounding_box']": "custom_bounding_box",
     // DEPRECATED: Ground level localization removed
     // "label[data-localize='ground_level']": "ground_level",
@@ -715,6 +716,28 @@ function initSettings() {
     slider.value = 1;
     sliderValue.textContent = "1.00";
   });
+
+  // CPU usage slider: percentage of CPU cores used for world generation.
+  // Persisted to localStorage so the choice survives restarts.
+  const cpuSlider = document.getElementById("cpu-usage-slider");
+  const cpuValue = document.getElementById("cpu-usage-value");
+  if (cpuSlider && cpuValue) {
+    const savedCpu = localStorage.getItem("arnis-cpu-percent");
+    if (savedCpu !== null && !isNaN(parseInt(savedCpu, 10))) {
+      cpuSlider.value = Math.min(Math.max(parseInt(savedCpu, 10), 10), 100);
+    }
+    cpuValue.textContent = `${parseInt(cpuSlider.value, 10)}%`;
+    cpuSlider.addEventListener("input", () => {
+      cpuValue.textContent = `${parseInt(cpuSlider.value, 10)}%`;
+      localStorage.setItem("arnis-cpu-percent", cpuSlider.value);
+    });
+    // Double-click to reset CPU usage to default (90%)
+    cpuSlider.addEventListener("dblclick", () => {
+      cpuSlider.value = 90;
+      cpuValue.textContent = "90%";
+      localStorage.setItem("arnis-cpu-percent", "90");
+    });
+  }
 
   // Rotation angle input
   const rotationInput = document.getElementById("rotation-angle-input");
@@ -1577,6 +1600,7 @@ async function startGeneration() {
     var aws_only_elevation = document.getElementById("aws-only-elevation-toggle").checked;
     var bake_lighting = document.getElementById("bake-lighting-toggle").checked;
     var scale = parseFloat(document.getElementById("scale-value-slider").value);
+    var cpuPercent = parseInt(document.getElementById("cpu-usage-slider").value, 10) || 90;
     // var ground_level = parseInt(document.getElementById("ground-level").value, 10);
     // DEPRECATED: Ground level input removed from UI
     var ground_level = -62;
@@ -1610,7 +1634,8 @@ async function startGeneration() {
         spawnPoint: spawnPoint,
         telemetryConsent: telemetryConsent || false,
         worldFormat: getEffectiveWorldFormat(),
-        rotationAngle: rotationAngle
+        rotationAngle: rotationAngle,
+        cpuPercent: cpuPercent
     });
 
     console.log("Generation process started.");

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -122,6 +122,7 @@ async function applyLocalization(localization) {
     "span[data-localize='disable_height_limit']": "disable_height_limit",
     "span[data-localize='aws_only_elevation']": "aws_only_elevation",
     "span[data-localize='bake_lighting']": "bake_lighting",
+    "span[data-localize='pipeline_merge']": "pipeline_merge",
     "span[data-localize='anonymous_crash_reports']": "anonymous_crash_reports",
     "span[data-localize='map_theme']": "map_theme",
     "span[data-localize='save_path']": "save_path",
@@ -736,6 +737,15 @@ function initSettings() {
       cpuSlider.value = 90;
       cpuValue.textContent = "90%";
       localStorage.setItem("arnis-cpu-percent", "90");
+    });
+  }
+
+  // "Faster merge" toggle: persisted so the choice sticks across launches.
+  const pipelineToggle = document.getElementById("pipeline-merge-toggle");
+  if (pipelineToggle) {
+    pipelineToggle.checked = localStorage.getItem("arnis-pipeline-merge") === "1";
+    pipelineToggle.addEventListener("change", () => {
+      localStorage.setItem("arnis-pipeline-merge", pipelineToggle.checked ? "1" : "0");
     });
   }
 
@@ -1599,6 +1609,7 @@ async function startGeneration() {
     var disable_height_limit = document.getElementById("disable-height-limit-toggle").checked;
     var aws_only_elevation = document.getElementById("aws-only-elevation-toggle").checked;
     var bake_lighting = document.getElementById("bake-lighting-toggle").checked;
+    var pipeline_merge = document.getElementById("pipeline-merge-toggle").checked;
     var scale = parseFloat(document.getElementById("scale-value-slider").value);
     var cpuPercent = parseInt(document.getElementById("cpu-usage-slider").value, 10) || 90;
     // var ground_level = parseInt(document.getElementById("ground-level").value, 10);
@@ -1635,7 +1646,8 @@ async function startGeneration() {
         telemetryConsent: telemetryConsent || false,
         worldFormat: getEffectiveWorldFormat(),
         rotationAngle: rotationAngle,
-        cpuPercent: cpuPercent
+        cpuPercent: cpuPercent,
+        pipelineMerge: pipeline_merge
     });
 
     console.log("Generation process started.");

--- a/src/gui/locales/en-US.json
+++ b/src/gui/locales/en-US.json
@@ -10,6 +10,7 @@
   "winter_mode": "Winter Mode",
   "world_scale": "World Scale",
   "cpu_usage": "CPU Usage",
+  "pipeline_merge": "Faster merge (beta)",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Floodfill Timeout (sec)",
   "ground_level": "Ground Level",

--- a/src/gui/locales/en-US.json
+++ b/src/gui/locales/en-US.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Generation process started.",
   "winter_mode": "Winter Mode",
   "world_scale": "World Scale",
+  "cpu_usage": "CPU Usage",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Floodfill Timeout (sec)",
   "ground_level": "Ground Level",

--- a/src/gui/locales/zh-CN.json
+++ b/src/gui/locales/zh-CN.json
@@ -10,6 +10,7 @@
   "winter_mode": "冬季模式",
   "world_scale": "世界比例",
   "cpu_usage": "CPU 占用率",
+  "pipeline_merge": "加速合并（实验）",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "填充超时（秒）",
   "ground_level": "地面高度",

--- a/src/gui/locales/zh-CN.json
+++ b/src/gui/locales/zh-CN.json
@@ -9,6 +9,7 @@
   "generation_process_started": "生成过程已开始。",
   "winter_mode": "冬季模式",
   "world_scale": "世界比例",
+  "cpu_usage": "CPU 占用率",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "填充超时（秒）",
   "ground_level": "地面高度",

--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -173,6 +173,7 @@ pub fn fetch_data_from_overpass(
         nwr["advertising"];
         nwr["man_made"];
         nwr["aeroway"];
+        nwr["area:aeroway"];
         nwr["3dmr"];
         way["place"]["place"!~"^(ocean|sea|bay|strait|sound|fjord)$"];
     )->.relsinbbox;

--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -175,7 +175,6 @@ pub fn fetch_data_from_overpass(
         nwr["aeroway"];
         nwr["3dmr"];
         way["place"]["place"!~"^(ocean|sea|bay|strait|sound|fjord)$"];
-        way;
     )->.relsinbbox;
     (
         way(r.relsinbbox);


### PR DESCRIPTION
## Summary

Three independent improvements aimed at generating large areas faster, plus a small
follow-up fix. Only the Overpass query change affects default output; the new generation
feature is opt-in and defaults off.

### 1. Overpass: drop the unfiltered `way;` selector
The query included a bare `way;` that pulled **every** way in the bbox (and all their
nodes), regardless of tags. The renderer only dispatches ways with recognised tags
(building / highway / landuse / …), which already have explicit selectors, and multipolygon
member ways are still fetched via `way(r.relsinbbox)`. The bare selector only added data
that gets discarded — a major source of oversized responses, timeouts, and the resulting
multi-server retry cascade on large areas.
- Follow-up: added an explicit `nwr["area:aeroway"]` selector, because the renderer handles
  `area:aeroway` (airport aprons / taxiway polygons), which previously rode in only via the
  bare `way;`.

### 2. CPU-usage control
Generation now runs in a dedicated rayon pool sized to a new setting (`cpu_percent`,
default **90%**, range 10–100). A scoped pool is used because rayon's global pool can only
be built once per process, so this is the only way the setting can take effect per-run
without a restart. Exposed as a GUI "CPU Usage" slider and a `--cpu-percent` flag;
`RAYON_NUM_THREADS` still overrides. Lets users push past the previously hard-coded 90% cap.

### 3. Opt-in pipelined tile merge
Phase 2 (merging each tile into the shared editor) is sequential, so worker cores sit idle
during merges. Behind an opt-in toggle, batch N's merge now overlaps batch N+1's placement
via `rayon::join`. **Merge order is unchanged** (in-order, batch by batch), so output is
bit-exact vs. the default path. Enabled via a GUI "Faster merge" toggle, a `--pipeline-merge`
flag, or the `ARNIS_PIPELINE_MERGE` env var; **default off**.

## Testing
- CI green: `cargo build --all-targets --all-features --release`, clippy (`-D warnings`),
  and unit tests all pass.
- On a large metropolitan-area generation at 1:1 scale (~80×60 km, ~9,900 tiles), enabling
  the pipeline lowered the in-app ETA from ~9h39m to ~6h58m at the same progress point
  (~28% faster). This is an observation, not a controlled benchmark — output equivalence
  can be verified with `ARNIS_BLOCK_HASH=1` (the per-region content hash should match
  between the default and pipelined runs).

## Notes
- The three changes are logically independent; happy to split into separate PRs if preferred.