### PR TITLE
Add custom world name option

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -24,6 +24,11 @@ pub struct Args {
     #[arg(long = "output-dir", alias = "path")]
     pub path: Option<PathBuf>,
 
+    /// Custom name for the generated world (optional, default: auto-generated).
+    /// A counter suffix is appended if a world with that name already exists.
+    #[arg(long)]
+    pub world_name: Option<String>,
+
     /// Generate a Bedrock Edition world (.mcworld) instead of Java Edition
     #[arg(long)]
     pub bedrock: bool,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -279,7 +279,7 @@ fn gui_pick_save_directory(start_path: String) -> Result<String, String> {
 /// Creates a new Java Edition world in the given base save directory.
 /// Called when the user clicks "Create World".
 #[tauri::command]
-fn gui_create_world(save_path: String) -> Result<String, i32> {
+fn gui_create_world(save_path: String, world_name: Option<String>) -> Result<String, i32> {
     let trimmed = save_path.trim();
     if trimmed.is_empty() {
         return Err(3);
@@ -288,11 +288,11 @@ fn gui_create_world(save_path: String) -> Result<String, i32> {
     if !base.is_dir() {
         return Err(3); // Error code 3: Failed to create new world
     }
-    create_new_world(&base).map_err(|_| 3)
+    create_new_world(&base, world_name.as_deref()).map_err(|_| 3)
 }
 
-fn create_new_world(base_path: &Path) -> Result<String, String> {
-    crate::world_utils::create_new_world(base_path)
+fn create_new_world(base_path: &Path, custom_name: Option<&str>) -> Result<String, String> {
+    crate::world_utils::create_new_world(base_path, custom_name)
 }
 
 /// Adds localized area name to the world name in level.dat
@@ -932,6 +932,7 @@ fn gui_start_generation(
     gamemode: String,
     world_time: i64,
     map_item: bool,
+    world_name: Option<String>,
 ) -> Result<(), String> {
     use progress::emit_gui_error;
     use LLBBox;
@@ -1107,24 +1108,21 @@ fn gui_start_generation(
                     (updated_path, None)
                 }
                 WorldFormat::BedrockMcWorld => {
-                    // Bedrock: generate .mcworld on Desktop with location-based name
+                    // Bedrock: generate .mcworld on Desktop with custom or location-based name
                     let output_dir = crate::world_utils::get_bedrock_output_directory();
-                    let (output_path, lvl_name) =
-                        crate::world_utils::build_bedrock_output(&bbox, output_dir);
+                    let (output_path, lvl_name) = crate::world_utils::build_bedrock_output(
+                        &bbox,
+                        output_dir,
+                        world_name.as_deref(),
+                    );
                     progress::emit_world_name_update(&lvl_name);
                     (output_path, Some(lvl_name))
                 }
                 WorldFormat::LuantiWorld => {
                     let worlds_dir = crate::world_utils::get_luanti_worlds_directory();
                     let _ = std::fs::create_dir_all(&worlds_dir);
-                    let mut counter = 1;
-                    let world_name = loop {
-                        let candidate = format!("Arnis Luanti World {counter}");
-                        if !worlds_dir.join(&candidate).exists() {
-                            break candidate;
-                        }
-                        counter += 1;
-                    };
+                    let world_name =
+                        crate::world_utils::luanti_world_name(&worlds_dir, world_name.as_deref());
                     let luanti_path = worlds_dir.join(&world_name);
                     println!(
                         "Creating Luanti world at: {}",
@@ -1180,6 +1178,9 @@ fn gui_start_generation(
                 } else {
                     world_path
                 }),
+                // World naming is already resolved above (create_new_world /
+                // build_bedrock_output / luanti_world_name), so Args doesn't need it.
+                world_name: None,
                 bedrock: world_format == WorldFormat::BedrockMcWorld,
                 luanti: world_format == WorldFormat::LuantiWorld,
                 downloader: "requests".to_string(),

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -166,6 +166,17 @@
         <!-- Section: World -->
         <div class="settings-section-header" data-localize="settings_section_world">World</div>
 
+        <!-- World Name Input -->
+        <div class="settings-row">
+          <label for="world-name-input">
+            <span data-localize="world_name">World Name</span>
+            <span class="tooltip-icon" data-tooltip="Custom name for the generated world. Leave empty for an auto-generated name.">?</span>
+          </label>
+          <div class="settings-control">
+            <input type="text" id="world-name-input" name="world-name-input" maxlength="64" placeholder="Arnis World (auto)">
+          </div>
+        </div>
+
         <!-- Game Mode -->
         <div class="settings-row">
           <label>

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -125,6 +125,7 @@ async function applyLocalization(localization) {
     "span[data-localize='map_theme']": "map_theme",
     "span[data-localize='save_path']": "save_path",
     "span[data-localize='rotation_angle']": "rotation_angle",
+    "span[data-localize='world_name']": "world_name",
     "span[data-localize='gamemode']": "gamemode",
     "button[data-localize='gamemode_survival']": "gamemode_survival",
     "button[data-localize='gamemode_creative']": "gamemode_creative",
@@ -750,6 +751,21 @@ function initSettings() {
   timeSlider.addEventListener("dblclick", () => {
     timeSlider.value = 720;
     timeValue.textContent = formatClock(720);
+  });
+
+  // World name input: preview the upcoming name under the Start button so
+  // it's visible that the custom name applies without a save step
+  const worldNameInput = document.getElementById("world-name-input");
+  worldNameInput.addEventListener("input", () => {
+    const custom = worldNameInput.value.trim();
+    const label = document.getElementById("world-name-label");
+    if (!label) return;
+    if (custom) {
+      label.removeAttribute("data-placeholder");
+      label.textContent = custom;
+    } else {
+      setWorldNameLabel(lastGeneratedWorldName);
+    }
   });
 
   // Rotation angle input
@@ -1513,8 +1529,10 @@ function displayBboxInfoText(bboxText) {
 }
 
 let worldPath = "";
+let lastGeneratedWorldName = "";
 
 function setWorldNameLabel(text) {
+  lastGeneratedWorldName = text || "";
   const label = document.getElementById('world-name-label');
   if (!label) return;
   if (text) {
@@ -1571,6 +1589,9 @@ async function startGeneration() {
       return;
     }
 
+    // Custom world name (empty input means auto-generated name)
+    const customWorldName = (document.getElementById('world-name-input')?.value || '').trim() || null;
+
     // Auto-create world for Java format
     if (selectedWorldFormat === 'java') {
       if (!savePath) {
@@ -1578,7 +1599,7 @@ async function startGeneration() {
         return;
       }
       try {
-        const worldName = await invoke('gui_create_world', { savePath: savePath });
+        const worldName = await invoke('gui_create_world', { savePath: savePath, worldName: customWorldName });
         if (worldName) {
           worldPath = worldName;
           setWorldNameLabel(basenameFromPath(worldName));
@@ -1661,7 +1682,8 @@ async function startGeneration() {
         rotationAngle: rotationAngle,
         gamemode: gamemode,
         worldTime: worldTime,
-        mapItem: mapItem
+        mapItem: mapItem,
+        worldName: customWorldName
     });
 
     console.log("Generation process started.");

--- a/src/gui/locales/ar.json
+++ b/src/gui/locales/ar.json
@@ -9,6 +9,7 @@
   "generation_process_started": "بدأت عملية البناء.",
   "winter_mode": "وضع الشتاء",
   "world_scale": "مقياس العالم",
+  "world_name": "اسم العالم",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "مهلة ملء الفيضان (ثواني)",
   "ground_level": "مستوى الأرض",

--- a/src/gui/locales/de.json
+++ b/src/gui/locales/de.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Generierungsprozess gestartet.",
   "winter_mode": "Wintermodus",
   "world_scale": "Weltmaßstab",
+  "world_name": "Weltname",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Floodfill-Timeout (Sek)",
   "ground_level": "Bodenhöhe",

--- a/src/gui/locales/en-US.json
+++ b/src/gui/locales/en-US.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Generation process started.",
   "winter_mode": "Winter Mode",
   "world_scale": "World Scale",
+  "world_name": "World Name",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Floodfill Timeout (sec)",
   "ground_level": "Ground Level",

--- a/src/gui/locales/es.json
+++ b/src/gui/locales/es.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Proceso de generación iniciado.",
   "winter_mode": "Modo invierno",
   "world_scale": "Escala del mundo",
+  "world_name": "Nombre del mundo",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Tiempo de espera de relleno (seg)",
   "ground_level": "Nivel del suelo",

--- a/src/gui/locales/fi.json
+++ b/src/gui/locales/fi.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Luontiprosessi aloitettu.",
   "winter_mode": "Talvitila",
   "world_scale": "Maailmanskaalaus",
+  "world_name": "Maailman nimi",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Täytön aikakatkaisu (sec)",
   "ground_level": "Maataso",

--- a/src/gui/locales/fr-FR.json
+++ b/src/gui/locales/fr-FR.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Processus de génération commencé.",
   "winter_mode": "Mode hiver",
   "world_scale": "Échelle du monde",
+  "world_name": "Nom du monde",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Expiration du délai de remplissage (en secondes)",
   "ground_level": "Niveau du sol",

--- a/src/gui/locales/hu.json
+++ b/src/gui/locales/hu.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Generálási folyamat elkezdődött",
   "winter_mode": "Téli mód",
   "world_scale": "Világ nagysága",
+  "world_name": "Világ neve",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Floodfill Timeout (sec)",
   "ground_level": "Földszint",

--- a/src/gui/locales/ja.json
+++ b/src/gui/locales/ja.json
@@ -9,6 +9,7 @@
   "generation_process_started": "生成処理を開始しました。",
   "winter_mode": "冬モード",
   "world_scale": "ワールド倍率",
+  "world_name": "ワールド名",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "フラッドフィルのタイムアウト（秒）",
   "ground_level": "地面レベル",

--- a/src/gui/locales/ko.json
+++ b/src/gui/locales/ko.json
@@ -9,6 +9,7 @@
   "generation_process_started": "생성 프로세스가 시작되었습니다.",
   "winter_mode": "겨울 모드",
   "world_scale": "세계 규모",
+  "world_name": "월드 이름",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "채우기 시간 초과 (초)",
   "ground_level": "지면 레벨",

--- a/src/gui/locales/lt.json
+++ b/src/gui/locales/lt.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Generacijos procesas pradėtas.",
   "winter_mode": "Žiemos režimas",
   "world_scale": "Pasaulio mastelis",
+  "world_name": "Pasaulio pavadinimas",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Užpildymo laiko limitas (sek.)",
   "ground_level": "Žemės lygis",

--- a/src/gui/locales/lv.json
+++ b/src/gui/locales/lv.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Ģenerēšanas process uzsākts",
   "winter_mode": "Ziemas režīms",
   "world_scale": "Pasaules mērogs",
+  "world_name": "Pasaules nosaukums",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Aizpildes noildze (sek.)",
   "ground_level": "Zemes līmenis",

--- a/src/gui/locales/pl.json
+++ b/src/gui/locales/pl.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Proces generowania rozpoczęty.",
   "winter_mode": "Tryb Zimowy",
   "world_scale": "Skala świata",
+  "world_name": "Nazwa świata",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Limit czasu wypełniania (sek)",
   "ground_level": "Wysokość obszaru",

--- a/src/gui/locales/pt-BR.json
+++ b/src/gui/locales/pt-BR.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Processo de geração iniciado.",
   "winter_mode": "Modo inverno",
   "world_scale": "Escala do mundo",
+  "world_name": "Nome do mundo",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Tempo limite do floodfill (seg)",
   "ground_level": "Nível do solo",

--- a/src/gui/locales/ru.json
+++ b/src/gui/locales/ru.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Процесс генерации начат",
   "winter_mode": "Зимний режим",
   "world_scale": "Масштаб мира",
+  "world_name": "Название мира",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Тайм-аут заливки (сек)",
   "ground_level": "Уровень земли",

--- a/src/gui/locales/sl.json
+++ b/src/gui/locales/sl.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Postopek generiranja se je začel.",
   "winter_mode": "Zimski način",
   "world_scale": "Merilo sveta",
+  "world_name": "Ime sveta",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Časovna omejitev zapolnjevanja (sek)",
   "ground_level": "Nivo tal",

--- a/src/gui/locales/sv.json
+++ b/src/gui/locales/sv.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Genereringsprocessen startad.",
   "winter_mode": "Vinterläge",
   "world_scale": "Världsskala",
+  "world_name": "Världens namn",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Floodfill-tidsgräns (sek)",
   "ground_level": "Marknivå",

--- a/src/gui/locales/ua.json
+++ b/src/gui/locales/ua.json
@@ -9,6 +9,7 @@
   "generation_process_started": "Процес генерації розпочато",
   "winter_mode": "Зимовий режим",
   "world_scale": "Масштаб світу",
+  "world_name": "Назва світу",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "Тайм-аут заливки (сек)",
   "ground_level": "Рівень землі",

--- a/src/gui/locales/zh-CN.json
+++ b/src/gui/locales/zh-CN.json
@@ -9,6 +9,7 @@
   "generation_process_started": "生成过程已开始。",
   "winter_mode": "冬季模式",
   "world_scale": "世界比例",
+  "world_name": "世界名称",
   "custom_bounding_box": "Bounding Box",
   "floodfill_timeout": "填充超时（秒）",
   "ground_level": "地面高度",

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,8 @@ fn run_cli() {
             .path
             .clone()
             .unwrap_or_else(world_utils::get_bedrock_output_directory);
-        let (output_path, lvl_name) = world_utils::build_bedrock_output(&args.bbox, output_dir);
+        let (output_path, lvl_name) =
+            world_utils::build_bedrock_output(&args.bbox, output_dir, args.world_name.as_deref());
         (output_path, Some(lvl_name))
     } else if args.luanti {
         let base_dir = args
@@ -176,14 +177,7 @@ fn run_cli() {
             .clone()
             .unwrap_or_else(world_utils::get_luanti_worlds_directory);
         let _ = std::fs::create_dir_all(&base_dir);
-        let mut counter = 1;
-        let world_name = loop {
-            let candidate = format!("Arnis Luanti World {counter}");
-            if !base_dir.join(&candidate).exists() {
-                break candidate;
-            }
-            counter += 1;
-        };
+        let world_name = world_utils::luanti_world_name(&base_dir, args.world_name.as_deref());
         let world_path = base_dir.join(&world_name);
         println!(
             "Creating Luanti world at: {}",
@@ -193,7 +187,8 @@ fn run_cli() {
     } else {
         // Java: create a new world in the provided output directory
         let base_dir = args.path.clone().unwrap();
-        let world_path = match world_utils::create_new_world(&base_dir) {
+        let world_path = match world_utils::create_new_world(&base_dir, args.world_name.as_deref())
+        {
             Ok(path) => PathBuf::from(path),
             Err(e) => {
                 eprintln!("{} {}", "Error:".red().bold(), e);

--- a/src/map_item.rs
+++ b/src/map_item.rs
@@ -310,8 +310,9 @@ mod tests {
     #[test]
     fn writes_map_files_and_inventory_item() {
         let tmp = tempfile::tempdir().unwrap();
-        let world =
-            std::path::PathBuf::from(crate::world_utils::create_new_world(tmp.path()).unwrap());
+        let world = std::path::PathBuf::from(
+            crate::world_utils::create_new_world(tmp.path(), None).unwrap(),
+        );
         let xzbbox = XZBBox::rect_from_xz_lengths(300.0, 100.0).unwrap();
         let preview = PreviewAccumulator::new(&xzbbox);
         write_map_item(&world, &preview, &xzbbox).unwrap();
@@ -360,8 +361,9 @@ mod tests {
     #[test]
     fn oversized_world_disables_the_player_marker() {
         let tmp = tempfile::tempdir().unwrap();
-        let world =
-            std::path::PathBuf::from(crate::world_utils::create_new_world(tmp.path()).unwrap());
+        let world = std::path::PathBuf::from(
+            crate::world_utils::create_new_world(tmp.path(), None).unwrap(),
+        );
         let xzbbox = XZBBox::rect_from_xz_lengths(3000.0, 3000.0).unwrap();
         let preview = PreviewAccumulator::new(&xzbbox);
         write_map_item(&world, &preview, &xzbbox).unwrap();
@@ -379,8 +381,9 @@ mod tests {
     #[test]
     fn preserves_user_items_and_dodges_occupied_slot_zero() {
         let tmp = tempfile::tempdir().unwrap();
-        let world =
-            std::path::PathBuf::from(crate::world_utils::create_new_world(tmp.path()).unwrap());
+        let world = std::path::PathBuf::from(
+            crate::world_utils::create_new_world(tmp.path(), None).unwrap(),
+        );
 
         // Seed: a sword in slot 0 and the user's own map in slot 5.
         let mut root = read_gzip_nbt(&world.join("level.dat")).unwrap();
@@ -434,8 +437,9 @@ mod tests {
     #[test]
     fn respects_existing_idcounts_and_replaces_old_item() {
         let tmp = tempfile::tempdir().unwrap();
-        let world =
-            std::path::PathBuf::from(crate::world_utils::create_new_world(tmp.path()).unwrap());
+        let world = std::path::PathBuf::from(
+            crate::world_utils::create_new_world(tmp.path(), None).unwrap(),
+        );
         let data_dir = world.join("data");
         std::fs::create_dir_all(&data_dir).unwrap();
         write_gzip_nbt(

--- a/src/world_utils.rs
+++ b/src/world_utils.rs
@@ -84,9 +84,56 @@ pub fn sanitize_for_filename(name: &str) -> String {
     }
 }
 
+/// Returns a trimmed custom name, or None if the input is missing or blank.
+fn normalize_custom_name(custom_name: Option<&str>) -> Option<&str> {
+    custom_name.map(str::trim).filter(|s| !s.is_empty())
+}
+
+/// Returns a world name that doesn't collide with an existing entry in
+/// `base_dir` by appending an increasing counter (`Name`, `Name 2`, `Name 3`, ...).
+pub fn unique_world_name(base_dir: &Path, desired: &str) -> String {
+    if !base_dir.join(desired).exists() {
+        return desired.to_string();
+    }
+    let mut counter = 2;
+    loop {
+        let candidate = format!("{desired} {counter}");
+        if !base_dir.join(&candidate).exists() {
+            return candidate;
+        }
+        counter += 1;
+    }
+}
+
+/// Picks the Luanti world directory name: the sanitized custom name if given,
+/// otherwise the next free "Arnis Luanti World N".
+pub fn luanti_world_name(worlds_dir: &Path, custom_name: Option<&str>) -> String {
+    if let Some(name) = normalize_custom_name(custom_name) {
+        return unique_world_name(worlds_dir, &sanitize_for_filename(name));
+    }
+    let mut counter = 1;
+    loop {
+        let candidate = format!("Arnis Luanti World {counter}");
+        if !worlds_dir.join(&candidate).exists() {
+            return candidate;
+        }
+        counter += 1;
+    }
+}
+
 /// Builds the Bedrock output path and level name for a given bounding box.
-/// Combines area name lookup, sanitization, and path construction.
-pub fn build_bedrock_output(bbox: &LLBBox, output_dir: PathBuf) -> (PathBuf, String) {
+/// Uses the custom name if given, otherwise combines area name lookup,
+/// sanitization, and path construction.
+pub fn build_bedrock_output(
+    bbox: &LLBBox,
+    output_dir: PathBuf,
+    custom_name: Option<&str>,
+) -> (PathBuf, String) {
+    if let Some(name) = normalize_custom_name(custom_name) {
+        let safe_name = sanitize_for_filename(name);
+        let filename = format!("{safe_name}.mcworld");
+        return (output_dir.join(&filename), name.to_string());
+    }
     let area_name = get_area_name_for_bedrock(bbox);
     let safe_name = sanitize_for_filename(&area_name);
     let filename = format!("Arnis {safe_name}.mcworld");
@@ -96,37 +143,43 @@ pub fn build_bedrock_output(bbox: &LLBBox, output_dir: PathBuf) -> (PathBuf, Str
 
 /// Creates a new Java Edition world in the given base directory.
 ///
-/// Generates a unique "Arnis World N" name, creates the directory structure
-/// (with a `region/` subdirectory), writes the region template, level.dat
-/// (with updated name, timestamp, and spawn position), and icon.png.
+/// Uses the sanitized custom name if given (with a counter suffix on
+/// collision), otherwise generates a unique "Arnis World N" name. Creates the
+/// directory structure (with a `region/` subdirectory), writes the region
+/// template, level.dat (with updated name, timestamp, and spawn position),
+/// and icon.png.
 ///
 /// Returns the full path to the newly created world directory.
-pub fn create_new_world(base_path: &Path) -> Result<String, String> {
-    // Generate a unique world name with proper counter
-    // Check for both "Arnis World X" and "Arnis World X: Location" patterns
-    let mut counter: i32 = 1;
-    let unique_name: String = loop {
-        let candidate_name: String = format!("Arnis World {counter}");
-        let candidate_path: PathBuf = base_path.join(&candidate_name);
+pub fn create_new_world(base_path: &Path, custom_name: Option<&str>) -> Result<String, String> {
+    let unique_name: String = if let Some(name) = normalize_custom_name(custom_name) {
+        unique_world_name(base_path, &sanitize_for_filename(name))
+    } else {
+        // Generate a unique world name with proper counter
+        // Check for both "Arnis World X" and "Arnis World X: Location" patterns
+        let mut counter: i32 = 1;
+        loop {
+            let candidate_name: String = format!("Arnis World {counter}");
+            let candidate_path: PathBuf = base_path.join(&candidate_name);
 
-        // Check for exact match (no location suffix)
-        let exact_match_exists = candidate_path.exists();
+            // Check for exact match (no location suffix)
+            let exact_match_exists = candidate_path.exists();
 
-        // Check for worlds with location suffix (Arnis World X: Location)
-        let location_pattern = format!("Arnis World {counter}: ");
-        let location_match_exists = fs::read_dir(base_path)
-            .map(|entries| {
-                entries
-                    .filter_map(Result::ok)
-                    .filter_map(|entry| entry.file_name().into_string().ok())
-                    .any(|name| name.starts_with(&location_pattern))
-            })
-            .unwrap_or(false);
+            // Check for worlds with location suffix (Arnis World X: Location)
+            let location_pattern = format!("Arnis World {counter}: ");
+            let location_match_exists = fs::read_dir(base_path)
+                .map(|entries| {
+                    entries
+                        .filter_map(Result::ok)
+                        .filter_map(|entry| entry.file_name().into_string().ok())
+                        .any(|name| name.starts_with(&location_pattern))
+                })
+                .unwrap_or(false);
 
-        if !exact_match_exists && !location_match_exists {
-            break candidate_name;
+            if !exact_match_exists && !location_match_exists {
+                break candidate_name;
+            }
+            counter += 1;
         }
-        counter += 1;
     };
 
     let new_world_path: PathBuf = base_path.join(&unique_name);
@@ -488,9 +541,42 @@ mod tests {
     use super::*;
 
     #[test]
+    fn create_new_world_uses_custom_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world = PathBuf::from(create_new_world(tmp.path(), Some("My City")).unwrap());
+        assert_eq!(world.file_name().unwrap(), "My City");
+
+        // A second world with the same name gets a counter suffix
+        let world2 = PathBuf::from(create_new_world(tmp.path(), Some("My City")).unwrap());
+        assert_eq!(world2.file_name().unwrap(), "My City 2");
+
+        // Blank names fall back to the default naming scheme
+        let world3 = PathBuf::from(create_new_world(tmp.path(), Some("   ")).unwrap());
+        assert_eq!(world3.file_name().unwrap(), "Arnis World 1");
+    }
+
+    #[test]
+    fn custom_name_is_sanitized_for_filesystem() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world = PathBuf::from(create_new_world(tmp.path(), Some("Berlin: Mitte")).unwrap());
+        assert_eq!(world.file_name().unwrap(), "Berlin_ Mitte");
+    }
+
+    #[test]
+    fn luanti_world_name_prefers_custom_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(luanti_world_name(tmp.path(), Some("My City")), "My City");
+        assert_eq!(luanti_world_name(tmp.path(), None), "Arnis Luanti World 1");
+        assert_eq!(
+            luanti_world_name(tmp.path(), Some("  ")),
+            "Arnis Luanti World 1"
+        );
+    }
+
+    #[test]
     fn apply_java_world_settings_writes_gametype_and_daytime() {
         let tmp = tempfile::tempdir().unwrap();
-        let world = PathBuf::from(create_new_world(tmp.path()).unwrap());
+        let world = PathBuf::from(create_new_world(tmp.path(), None).unwrap());
         apply_java_world_settings(&world, crate::args::GameMode::Survival, 13000).unwrap();
 
         let raw = fs::read(world.join("level.dat")).unwrap();


### PR DESCRIPTION
Closes #1122

Adds an optional World Name setting (GUI, settings > World) and a `--world-name` CLI flag. Applies to Java, Bedrock and Luanti; a counter suffix is appended on name collisions. Empty name keeps the current auto-generated naming. Happy to move the input onto the main panel instead if you prefer.