### PR TITLE
Fix nix build by adding missing dependency and updating lock file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,12 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
-        "type": "github"
+        "lastModified": 1786106723,
+        "narHash": "sha256-CgKDSHL6rqAAQkkvg1xaZDQXb77+4XW73iGcUMJ+2w0=",
+        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1049422.f13ff45afd1b/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
             outputHashes = {
               "bedrockrs_core-0.1.0" = "sha256-0HP6p2x6sulZ2u8FzEfAiNAeyaUjQQWgGyK/kPo0PuQ=";
               "nbtx-0.1.0" = "sha256-JoNSL1vrUbxX6hKWB4i/DX02+hsQemANJhQaEELlT2o=";
+              "dda-voxelize-0.2.0-alpha.1" = "sha256-MiSvqlzvezp7TXIDZl7+/x+zCPcsbFo2hhMWBJKqvaE=";
             };
           };
 


### PR DESCRIPTION
Thanks for the project! It is very cool and, as a nix user, I also appreciate the included nix flake. 

The flake fails to build right now because of two reasons:

- dda-voxelize is fetched from a Github repo but its hash is not specified in the flake.
- cfg_select is used by a dependency but is not available on rustc 1.88.0. 

To fix this, this PR does two things:

- Adds the hash of "dda-voxelize" to `flake.nix`
- Updates the `flake.lock` by running a `nix flake update`. This bumps rustc to 1.97.1.

If you are using nix, you can verify that this builds cleanly by running `nix run github:KevinHermelin/arnis -- --help`
(and compare it to upstream `nix run github:louis-e/arnis -- --help`)