### PR TITLE
fix: use material=wood for fences

### DIFF
--- a/src/element_processing/barriers.rs
+++ b/src/element_processing/barriers.rs
@@ -78,6 +78,9 @@ pub fn generate_barriers(
         if barrier_mat == "metal" {
             barrier_material = STONE_BRICK_WALL;
         }
+        if barrier_mat == "wood" {
+            barrier_material = OAK_FENCE;
+        }
     }
 
     if let ProcessedElement::Way(way) = element {


### PR DESCRIPTION
## Fix for #1240

### Problem
OpenStreetMap is migrating `fence_type=wood` to `material=wood` (see [OSM wiki](https://wiki.openstreetmap.org/wiki/Key:fence_type) and [community discussion](https://community.openstreetmap.org/t/tagging-that-fence-is-wooden-without-further-detail-fence-type-wood-vs-material-wood/135748)).

Previously, only `fence_type=wood` would render as `OAK_FENCE`. Fences tagged with `material=wood` but a different `fence_type` (or no `fence_type` at all) would fall through to the default `COBBLESTONE_WALL`.

### Solution
Added `wood` to the material override section in `barriers.rs`, consistent with how `brick`, `concrete`, and `metal` are already handled. The material tag takes priority over the inferred type from `fence_type`.

### Testing
- Verified the existing material override logic (brick/concrete/metal) is unchanged
- `material=wood` now correctly maps to `OAK_FENCE`
- Fences with `fence_type=wood` are unaffected (they still map to `OAK_FENCE` via the fence_type match)

Signed-off-by: badhope <306089220+weed33834@users.noreply.github.com>