### PR TITLE
Add local .osm file support with auto-derived bbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "nbtx",
  "once_cell",
  "parquet",
+ "quick-xml 0.41.0",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",
@@ -3887,7 +3888,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -4097,6 +4098,15 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -6628,7 +6638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.4",
  "quote",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ zip = { version = "0.6", default-features = false, features = ["deflate"] }
 rusty-leveldb = "3"
 rusqlite = { version = "0.40", features = ["bundled"] }
 zstd = "0.13"
+quick-xml = "0.41.0"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.0", features = ["Win32_System_Console"] }

--- a/src/args.rs
+++ b/src/args.rs
@@ -7,9 +7,11 @@ use std::time::Duration;
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 pub struct Args {
-    /// Bounding box of the area (min_lat,min_lng,max_lat,max_lng) (required)
+    /// Bounding box of the area (min_lat,min_lng,max_lat,max_lng).
+    /// Required unless --file supplies a local .osm/.xml file to derive it from
+    /// (terrain-only mode ignores --file, so it always requires --bbox).
     #[arg(long, allow_hyphen_values = true, value_parser = LLBBox::from_str)]
-    pub bbox: LLBBox,
+    pub bbox: Option<LLBBox>,
 
     /// JSON file containing OSM data (optional)
     #[arg(long, group = "location")]
@@ -242,6 +244,23 @@ pub fn validate_args(args: &Args) -> Result<(), String> {
         return Err("--map-preview is not supported for Luanti worlds.".to_string());
     }
 
+    // A bounding box is required unless a local --file supplies one to derive it from.
+    // Terrain-only mode ignores --file (it never loads OSM objects), so it always needs --bbox.
+    if args.bbox.is_none() {
+        if args.skip_objects() {
+            return Err(
+                "--mode terrain-only requires --bbox (a local --file is ignored in terrain-only mode)."
+                    .to_string(),
+            );
+        }
+        if args.file.is_none() {
+            return Err(
+                "Provide --bbox, or --file with a local .osm/.xml file to derive the bounding box from."
+                    .to_string(),
+            );
+        }
+    }
+
     if args.bedrock {
         // Bedrock: path is optional; if provided, it must be an existing directory
         if let Some(ref path) = args.path {
@@ -295,12 +314,15 @@ pub fn validate_args(args: &Args) -> Result<(), String> {
             let llpoint =
                 LLPoint::new(lat, lng).map_err(|e| format!("Invalid spawn coordinates: {e}"))?;
 
-            // Validate that spawn point is within the bounding box
-            if !args.bbox.contains(&llpoint) {
-                return Err(
-                    "Spawn point (--spawn-lat, --spawn-lng) must be within the bounding box."
-                        .to_string(),
-                );
+            // Validate that spawn point is within the bounding box. Only enforceable when the
+            // bbox is known up front; a file-derived bbox isn't available until the file is parsed.
+            if let Some(bbox) = args.bbox {
+                if !bbox.contains(&llpoint) {
+                    return Err(
+                        "Spawn point (--spawn-lat, --spawn-lng) must be within the bounding box."
+                            .to_string(),
+                    );
+                }
             }
         }
         _ => {}
@@ -529,8 +551,11 @@ mod tests {
         let tmpdir = tempfile::tempdir().unwrap();
         let tmp_path = tmpdir.path().to_str().unwrap();
 
+        // `arnis` alone now parses (--bbox is optional at the CLI layer), but validation
+        // rejects it: no output dir, and neither --bbox nor --file.
         let cmd = ["arnis"];
-        assert!(Args::try_parse_from(cmd.iter()).is_err());
+        let args = Args::try_parse_from(cmd.iter()).unwrap();
+        assert!(validate_args(&args).is_err());
 
         let cmd = ["arnis", "--output-dir", tmp_path, "--bbox", "1,2,3,4"];
         let args = Args::try_parse_from(cmd.iter()).unwrap();
@@ -541,12 +566,51 @@ mod tests {
         let args = Args::try_parse_from(cmd.iter()).unwrap();
         assert!(validate_args(&args).is_ok());
 
-        let cmd = ["arnis", "--output-dir", tmp_path, "--file", ""];
-        assert!(Args::try_parse_from(cmd.iter()).is_err());
+        // #881: --file without --bbox is accepted; the bbox is derived from the file later.
+        let cmd = ["arnis", "--output-dir", tmp_path, "--file", "area.osm"];
+        let args = Args::try_parse_from(cmd.iter()).unwrap();
+        assert!(validate_args(&args).is_ok());
+
+        // Neither --bbox nor --file (even with an output dir) is a validation error.
+        let cmd = ["arnis", "--output-dir", tmp_path];
+        let args = Args::try_parse_from(cmd.iter()).unwrap();
+        assert!(validate_args(&args).is_err());
 
         // The --gui flag isn't used here, ugh. TODO clean up main.rs and its argparse usage.
         // let cmd = ["arnis", "--gui"];
         // assert!(Args::try_parse_from(cmd.iter()).is_ok());
+    }
+
+    #[test]
+    fn test_terrain_only_requires_bbox_even_with_file() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let tmp_path = tmpdir.path().to_str().unwrap();
+
+        // terrain-only ignores --file, so a bbox is still required.
+        let cmd = [
+            "arnis",
+            "--output-dir",
+            tmp_path,
+            "--file",
+            "area.osm",
+            "--mode",
+            "terrain-only",
+        ];
+        let args = Args::try_parse_from(cmd.iter()).unwrap();
+        assert!(validate_args(&args).is_err());
+
+        // With --bbox it validates.
+        let cmd = [
+            "arnis",
+            "--output-dir",
+            tmp_path,
+            "--bbox",
+            "1,2,3,4",
+            "--mode",
+            "terrain-only",
+        ];
+        let args = Args::try_parse_from(cmd.iter()).unwrap();
+        assert!(validate_args(&args).is_ok());
     }
 
     #[test]

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -560,7 +560,7 @@ pub fn generate_world_with_options(
     ground.warm_water_blend();
     // Load the schematic tree pack once (None keeps procedural trees); shared with tile editors.
     let tree_pack =
-        crate::trees::tree_pack::load(args, args.scale, args.ground_level).map(Arc::new);
+        crate::trees::tree_pack::load(args, llbbox, args.scale, args.ground_level).map(Arc::new);
     let mut bench = crate::bench::Bench::new(args.benchmark);
 
     // Per-cell water depth field from the LC_WATER mask; empty without land cover.
@@ -623,7 +623,7 @@ pub fn generate_world_with_options(
     let tunnel_internal_endpoints = highways::collect_tunnel_internal_endpoints(&elements);
 
     // Resolved before the 3D archetypes so they never claim a landmark's element.
-    let landmarks = crate::landmarks::prescan(&elements, &xzbbox, args);
+    let landmarks = crate::landmarks::prescan(&elements, &xzbbox, llbbox, args);
 
     // 3D model pipeline pre-scan: elements rendered as 3D models instead of
     // voxels are recorded here and skipped by the element loop below.
@@ -1250,10 +1250,10 @@ pub fn generate_world_with_options(
         let png_path = map_preview::preview_output_path(&output_path, world_format);
         let result = map_preview::PreviewResult {
             png_path: png_path.clone(),
-            min_lat: args.bbox.min().lat(),
-            max_lat: args.bbox.max().lat(),
-            min_lon: args.bbox.min().lng(),
-            max_lon: args.bbox.max().lng(),
+            min_lat: llbbox.min().lat(),
+            max_lat: llbbox.max().lat(),
+            min_lon: llbbox.min().lng(),
+            max_lon: llbbox.max().lng(),
             min_mc_x: xzbbox.min_x(),
             max_mc_x: xzbbox.max_x(),
             min_mc_z: xzbbox.min_z(),

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -880,11 +880,11 @@ impl Ground {
     }
 }
 
-pub fn generate_ground_data(args: &Args) -> Ground {
+pub fn generate_ground_data(args: &Args, bbox: LLBBox) -> Ground {
     if args.terrain() {
         println!("{} Fetching elevation...", "[3/7]".bold());
         let ground = Ground::new_enabled(
-            &args.bbox,
+            &bbox,
             args.scale,
             args.ground_level,
             args.disable_height_limit,
@@ -901,12 +901,7 @@ pub fn generate_ground_data(args: &Args) -> Ground {
         return ground;
     }
     println!("{} Fetching land cover...", "[3/7]".bold());
-    Ground::new_flat_with_land_cover(
-        &args.bbox,
-        args.scale,
-        args.ground_level,
-        args.canopy_height,
-    )
+    Ground::new_flat_with_land_cover(&bbox, args.scale, args.ground_level, args.canopy_height)
 }
 
 /// Per-format build-height cap when the user opts into extended build height:

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1169,7 +1169,7 @@ fn gui_start_generation(
             // Create an Args instance with the chosen bounding box
             // Note: path is used for Java-specific features like spawn point update
             let args: Args = Args {
-                bbox,
+                bbox: Some(bbox),
                 file: None,
                 save_json_file: None,
                 path: Some(if world_format == WorldFormat::JavaAnvil {
@@ -1218,12 +1218,12 @@ fn gui_start_generation(
             // If skip_osm_objects is true (terrain-only mode), skip fetching and processing OSM data
             if skip_osm_objects {
                 // Generate ground data (terrain) for terrain-only mode
-                let mut ground = ground::generate_ground_data(&args);
+                let mut ground = ground::generate_ground_data(&args, bbox);
 
                 // Create empty parsed_elements and xzbbox for terrain-only mode
                 let mut parsed_elements = Vec::new();
                 let (_coord_transformer, mut xzbbox) =
-                    CoordTransformer::llbbox_to_xzbbox(&args.bbox, args.scale)
+                    CoordTransformer::llbbox_to_xzbbox(&bbox, args.scale)
                         .map_err(|e| format!("Failed to create coordinate transformer: {}", e))?;
 
                 // The spawn point is rotated above, so skipping the world
@@ -1243,7 +1243,7 @@ fn gui_start_generation(
                 let _ = data_processing::generate_world_with_options(
                     parsed_elements,
                     xzbbox,
-                    args.bbox,
+                    bbox,
                     ground,
                     &args,
                     generation_options.clone(),
@@ -1266,15 +1266,14 @@ fn gui_start_generation(
             let (fetch_result, overture_elements, ground) = std::thread::scope(|s| {
                 let overture_handle = s.spawn(|| {
                     if args.overture {
-                        overture::fetch_overture_buildings(&args.bbox, args.scale, args.debug)
+                        overture::fetch_overture_buildings(&bbox, args.scale, args.debug)
                     } else {
                         Vec::new()
                     }
                 });
-                let ground_handle = s.spawn(|| ground::generate_ground_data(&args));
-                let fetch_result = retrieve_data::fetch_data_from_overpass(
-                    args.bbox, args.debug, "requests", None,
-                );
+                let ground_handle = s.spawn(|| ground::generate_ground_data(&args, bbox));
+                let fetch_result =
+                    retrieve_data::fetch_data_from_overpass(bbox, args.debug, "requests", None);
                 (
                     fetch_result,
                     overture_handle.join().expect("Overture fetch panicked"),
@@ -1288,7 +1287,7 @@ fn gui_start_generation(
                     let (mut parsed_elements, mut xzbbox, outline_suppression, part_groups) =
                         osm_parser::parse_osm_data(
                             raw_data,
-                            args.bbox,
+                            bbox,
                             args.scale,
                             args.debug,
                             crate::projection::ProjectionKind::Local,
@@ -1341,7 +1340,7 @@ fn gui_start_generation(
                     let _ = data_processing::generate_world_with_options(
                         parsed_elements,
                         xzbbox,
-                        args.bbox,
+                        bbox,
                         ground,
                         &args,
                         generation_options.clone(),

--- a/src/landmarks.rs
+++ b/src/landmarks.rs
@@ -13,7 +13,7 @@ use crate::block_definitions::{
     WHITE_CONCRETE,
 };
 use crate::coordinate_system::cartesian::XZBBox;
-use crate::coordinate_system::geographic::LLPoint;
+use crate::coordinate_system::geographic::{LLBBox, LLPoint};
 use crate::coordinate_system::transformation::CoordTransformer;
 use crate::osm_parser::ProcessedElement;
 use crate::structures::schematic::{load_palettized, rotate_props};
@@ -171,7 +171,12 @@ impl LandmarkPrescan {
 }
 
 /// Resolve the landmarks inside this world and collect what they replace.
-pub fn prescan(elements: &[ProcessedElement], xzbbox: &XZBBox, args: &Args) -> LandmarkPrescan {
+pub fn prescan(
+    elements: &[ProcessedElement],
+    xzbbox: &XZBBox,
+    llbbox: LLBBox,
+    args: &Args,
+) -> LandmarkPrescan {
     let mut placements: Vec<LandmarkPlacement> = Vec::new();
     let mut suppressed: HashSet<(&'static str, u64)> = HashSet::new();
 
@@ -184,7 +189,8 @@ pub fn prescan(elements: &[ProcessedElement], xzbbox: &XZBBox, args: &Args) -> L
     }
 
     for landmark in LANDMARKS {
-        let Some((world_x, world_z)) = world_anchor(landmark.lat, landmark.lon, args) else {
+        let Some((world_x, world_z)) = world_anchor(landmark.lat, landmark.lon, llbbox, args)
+        else {
             continue;
         };
         // The model only matters if its reach overlaps the world.
@@ -213,18 +219,18 @@ pub fn prescan(elements: &[ProcessedElement], xzbbox: &XZBBox, args: &Args) -> L
 }
 
 /// Project an anchor into world XZ the way the parser projects node coords.
-fn world_anchor(lat: f64, lon: f64, args: &Args) -> Option<(i32, i32)> {
+fn world_anchor(lat: f64, lon: f64, llbbox: LLBBox, args: &Args) -> Option<(i32, i32)> {
     let llpoint = LLPoint::new(lat, lon).ok()?;
     let (transformer, pre_rotation_bbox) = match args.projection {
         crate::projection::ProjectionKind::WebMercator => {
-            let origin_lat = (args.bbox.min().lat() + args.bbox.max().lat()) / 2.0;
-            let origin_lon = (args.bbox.min().lng() + args.bbox.max().lng()) / 2.0;
+            let origin_lat = (llbbox.min().lat() + llbbox.max().lat()) / 2.0;
+            let origin_lon = (llbbox.min().lng() + llbbox.max().lng()) / 2.0;
             let proj =
                 crate::projection::WebMercatorProjection::new(origin_lat, origin_lon, args.scale);
-            CoordTransformer::with_projection(&args.bbox, args.scale, &proj)
+            CoordTransformer::with_projection(&llbbox, args.scale, &proj)
         }
         crate::projection::ProjectionKind::Local => {
-            CoordTransformer::llbbox_to_xzbbox(&args.bbox, args.scale)
+            CoordTransformer::llbbox_to_xzbbox(&llbbox, args.scale)
         }
     }
     .ok()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,11 +134,69 @@ fn run_cli() {
         );
     }
 
+    // Resolve the effective bounding box ONCE, up front, and thread the concrete value to every
+    // consumer below (the CLI bbox is now optional). Precedence: explicit --bbox > file <bounds>
+    // element > node-coordinate extent.
+    //
+    // A local .osm/.xml file is the only bbox source when --bbox is omitted, so it must be loaded
+    // BEFORE the parallel fetch scope (Overture + land cover need the bbox) and before the bedrock
+    // world-name / area-size steps below. The parsed data is kept in `preloaded_osm` so the file
+    // isn't read twice. The Overpass and terrain-only paths already know the bbox from --bbox.
+    let skip_objects = args.skip_objects();
+    let (mut preloaded_osm, effective_bbox) = match (skip_objects, args.file.as_deref()) {
+        (false, Some(file)) => {
+            let (data, file_bounds) = match retrieve_data::fetch_data_from_file(file) {
+                Ok(loaded) => loaded,
+                Err(e) => {
+                    eprintln!("{} Failed to load OSM file: {}", "Error:".red().bold(), e);
+                    std::process::exit(1);
+                }
+            };
+            let bbox = match osm_parser::resolve_bbox(args.bbox, file_bounds, &data) {
+                Some(bbox) => bbox,
+                None => {
+                    eprintln!(
+                        "{} could not derive a bounding box from '{file}' (no <bounds> element and no usable node extent); pass --bbox explicitly.",
+                        "Error:".red().bold()
+                    );
+                    std::process::exit(1);
+                }
+            };
+            // Report where a derived bbox came from (an explicit --bbox is echoed by the parse step).
+            if args.bbox.is_none() {
+                let source = if file_bounds.is_some() {
+                    "file <bounds> element"
+                } else {
+                    "node coordinate extent"
+                };
+                println!(
+                    "Derived bounding box from {source}: {},{},{},{}",
+                    bbox.min().lat(),
+                    bbox.min().lng(),
+                    bbox.max().lat(),
+                    bbox.max().lng()
+                );
+            }
+            (Some(data), bbox)
+        }
+        _ => {
+            // Overpass or terrain-only: --bbox is required (enforced by validate_args above).
+            let bbox = args.bbox.unwrap_or_else(|| {
+                eprintln!(
+                    "{} A bounding box is required. Provide --bbox, or --file with a local .osm/.xml file.",
+                    "Error:".red().bold()
+                );
+                std::process::exit(1);
+            });
+            (None, bbox)
+        }
+    };
+
     // Heads-up for very large areas: generation is long and memory-heavy, and big
     // requests load the public OpenStreetMap / elevation servers. Non-blocking.
     {
         const MAX_RECOMMENDED_AREA_KM2: f64 = 250.0;
-        let b = &args.bbox;
+        let b = &effective_bbox;
         let mid_lat = ((b.min().lat() + b.max().lat()) / 2.0).to_radians();
         let width_m = (b.max().lng() - b.min().lng()) * 111_320.0 * mid_lat.cos();
         let height_m = (b.max().lat() - b.min().lat()) * 111_320.0;
@@ -170,7 +228,8 @@ fn run_cli() {
             .path
             .clone()
             .unwrap_or_else(world_utils::get_bedrock_output_directory);
-        let (output_path, lvl_name) = world_utils::build_bedrock_output(&args.bbox, output_dir);
+        let (output_path, lvl_name) =
+            world_utils::build_bedrock_output(&effective_bbox, output_dir);
         (output_path, Some(lvl_name))
     } else if args.luanti {
         let base_dir = args
@@ -228,7 +287,6 @@ fn run_cli() {
     let mut bench = bench::Bench::new(args.benchmark);
 
     // Terrain-only skips every object source: no Overpass query, no Overture footprints.
-    let skip_objects = args.skip_objects();
     if skip_objects {
         println!(
             "{} Terrain-only mode: skipping OpenStreetMap and Overture objects",
@@ -245,7 +303,7 @@ fn run_cli() {
         let overture_handle = s.spawn(|| {
             let t = std::time::Instant::now();
             let elements = if args.overture && !skip_objects {
-                overture::fetch_overture_buildings(&args.bbox, args.scale, args.debug)
+                overture::fetch_overture_buildings(&effective_bbox, args.scale, args.debug)
             } else {
                 Vec::new()
             };
@@ -253,23 +311,25 @@ fn run_cli() {
         });
         let ground_handle = s.spawn(|| {
             let t = std::time::Instant::now();
-            let ground = ground::generate_ground_data(&args);
+            let ground = ground::generate_ground_data(&args, effective_bbox);
             (ground, t.elapsed())
         });
 
         let t = std::time::Instant::now();
+        // A local file was already parsed up front (to derive the bbox), so reuse that data.
+        // Terrain-only carries no objects. Otherwise fetch from Overpass, in parallel with the
+        // Overture and land-cover fetches spawned above.
         let raw_data = if skip_objects {
             osm_parser::OsmData::empty()
+        } else if let Some(data) = preloaded_osm.take() {
+            data
         } else {
-            match &args.file {
-                Some(file) => retrieve_data::fetch_data_from_file(file),
-                None => retrieve_data::fetch_data_from_overpass(
-                    args.bbox,
-                    args.debug,
-                    args.downloader.as_str(),
-                    args.save_json_file.as_deref(),
-                ),
-            }
+            retrieve_data::fetch_data_from_overpass(
+                effective_bbox,
+                args.debug,
+                args.downloader.as_str(),
+                args.save_json_file.as_deref(),
+            )
             .expect("Failed to fetch data")
         };
         bench.report("osm_fetch", t.elapsed());
@@ -287,7 +347,13 @@ fn run_cli() {
 
     // Parse raw data
     let (mut parsed_elements, mut xzbbox, outline_suppression, part_groups) =
-        osm_parser::parse_osm_data(raw_data, args.bbox, args.scale, args.debug, args.projection);
+        osm_parser::parse_osm_data(
+            raw_data,
+            effective_bbox,
+            args.scale,
+            args.debug,
+            args.projection,
+        );
     bench.mark("parse_osm");
 
     // Merge the Overture buildings now that the OSM elements are parsed.
@@ -367,14 +433,16 @@ fn run_cli() {
 
             let (transformer, pre_rot_bbox) = match args.projection {
                 projection::ProjectionKind::WebMercator => {
-                    let origin_lat = (args.bbox.min().lat() + args.bbox.max().lat()) / 2.0;
-                    let origin_lon = (args.bbox.min().lng() + args.bbox.max().lng()) / 2.0;
+                    let origin_lat =
+                        (effective_bbox.min().lat() + effective_bbox.max().lat()) / 2.0;
+                    let origin_lon =
+                        (effective_bbox.min().lng() + effective_bbox.max().lng()) / 2.0;
                     let proj =
                         projection::WebMercatorProjection::new(origin_lat, origin_lon, args.scale);
-                    CoordTransformer::with_projection(&args.bbox, args.scale, &proj)
+                    CoordTransformer::with_projection(&effective_bbox, args.scale, &proj)
                 }
                 projection::ProjectionKind::Local => {
-                    CoordTransformer::llbbox_to_xzbbox(&args.bbox, args.scale)
+                    CoordTransformer::llbbox_to_xzbbox(&effective_bbox, args.scale)
                 }
             }
             .unwrap_or_else(|e| {
@@ -429,7 +497,7 @@ fn run_cli() {
     match data_processing::generate_world_with_options(
         parsed_elements,
         xzbbox,
-        args.bbox,
+        effective_bbox,
         ground,
         &args,
         generation_options,

--- a/src/osm_parser.rs
+++ b/src/osm_parser.rs
@@ -114,6 +114,266 @@ impl OsmData {
             remark: None,
         }
     }
+
+    /// Bounding box spanning every node with coordinates, or None when the data has no
+    /// locatable nodes (or they are collinear/degenerate). Used as the fallback bbox for
+    /// local `.osm` files that omit the `<bounds>` element.
+    pub fn bounds(&self) -> Option<LLBBox> {
+        let mut min_lat = f64::INFINITY;
+        let mut min_lng = f64::INFINITY;
+        let mut max_lat = f64::NEG_INFINITY;
+        let mut max_lng = f64::NEG_INFINITY;
+        let mut found = false;
+        for element in &self.elements {
+            if let (Some(lat), Some(lon)) = (element.lat, element.lon) {
+                min_lat = min_lat.min(lat);
+                max_lat = max_lat.max(lat);
+                min_lng = min_lng.min(lon);
+                max_lng = max_lng.max(lon);
+                found = true;
+            }
+        }
+        if !found {
+            return None;
+        }
+        // LLBBox::new rejects a zero-area (min == max) box; treat that as "no usable bounds".
+        LLBBox::new(min_lat, min_lng, max_lat, max_lng).ok()
+    }
+}
+
+/// Parses a raw OSM XML (`.osm`) document into the same [`OsmData`] shape produced by the
+/// Overpass `[out:json]` path, so the entire downstream pipeline is reused unchanged.
+///
+/// Returns the parsed data plus the `<bounds>` element as an [`LLBBox`] when the document
+/// carries one. The caller decides bbox precedence via [`resolve_bbox`]; surfacing the
+/// explicit `<bounds>` here keeps it from being silently replaced by the node-extent fallback.
+pub fn parse_osm_xml(
+    reader: impl std::io::BufRead,
+) -> Result<(OsmData, Option<LLBBox>), Box<dyn std::error::Error>> {
+    use quick_xml::events::{BytesStart, Event};
+    use quick_xml::reader::Reader;
+
+    // Single-attribute lookup, decoding XML entities in the value. Element attribute
+    // counts are tiny, re-scan is cheap.
+    fn attr_string(
+        e: &BytesStart,
+        key: &[u8],
+    ) -> Result<Option<String>, Box<dyn std::error::Error>> {
+        for attr in e.attributes() {
+            let attr = attr?;
+            if attr.key.into_inner() == key {
+                // normalized_value resolves predefined entities (&amp; -> & etc.); Implicit1_0
+                // applies XML 1.0 attribute-value normalization for OSM files.
+                return Ok(Some(
+                    attr.normalized_value(quick_xml::XmlVersion::Implicit1_0)?
+                        .into_owned(),
+                ));
+            }
+        }
+        Ok(None)
+    }
+    fn attr_u64(e: &BytesStart, key: &[u8]) -> Result<Option<u64>, Box<dyn std::error::Error>> {
+        match attr_string(e, key)? {
+            Some(s) => Ok(Some(s.trim().parse()?)),
+            None => Ok(None),
+        }
+    }
+    fn attr_f64(e: &BytesStart, key: &[u8]) -> Result<Option<f64>, Box<dyn std::error::Error>> {
+        match attr_string(e, key)? {
+            Some(s) => Ok(Some(s.trim().parse()?)),
+            None => Ok(None),
+        }
+    }
+
+    // The node/way/relation currently being assembled from its child events.
+    enum Building {
+        Node {
+            id: u64,
+            lat: Option<f64>,
+            lon: Option<f64>,
+            tags: HashMap<String, String>,
+        },
+        Way {
+            id: u64,
+            nodes: Vec<u64>,
+            tags: HashMap<String, String>,
+        },
+        Relation {
+            id: u64,
+            members: Vec<OsmMember>,
+            tags: HashMap<String, String>,
+        },
+    }
+
+    // Mirror Overpass JSON: an element with no tags deserializes to `None`, not an empty map.
+    fn finish(b: Building) -> OsmElement {
+        let opt = |t: HashMap<String, String>| if t.is_empty() { None } else { Some(t) };
+        match b {
+            Building::Node { id, lat, lon, tags } => OsmElement {
+                r#type: "node".to_string(),
+                id,
+                lat,
+                lon,
+                nodes: None,
+                tags: opt(tags),
+                members: Vec::new(),
+            },
+            Building::Way { id, nodes, tags } => OsmElement {
+                r#type: "way".to_string(),
+                id,
+                lat: None,
+                lon: None,
+                nodes: Some(nodes),
+                tags: opt(tags),
+                members: Vec::new(),
+            },
+            Building::Relation { id, members, tags } => OsmElement {
+                r#type: "relation".to_string(),
+                id,
+                lat: None,
+                lon: None,
+                nodes: None,
+                tags: opt(tags),
+                members,
+            },
+        }
+    }
+
+    // Handles a start/empty tag. `is_empty` is true for self-closing tags (no child events,
+    // so node/way/relation are finalized immediately rather than on a matching end tag).
+    fn on_open(
+        e: &BytesStart,
+        is_empty: bool,
+        elements: &mut Vec<OsmElement>,
+        bounds: &mut Option<LLBBox>,
+        building: &mut Option<Building>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match e.name().into_inner() {
+            b"bounds" => {
+                if let (Some(minlat), Some(minlon), Some(maxlat), Some(maxlon)) = (
+                    attr_f64(e, b"minlat")?,
+                    attr_f64(e, b"minlon")?,
+                    attr_f64(e, b"maxlat")?,
+                    attr_f64(e, b"maxlon")?,
+                ) {
+                    // Propagate LLBBox::new's validation error
+                    *bounds = Some(LLBBox::new(minlat, minlon, maxlat, maxlon)?);
+                }
+            }
+            b"node" => {
+                let id = attr_u64(e, b"id")?.ok_or("OSM node missing required id attribute")?;
+                let node = Building::Node {
+                    id,
+                    lat: attr_f64(e, b"lat")?,
+                    lon: attr_f64(e, b"lon")?,
+                    tags: HashMap::new(),
+                };
+                if is_empty {
+                    elements.push(finish(node));
+                } else {
+                    *building = Some(node);
+                }
+            }
+            b"way" => {
+                let id = attr_u64(e, b"id")?.ok_or("OSM way missing required id attribute")?;
+                let way = Building::Way {
+                    id,
+                    nodes: Vec::new(),
+                    tags: HashMap::new(),
+                };
+                if is_empty {
+                    elements.push(finish(way));
+                } else {
+                    *building = Some(way);
+                }
+            }
+            b"relation" => {
+                let id = attr_u64(e, b"id")?.ok_or("OSM relation missing required id attribute")?;
+                let relation = Building::Relation {
+                    id,
+                    members: Vec::new(),
+                    tags: HashMap::new(),
+                };
+                if is_empty {
+                    elements.push(finish(relation));
+                } else {
+                    *building = Some(relation);
+                }
+            }
+            b"tag" => {
+                if let Some(b) = building.as_mut() {
+                    if let (Some(k), Some(v)) = (attr_string(e, b"k")?, attr_string(e, b"v")?) {
+                        match b {
+                            Building::Node { tags, .. }
+                            | Building::Way { tags, .. }
+                            | Building::Relation { tags, .. } => {
+                                tags.insert(k, v);
+                            }
+                        }
+                    }
+                }
+            }
+            b"nd" => {
+                if let Some(Building::Way { nodes, .. }) = building.as_mut() {
+                    if let Some(node_ref) = attr_u64(e, b"ref")? {
+                        nodes.push(node_ref);
+                    }
+                }
+            }
+            b"member" => {
+                if let Some(Building::Relation { members, .. }) = building.as_mut() {
+                    members.push(OsmMember {
+                        r#type: attr_string(e, b"type")?.unwrap_or_default(),
+                        r#ref: attr_u64(e, b"ref")?.unwrap_or_default(),
+                        r#role: attr_string(e, b"role")?.unwrap_or_default(),
+                    });
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    let mut xml = Reader::from_reader(reader);
+    let mut buf: Vec<u8> = Vec::new();
+    let mut elements: Vec<OsmElement> = Vec::new();
+    let mut bounds: Option<LLBBox> = None;
+    let mut building: Option<Building> = None;
+
+    loop {
+        match xml.read_event_into(&mut buf)? {
+            Event::Eof => break,
+            Event::Start(e) => on_open(&e, false, &mut elements, &mut bounds, &mut building)?,
+            Event::Empty(e) => on_open(&e, true, &mut elements, &mut bounds, &mut building)?,
+            Event::End(e) => {
+                if matches!(e.name().into_inner(), b"node" | b"way" | b"relation") {
+                    if let Some(b) = building.take() {
+                        elements.push(finish(b));
+                    }
+                }
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok((
+        OsmData {
+            elements,
+            remark: None,
+        },
+        bounds,
+    ))
+}
+
+/// Resolves the effective bounding box with precedence: explicit `--bbox` > file `<bounds>`
+/// element > node-coordinate extent. Returns None only when no source yields a usable box.
+pub fn resolve_bbox(
+    explicit: Option<LLBBox>,
+    file_bounds: Option<LLBBox>,
+    data: &OsmData,
+) -> Option<LLBBox> {
+    explicit.or(file_bounds).or_else(|| data.bounds())
 }
 
 struct SplitOsmData {
@@ -1919,5 +2179,146 @@ mod outline_suppression_tests {
 
         let s = compute_spatial_relation_part_suppression(&[outline, part], &ways, &nodes);
         assert!(!s.contains(&("relation", 1)));
+    }
+}
+
+#[cfg(test)]
+mod osm_xml_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn parse(xml: &str) -> (OsmData, Option<LLBBox>) {
+        parse_osm_xml(Cursor::new(xml.as_bytes())).expect("valid OSM XML")
+    }
+
+    fn find<'a>(data: &'a OsmData, kind: &str, id: u64) -> &'a OsmElement {
+        data.elements
+            .iter()
+            .find(|e| e.r#type == kind && e.id == id)
+            .unwrap_or_else(|| panic!("missing {kind} {id}"))
+    }
+
+    // Testing every element kind: tagged node, bare node, way (nd refs + tags),
+    // relation (member + tags), and a <bounds> element.
+    const SAMPLE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="test">
+  <bounds minlat="1.0" minlon="2.0" maxlat="3.0" maxlon="4.0"/>
+  <node id="10" lat="1.5" lon="2.5"><tag k="amenity" v="cafe"/></node>
+  <node id="11" lat="1.6" lon="2.6"/>
+  <way id="20">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <tag k="building" v="yes"/>
+    <tag k="name" v="Ben &amp; Jerry"/>
+  </way>
+  <relation id="30">
+    <member type="way" ref="20" role="outer"/>
+    <tag k="type" v="multipolygon"/>
+  </relation>
+</osm>"#;
+
+    #[test]
+    fn parses_bounds_into_llbbox() {
+        let (_, bounds) = parse(SAMPLE);
+        assert_eq!(bounds, Some(LLBBox::new(1.0, 2.0, 3.0, 4.0).unwrap()));
+    }
+
+    #[test]
+    fn parses_expected_element_count() {
+        let (data, _) = parse(SAMPLE);
+        // 2 nodes + 1 way + 1 relation; <bounds> is not an element.
+        assert_eq!(data.elements.len(), 4);
+    }
+
+    #[test]
+    fn parses_node_with_and_without_tags() {
+        let (data, _) = parse(SAMPLE);
+
+        let tagged = find(&data, "node", 10);
+        assert_eq!(tagged.lat, Some(1.5));
+        assert_eq!(tagged.lon, Some(2.5));
+        assert_eq!(
+            tagged.tags.as_ref().unwrap().get("amenity"),
+            Some(&"cafe".to_string())
+        );
+
+        // A node with no <tag> children mirrors Overpass JSON: tags is None, not an empty map.
+        let bare = find(&data, "node", 11);
+        assert_eq!(bare.lat, Some(1.6));
+        assert!(bare.tags.is_none());
+    }
+
+    #[test]
+    fn parses_way_node_refs_and_tags() {
+        let (data, _) = parse(SAMPLE);
+        let way = find(&data, "way", 20);
+        assert_eq!(way.nodes, Some(vec![10, 11]));
+        let tags = way.tags.as_ref().unwrap();
+        assert_eq!(tags.get("building"), Some(&"yes".to_string()));
+        // XML entities in attribute values are unescaped.
+        assert_eq!(tags.get("name"), Some(&"Ben & Jerry".to_string()));
+    }
+
+    #[test]
+    fn parses_relation_members_and_tags() {
+        let (data, _) = parse(SAMPLE);
+        let relation = find(&data, "relation", 30);
+        assert_eq!(relation.members.len(), 1);
+        let member = &relation.members[0];
+        assert_eq!(member.r#type, "way");
+        assert_eq!(member.r#ref, 20);
+        assert_eq!(member.r#role, "outer");
+        assert_eq!(
+            relation.tags.as_ref().unwrap().get("type"),
+            Some(&"multipolygon".to_string())
+        );
+    }
+
+    // Without a <bounds> element, the parser returns None and OsmData::bounds() derives the
+    // node-coordinate extent instead.
+    const NO_BOUNDS: &str = r#"<osm version="0.6">
+  <node id="1" lat="10.0" lon="20.0"/>
+  <node id="2" lat="12.0" lon="24.0"/>
+  <node id="3" lat="11.0" lon="22.0"/>
+</osm>"#;
+
+    #[test]
+    fn missing_bounds_falls_back_to_node_extent() {
+        let (data, bounds) = parse(NO_BOUNDS);
+        assert!(bounds.is_none());
+        assert_eq!(
+            data.bounds(),
+            Some(LLBBox::new(10.0, 20.0, 12.0, 24.0).unwrap())
+        );
+    }
+
+    #[test]
+    fn bounds_is_none_without_located_nodes() {
+        let data = OsmData::empty();
+        assert!(data.bounds().is_none());
+    }
+
+    #[test]
+    fn resolve_bbox_precedence() {
+        let explicit = LLBBox::new(0.0, 0.0, 1.0, 1.0).unwrap();
+        let file = LLBBox::new(5.0, 5.0, 6.0, 6.0).unwrap();
+        let (data_with_bounds, _) = parse(SAMPLE);
+        let (data_no_bounds, _) = parse(NO_BOUNDS);
+        let node_extent = data_no_bounds.bounds().unwrap();
+
+        // 1--bbox wins over a file <bounds>
+        assert_eq!(
+            resolve_bbox(Some(explicit), Some(file), &data_with_bounds),
+            Some(explicit)
+        );
+        // file <bounds> used when --bbox is absent
+        assert_eq!(
+            resolve_bbox(None, Some(file), &data_with_bounds),
+            Some(file)
+        );
+        // node-extent fallback when neither --bbox nor <bounds> is present
+        assert_eq!(resolve_bbox(None, None, &data_no_bounds), Some(node_extent));
+        // nothing resolvable -> None
+        assert_eq!(resolve_bbox(None, None, &OsmData::empty()), None);
     }
 }

--- a/src/retrieve_data.rs
+++ b/src/retrieve_data.rs
@@ -110,15 +110,41 @@ fn download_with_wget(url: &str, query: &str) -> io::Result<String> {
     }
 }
 
-pub fn fetch_data_from_file(file: &str) -> Result<OsmData, Box<dyn std::error::Error>> {
+/// File extensions (case-insensitive) that select the raw OSM XML path instead of
+/// Arnis's own JSON dump.
+const OSM_XML_EXTENSIONS: &[&str] = &["osm", "xml"];
+
+/// Loads OSM data from a local file. `.osm`/`.xml` files are parsed as raw OSM XML (offline,
+/// avoiding Overpass size limits) and their `<bounds>` element, if present, is returned so the
+/// caller can auto-derive the bounding box. Any other extension keeps the original behavior:
+/// deserializing Arnis's own JSON dump (`{"elements":[...],"remark":...}`), which carries no
+/// bounds (returned as None).
+pub fn fetch_data_from_file(
+    file: &str,
+) -> Result<(OsmData, Option<LLBBox>), Box<dyn std::error::Error>> {
     println!("{} Loading data from file...", "[1/7]".bold());
     emit_gui_progress_update(1.0, "Loading data from file...");
 
-    let file: File = File::open(file)?;
-    let reader: BufReader<File> = BufReader::new(file);
-    let mut deserializer = serde_json::Deserializer::from_reader(reader);
-    let data: OsmData = OsmData::deserialize(&mut deserializer)?;
-    Ok(data)
+    let is_xml = std::path::Path::new(file)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| {
+            OSM_XML_EXTENSIONS
+                .iter()
+                .any(|x| ext.eq_ignore_ascii_case(x))
+        })
+        .unwrap_or(false);
+
+    let f: File = File::open(file)?;
+    let reader: BufReader<File> = BufReader::new(f);
+
+    if is_xml {
+        crate::osm_parser::parse_osm_xml(reader)
+    } else {
+        let mut deserializer = serde_json::Deserializer::from_reader(reader);
+        let data: OsmData = OsmData::deserialize(&mut deserializer)?;
+        Ok((data, None))
+    }
 }
 
 /// Main function to fetch data
@@ -397,4 +423,54 @@ pub fn fetch_area_name(lat: f64, lon: f64) -> Result<Option<String>, Box<dyn std
     }
 
     Ok(None)
+}
+
+#[cfg(test)]
+mod fetch_from_file_tests {
+    use super::*;
+
+    // A `.osm` file must route to the raw-XML parser, which surfaces the document's <bounds>
+    // element; the JSON path returns None, so a Some result here proves the extension routing.
+    #[test]
+    fn osm_extension_routes_to_xml_parser_and_returns_bounds() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/sample.osm");
+        let (data, bounds) = fetch_data_from_file(path).expect("fixture .osm should load");
+
+        // Exactly the fixture's <bounds minlat=.. minlon=.. maxlat=.. maxlon=..> element.
+        assert_eq!(
+            bounds,
+            Some(LLBBox::new(54.63, 9.93, 54.632, 9.933).unwrap())
+        );
+
+        // The fixture's 8 nodes + 2 ways were parsed. Element internals are private to
+        // osm_parser (exact-count / tag assertions live in its osm_xml_tests), so the parse
+        // is asserted here through the public surface.
+        assert!(!data.is_empty());
+
+        // The returned box is the explicit <bounds>, not the node-coordinate extent: the 8
+        // nodes span a strictly smaller box, so this confirms <bounds> was surfaced instead of
+        // the OsmData::bounds() fallback.
+        assert_eq!(
+            data.bounds(),
+            Some(LLBBox::new(54.6302, 9.9302, 54.6318, 9.9325).unwrap())
+        );
+    }
+
+    // Any non-.osm/.xml extension keeps the original Arnis JSON-dump path, which carries no
+    // <bounds> (None). Paired with the .osm case above, this proves routing keys off the extension.
+    #[test]
+    fn json_extension_keeps_json_path_and_has_no_bounds() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dump.json");
+        std::fs::write(
+            &path,
+            r#"{"elements":[{"type":"node","id":1,"lat":1.0,"lon":2.0}],"remark":null}"#,
+        )
+        .unwrap();
+
+        let (data, bounds) =
+            fetch_data_from_file(path.to_str().unwrap()).expect("JSON dump should load");
+        assert!(bounds.is_none());
+        assert!(!data.is_empty());
+    }
 }

--- a/src/trees/tree_pack.rs
+++ b/src/trees/tree_pack.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use include_dir::{include_dir, Dir};
 
 use crate::args::Args;
+use crate::coordinate_system::geographic::LLBBox;
 use crate::trees::region::RegionLibrary;
 use crate::trees::tree_library::SizeFilter;
 
@@ -68,13 +69,13 @@ pub fn realm_for_latlon(lat: f64, lon: f64) -> &'static str {
 }
 
 /// Load the region tree pack (realm from bbox center), or None for legacy procedural trees.
-pub fn load(args: &Args, scale: f64, ground_level: i32) -> Option<RegionLibrary> {
+pub fn load(args: &Args, bbox: LLBBox, scale: f64, ground_level: i32) -> Option<RegionLibrary> {
     if args.legacy_trees {
         return None;
     }
     let sizes = SizeFilter::up_to(args.max_tree_size);
-    let lat = (args.bbox.min().lat() + args.bbox.max().lat()) / 2.0;
-    let lon = (args.bbox.min().lng() + args.bbox.max().lng()) / 2.0;
+    let lat = (bbox.min().lat() + bbox.max().lat()) / 2.0;
+    let lon = (bbox.min().lng() + bbox.max().lng()) / 2.0;
     let realm = realm_for_latlon(lat, lon);
     let source = TreePackSource::embedded(realm);
     // No palms outside the subtropics (the wide ena realm also spans the Caribbean).

--- a/tests/fixtures/sample.osm
+++ b/tests/fixtures/sample.osm
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="arnis-test-fixture">
+  <bounds minlat="54.6300000" minlon="9.9300000" maxlat="54.6320000" maxlon="9.9330000"/>
+  <!-- Building footprint corners -->
+  <node id="1001" lat="54.6308000" lon="9.9308000"/>
+  <node id="1002" lat="54.6308000" lon="9.9314000"/>
+  <node id="1003" lat="54.6313000" lon="9.9314000"/>
+  <node id="1004" lat="54.6313000" lon="9.9308000"/>
+  <!-- Highway nodes -->
+  <node id="2001" lat="54.6302000" lon="9.9302000"/>
+  <node id="2002" lat="54.6310000" lon="9.9311000"/>
+  <node id="2003" lat="54.6318000" lon="9.9325000"/>
+  <!-- A tagged point of interest -->
+  <node id="3001" lat="54.6310000" lon="9.9310000">
+    <tag k="amenity" v="bench"/>
+  </node>
+  <way id="100">
+    <nd ref="1001"/>
+    <nd ref="1002"/>
+    <nd ref="1003"/>
+    <nd ref="1004"/>
+    <nd ref="1001"/>
+    <tag k="building" v="yes"/>
+    <tag k="name" v="Test Hall"/>
+  </way>
+  <way id="200">
+    <nd ref="2001"/>
+    <nd ref="2002"/>
+    <nd ref="2003"/>
+    <tag k="highway" v="residential"/>
+    <tag k="name" v="Test Street"/>
+  </way>
+</osm>


### PR DESCRIPTION
Implements #881: adds `--file` support for a local raw OSM XML (`.osm`) file, with the bounding box auto-derived from it (no `--bbox` needed).

Tested: `fmt` / `clippy -D warnings` / `test` (369 passing, 10 new) plus an end-to-end `--map-preview` run with no `--bbox` on both a small fixture and a real ~4.7 MB openstreetmap.org export.

Adds a `quick-xml` dependency (an older `quick-xml` also remains transitively via an existing dependency).

Closes #881