### PR TITLE
fix: allow EGL software rendering override (#1247)

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -122,9 +122,15 @@ pub fn run_gui() {
         env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
 
-        // Force software rendering for better compatibility
-        env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
-        env::set_var("GALLIUM_DRIVER", "softpipe");
+        // Force software rendering for better compatibility.
+        // Only set if not already configured by the user, allowing manual override
+        // for systems where software rendering causes EGL_BAD_PARAMETER (see #1247).
+        if env::var("LIBGL_ALWAYS_SOFTWARE").is_err() {
+            env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
+        }
+        if env::var("GALLIUM_DRIVER").is_err() {
+            env::set_var("GALLIUM_DRIVER", "softpipe");
+        }
 
         // Note: Removed sandbox disabling for security reasons
         // Note: Removed Qt WebEngine flags as they don't apply to Tauri


### PR DESCRIPTION
## Problem

Fixes #1247

On some Linux systems (Fedora KDE Plasma, Wayland, AMD graphics), the unconditional `LIBGL_ALWAYS_SOFTWARE=1` and `GALLIUM_DRIVER=softpipe` environment variables cause `EGL_BAD_PARAMETER` errors that prevent the UI from launching.

As noted by @JezSonic in [the issue](https://github.com/louis-e/arnis/issues/1247#issuecomment-3271008202), the problematic code is in `src/gui.rs` L126-127. @JEvan234 confirmed that commenting out these lines fixes the issue on Nobara 44.

## Solution

Instead of unconditionally forcing software rendering, only set these env vars when they are not already configured by the user. This allows users experiencing `EGL_BAD_PARAMETER` to override with:

```bash
LIBGL_ALWAYS_SOFTWARE=0 ./arnis
# or simply don't force software rendering
GALLIUM_DRIVER= ./arnis
```

## Changes

- `src/gui.rs`: Wrap `LIBGL_ALWAYS_SOFTWARE` and `GALLIUM_DRIVER` env var assignments in `if env::var(...).is_err()` checks
- Default behavior unchanged (software rendering still applied when not explicitly overridden)
- No breaking changes for existing users

## Testing

- Code compiles and passes `cargo fmt --check` and `cargo clippy -D warnings`
- Default behavior is preserved (env vars still set when not manually configured)
- Users can now override by setting env vars before launching arnis