### PR TITLE
Fix #1189: stop open ocean rendering as a river ring along coasts

### DIFF
--- a/src/biome.rs
+++ b/src/biome.rs
@@ -15,8 +15,12 @@ pub fn biome_for_class(lc: u8, climate: Climate, lat_deg: f64, water_dist: u8) -
     if lc == LC_WATER {
         let abs_lat = lat_deg.abs();
         let cold = matches!(climate, Climate::IceCap | Climate::Tundra | Climate::Boreal);
-        let deep = water_dist >= 12;
-        if water_dist < 8 {
+        // water_distance BFS caps at 15, so open water past the cap stays at 0.
+        // Treat that as deep ocean, not river, otherwise open sea renders as a
+        // river ring with a band of ocean hugging the coast (issue #1189).
+        let past_cap = water_dist == 0;
+        let deep = past_cap || water_dist >= 12;
+        if water_dist < 8 && !past_cap {
             return if cold {
                 "minecraft:frozen_river"
             } else {
@@ -285,6 +289,15 @@ mod tests {
         let t = Climate::Temperate;
         assert_eq!(biome_for_class(LC_WATER, t, 0.0, 1), "minecraft:river");
         assert_eq!(biome_for_class(LC_WATER, t, 0.0, 8), "minecraft:warm_ocean");
+        // water_dist == 0 is open water past the BFS cap: deep ocean, not a river.
+        assert_eq!(
+            biome_for_class(LC_WATER, t, 0.0, 0),
+            "minecraft:warm_ocean"
+        );
+        assert_eq!(
+            biome_for_class(LC_WATER, t, 50.0, 0),
+            "minecraft:deep_cold_ocean"
+        );
         assert_eq!(
             biome_for_class(LC_WATER, t, 35.0, 8),
             "minecraft:lukewarm_ocean"


### PR DESCRIPTION
**Issue:** #1189 - a thin line/ring of ocean biome appears hugging the coastline, with river biome on both sides.

**Root cause:** `compute_water_distance` (in `land_cover`) runs a BFS that caps at 15, so any water cell more than 15 blocks from shore keeps distance `0` (this convention is already relied on in `structures/boat.rs`). But `biome_for_class` treated `water_dist < 8` as river with no exception for the past-cap `0`. The result on a real coastline:
- dist 1-7 (shore): river
- dist 8-15 (a ring hugging the coast): ocean
- dist 0 (open sea past the cap): misclassified as river

That ring of ocean between two river zones is the reported artifact.

**Fix:** Treat past-cap water (`water_dist == 0`) as deep open ocean rather than river, matching the existing `boat.rs` convention.

**Verification:** `cargo test biome::` -> 9 passed, incl. new past-cap assertions; full suite 361 passed, 0 failed.