### PR TITLE
fix: unfreeze sun in Bedrock worlds with extend build height

### DIFF
--- a/src/world_editor/bedrock.rs
+++ b/src/world_editor/bedrock.rs
@@ -421,8 +421,8 @@ impl BedrockWriter {
             permissions_level: 0,
             player_permissions_level: 1,
 
-            // Daylight cycle
-            daylight_cycle: 0,
+            // Daylight cycle (1 = normal, 0 = frozen)
+            daylight_cycle: 1,
         };
 
         let nbt_bytes = nbtx::to_le_bytes(&level_dat)


### PR DESCRIPTION
## Fix for #1254

### Problem
When generating Bedrock worlds (especially with the "Extend build height" option), the sun visually freezes in-game. Time still passes according to the HUD, but the sky remains static.

### Root Cause
In `bedrock.rs`, `daylight_cycle` was hardcoded to `0` in the level.dat structure. In Bedrock, `daylightCycle: 0` means "always day" (frozen time), which conflicts with `do_daylight_cycle: true` also being set.

### Solution
Changed `daylight_cycle` from `0` to `1`, which enables normal day/night progression. This is consistent with `do_daylight_cycle: true` already set in the game rules.

### Testing
- Verified the level.dat field mapping matches Bedrock documentation
- `do_daylight_cycle: true` + `daylight_cycle: 1` enables normal time progression
- No impact on Java edition (this field is Bedrock-only)

Fixes #1254

Signed-off-by: badhope <306089220+weed33834@users.noreply.github.com>