### PR TITLE
Complete and correct the Mineclonia block mapping

### DIFF
--- a/src/luanti_block_map.rs
+++ b/src/luanti_block_map.rs
@@ -10,6 +10,12 @@ use fastnbt::Value;
  * version 2.1 of the License, or (at your option) any later version.
  */
 
+// Part of the table below no longer comes from MC2MT: node names added or
+// corrected since are read off the Mineclonia source (mods/ITEMS/**), which is
+// LGPL-2.1-or-later as well. The MC2MT attribution above still applies -- the
+// conv_* helpers are direct ports of its C macros, and most of the mapping is
+// unchanged from it.
+
 /// Supported Luanti game pack
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LuantiGame {
@@ -134,6 +140,7 @@ pub fn to_luanti_node(block: Block, game: LuantiGame, props: Option<&Value>) -> 
 
 fn to_mineclonia_node(block: Block, props: Option<&Value>) -> LuantiNode {
     let name = match block.id() {
+        0 => "mcl_trees:tree_mangrove",
         1 => "air",
         2 => "mcl_core:andesite",
         3 => "mcl_trees:leaves_birch",
@@ -169,9 +176,9 @@ fn to_mineclonia_node(block: Block, props: Option<&Value>) -> LuantiNode {
         33 => "mcl_colorblocks:hardened_clay_green",
         34 => "mcl_wool:green",
         35 => "mcl_farming:hay_block",
-        36 => "xpanes:bar_flat",
+        36 => "mcl_panes:bar_flat",
         37 => "mcl_core:ironblock",
-        38 => return conv_stair(props, "mcl_copper:waxed_cut_stair"), // WAXED_CUT_COPPER_STAIRS
+        38 => return conv_stair(props, "mcl_stairs:stair_copper_cut"), // WAXED_CUT_COPPER_STAIRS
         39 => "mcl_colorblocks:concrete_yellow",
         40 => "mcl_core:snow", // SNOW_LAYER
         41 => "mcl_colorblocks:hardened_clay_light_blue",
@@ -181,7 +188,7 @@ fn to_mineclonia_node(block: Block, props: Option<&Value>) -> LuantiNode {
         45 => "mcl_mud:mud_bricks",
         46 => "mcl_nether:nether_brick",
         47 => "mcl_nether:netheriteblock",
-        48 => "mcl_fences:fence",
+        48 => "mcl_fences:oak_fence",
         49 => "mcl_trees:leaves_oak",
         50 => "mcl_trees:tree_oak",
         51 => "mcl_trees:wood_oak",
@@ -199,11 +206,11 @@ fn to_mineclonia_node(block: Block, props: Option<&Value>) -> LuantiNode {
         63 => return conv_stair(props, "mcl_stairs:stair_deepslate_bricks"), // DEEPSLATE_BRICK_STAIRS
         64 => return conv_stair(props, "mcl_stairs:stair_deepslate_polished"), // POLISHED_DEEPSLATE_STAIRS
         65 => "mcl_nether:quartz_block",
-        66 => "mcl_ocean:kelp", // KELP
+        66 => "mcl_core:water_source", // KELP
         67 => "mcl_flowers:poppy",
         68 => "mcl_nether:red_nether_brick",
         69 => "mcl_colorblocks:hardened_clay_red",
-        70 => "mcl_ocean:tall_seagrass", // TALL_SEAGRASS_BOTTOM
+        70 => "mcl_core:water_source", // TALL_SEAGRASS_BOTTOM
         71 => "mcl_core:sand",
         72 => "mcl_core:sandstone",
         73 => "mcl_bamboo:scaffolding",
@@ -226,24 +233,33 @@ fn to_mineclonia_node(block: Block, props: Option<&Value>) -> LuantiNode {
         90 => "mcl_core:glass_white",
         91 => "mcl_colorblocks:hardened_clay_white",
         92 => "mcl_wool:white",
-        93 => "mcl_ocean:tall_seagrass", // TALL_SEAGRASS_TOP
+        93 => "mcl_core:water_source", // TALL_SEAGRASS_TOP
         94 => "mcl_flowers:dandelion",
-        95 => "mcl_ocean:sea_pickle", // SEA_PICKLE
-        96 => "mcl_nether:soul_sand", // SOUL_SAND
+        95 => "mcl_core:water_source", // SEA_PICKLE
+        96 => "mcl_nether:soul_sand",  // SOUL_SAND
         97 => return conv_stair(props, "mcl_stairs:stair_red_nether_brick"), // RED_NETHER_BRICK_STAIRS
+        98 => "mcl_walls:sandstone",
+        99 => "mcl_stairs:slab_sandstonesmooth",
         100 => "mcl_colorblocks:concrete_red",
         101 => "mcl_doors:iron_trapdoor", // IRON_TRAPDOOR
-        102 => return conv_stair(props, "mcl_copper:waxed_oxidized_cut_stair"), // WAXED_OXIDIZED_CUT_COPPER_STAIRS
+        102 => return conv_stair(props, "mcl_stairs:stair_copper_oxidized_cut"), // WAXED_OXIDIZED_CUT_COPPER_STAIRS
         103 => "mcl_copper:block_oxidized", // WAXED_OXIDIZED_COPPER (waxed variant approximated as oxidized)
         104 => "mcl_colorblocks:hardened_clay_yellow",
         105 => "mcl_farming:carrot_7",
-        106 => "mcl_doors:dark_oak_door_b_1",
-        107 => "mcl_doors:dark_oak_door_t_1",
+        106 => "mcl_doors:door_dark_oak_b_1",
+        107 => "mcl_doors:door_dark_oak_t_1",
         108 => "mcl_farming:potato_4",
         109 => "mcl_farming:wheat_7",
         110 => "mcl_core:bedrock",
         111 => "mcl_core:snowblock",
         112 => return conv_stair(props, "mcl_stairs:stair_andesite"), // ANDESITE_STAIRS
+        113 => {
+            return conv_trapdoor(
+                props,
+                "mcl_doors:trapdoor_jungle",
+                "mcl_doors:trapdoor_jungle_open",
+            )
+        } // JUNGLE_TRAPDOOR
         114 => "mcl_walls:andesite",
         115 => "mcl_walls:stonebrick",
         116..=125 => "mcl_minecarts:rail",
@@ -254,7 +270,7 @@ fn to_mineclonia_node(block: Block, props: Option<&Value>) -> LuantiNode {
         130 => "mcl_copper:stone_with_copper",
         131 => "mcl_core:clay",
         132 => "mcl_core:grass_path",
-        133 => return conv_stair(props, "mcl_copper:waxed_exposed_cut_stair"), // WAXED_EXPOSED_CUT_COPPER_STAIRS
+        133 => return conv_stair(props, "mcl_stairs:stair_copper_exposed_cut"), // WAXED_EXPOSED_CUT_COPPER_STAIRS
         134 => "mcl_core:packed_ice",
         135 => "mcl_mud:mud",
         136 => "mcl_core:deadbush",
@@ -266,17 +282,25 @@ fn to_mineclonia_node(block: Block, props: Option<&Value>) -> LuantiNode {
         142 => "mcl_books:bookshelf",
         143 => "mcl_trees:wood_oak",
         144 => return conv_stair(props, "mcl_stairs:stair_oak"),
+        145 => "mcl_colorblocks:concrete_orange",
         146 => "mcl_colorblocks:concrete_purple",
+        147 => "mcl_fences:birch_fence_gate",
+        148 => "mcl_fences:dark_oak_fence_gate",
         149 => "mcl_colorblocks:concrete_light_blue",
         150 => "mcl_core:stonebrickmossy", // MOSSY_STONE_BRICKS
         151 => "mcl_deepslate:deepslate",  // DEEPSLATE
         152 => "mcl_deepslate:tuff",       // TUFF
         153 => "mcl_deepslate:deepslate_cobbled", // COBBLED_DEEPSLATE
+        154 => "mcl_lanterns:lantern_floor",
         155 => "mcl_chests:chest",
+        156 => "mcl_buttons:button_stone_off",
         157 => "mcl_anvils:anvil",
         158 => "mcl_noteblock:noteblock",
+        159 => "mcl_deepslate:deepslatepolishedwall",
         160 => "mcl_brewing:stand_000",
         161 | 162 | 165..=168 | 294 | 295 => "mcl_beds:bed_red_bottom",
+        163 => "mcl_core:glass_black",
+        164 => "mcl_stairs:slab_andesite_smooth",
         169 => "mcl_core:glass_grey",
         170 => "mcl_core:glass_silver",
         171 => "mcl_core:glass_brown",
@@ -300,22 +324,39 @@ fn to_mineclonia_node(block: Block, props: Option<&Value>) -> LuantiNode {
         189 => "mcl_flowers:fern",
         190 => "mcl_colorblocks:concrete_lime",
         191 => "mcl_colorblocks:concrete_blue",
+        192 => "mcl_panes:pane_grey_flat",
+        193 => "mcl_fences:oak_fence_gate",
+        194 => "mcl_fences:spruce_fence_gate",
         195 => "mcl_copper:block", // WAXED_COPPER_BLOCK
+        196 => "mcl_panes:pane_natural_flat",
         197 => "mcl_flowers:double_fern",
         198 => "mcl_flowers:double_fern_top",
         199 => "mcl_copper:block_exposed", // WAXED_EXPOSED_COPPER
+        200 => return conv_stair(props, "mcl_stairs:stair_stone_rough"), // STONE_STAIRS
         201 => "mcl_lightning_rods:rod",
+        202 => "mcl_flowerpots:flower_pot",
         203 => "mcl_ocean:sea_lantern",
-        204 => "mcl_copper:block_chiseled_exposed", // WAXED_EXPOSED_CHISELED_COPPER
+        204 => "mcl_copper:block_exposed_chiseled", // WAXED_EXPOSED_CHISELED_COPPER
+        205 => "mcl_stairs:slab_warped",
+        206 => return conv_stair(props, "mcl_stairs:stair_warped"), // WARPED_STAIRS
         207 => "mcl_colorblocks:concrete_green",
         208 => "mcl_walls:brick",
         209 => "mcl_redstone_torch:redstoneblock",
         210 | 362 => "mcl_lanterns:chain",
+        211 => {
+            return conv_trapdoor(
+                props,
+                "mcl_doors:trapdoor_warped",
+                "mcl_doors:trapdoor_warped_open",
+            )
+        } // WARPED_TRAPDOOR
+        212 => "mcl_trees:stripped_warped",
+        213 => "mcl_trees:bark_stripped_warped",
         214 => "mcl_stairs:slab_stone_double",
-        215 => "mcl_copper:block_cut_exposed", // WAXED_EXPOSED_CUT_COPPER
+        215 => "mcl_copper:block_exposed_cut", // WAXED_EXPOSED_CUT_COPPER
         216 => "mcl_colorblocks:hardened_clay_silver",
         217 => "mcl_stairs:slab_oak",
-        218 => "mcl_redstone_lamps:lamp_on", // REDSTONE_LAMP (only placed lit)
+        218 => "mcl_redstone_lamp:lamp_on", // REDSTONE_LAMP (only placed lit)
         219 => "mcl_trees:tree_dark_oak",
         220 => "mcl_trees:leaves_dark_oak",
         221 => "mcl_trees:tree_jungle",
@@ -327,34 +368,42 @@ fn to_mineclonia_node(block: Block, props: Option<&Value>) -> LuantiNode {
         227 => "mcl_core:glass_blue",
         228 => "mcl_core:glass_light_blue",
         229 => "mcl_daylight_detector:daylight_detector",
-        230 => "mcl_cherry_blossom:cherrytree", // CHERRY_LOG (Mineclonia may not have cherry yet)
-        231 => "mcl_cherry_blossom:leaves",     // CHERRY_LEAVES (fallback if cherry missing)
+        230 => "mcl_trees:tree_cherry_blossom", // CHERRY_LOG (Mineclonia may not have cherry yet)
+        231 => "mcl_trees:leaves_cherry_blossom", // CHERRY_LEAVES (fallback if cherry missing)
         232 => "mcl_colorblocks:concrete_powder_brown", // BROWN_CONCRETE_POWDER
+        233 => "mcl_trees:leaves_mangrove",
+        234 => "mcl_trees:leaves_azalea",
         235 => "mcl_flowers:poppy",
-        236 | 299 => return conv_trapdoor(props, "mcl_doors:trapdoor", "mcl_doors:trapdoor_open"),
-        237 => "mcl_core:reeds",     // SUGAR_CANE
-        238 => "mcl_ocean:seagrass", // SEAGRASS
-        239 => "mcl_ocean:kelp",     // KELP_PLANT
+        236 | 299 => {
+            return conv_trapdoor(
+                props,
+                "mcl_doors:trapdoor_oak",
+                "mcl_doors:trapdoor_oak_open",
+            )
+        }
+        237 => "mcl_core:reeds",        // SUGAR_CANE
+        238 => "mcl_core:water_source", // SEAGRASS
+        239 => "mcl_core:water_source", // KELP_PLANT
         240 => "mcl_stairs:slab_quartzblock",
         241 => {
             return conv_trapdoor(
                 props,
-                "mcl_doors:dark_oak_trapdoor",
-                "mcl_doors:dark_oak_trapdoor_open",
+                "mcl_doors:trapdoor_dark_oak",
+                "mcl_doors:trapdoor_dark_oak_open",
             )
         }
         242 => {
             return conv_trapdoor(
                 props,
-                "mcl_doors:spruce_trapdoor",
-                "mcl_doors:spruce_trapdoor_open",
+                "mcl_doors:trapdoor_spruce",
+                "mcl_doors:trapdoor_spruce_open",
             )
         }
         243 => {
             return conv_trapdoor(
                 props,
-                "mcl_doors:birch_trapdoor",
-                "mcl_doors:birch_trapdoor_open",
+                "mcl_doors:trapdoor_birch",
+                "mcl_doors:trapdoor_birch_open",
             )
         }
         244 => "mcl_stairs:slab_mud_brick",
@@ -362,35 +411,155 @@ fn to_mineclonia_node(block: Block, props: Option<&Value>) -> LuantiNode {
         246 => "mcl_flowers:tulip_red",
         247 => "mcl_flowers:dandelion",
         248 => "mcl_flowers:blue_orchid",
+        249 => "mcl_core:stone_with_diamond",
+        250 => "mcl_core:stone_with_redstone",
+        251 => "mcl_core:stone_with_lapis",
         252 => "mcl_colorblocks:concrete_powder_grey", // GRAY_CONCRETE_POWDER
         253 => "mcl_colorblocks:hardened_clay_cyan",   // CYAN_TERRACOTTA
         254 => "mcl_wool:black",                       // BLACK_WOOL
-        255 => "mcl_banners:hanging_banner_silver",    // LIGHT_GRAY_WALL_BANNER
-        256 => "mesecons_walllever:wall_lever_off",    // LEVER
+        255 => "mcl_banners:hanging_banner",           // LIGHT_GRAY_WALL_BANNER
+        256 => "mcl_lever:lever_off",                  // LEVER
+        257 => "mcl_grindstone:grindstone",
         258 => "mcl_minecarts:rail",
         259 => "mcl_wool:red",
         260 => "mcl_core:ladder",
         261 => "mcl_wool:yellow",
-        274 => "mcl_signs:wall_sign",
-        275 => "mcl_banners:hanging_banner_blue", // BLUE_WALL_BANNER
-        277 => "mcl_banners:hanging_banner_black", // BLACK_WALL_BANNER
-        278 => "mcl_banners:hanging_banner_red",  // RED_WALL_BANNER
-        285 => "mcl_banners:hanging_banner_green", // GREEN_WALL_BANNER
-        286 => "mcl_cauldrons:cauldron_3",        // WATER_CAULDRON (filled)
+        265 => "mcl_stairs:slab_cobble",
+        266 => "mcl_fences:nether_brick_fence",
+        267 => "mcl_fences:birch_fence",
+        268 => "mcl_stairs:slab_quartz_smooth",
+        269 => return conv_stair(props, "mcl_stairs:stair_quartz_smooth"), // SMOOTH_QUARTZ_STAIRS
+        270 => return conv_stair(props, "mcl_stairs:stair_blackstone"),    // BLACKSTONE_STAIRS
+        271 => "mcl_blackstone:wall",
+        272 => "mcl_walls:diorite",
+        273 => "mcl_stairs:slab_deepslate_polished",
+        274 => "mcl_signs:wall_sign_oak",
+        275 => "mcl_banners:hanging_banner", // BLUE_WALL_BANNER
+        276 => "mcl_fences:jungle_fence",
+        277 => "mcl_banners:hanging_banner", // BLACK_WALL_BANNER
+        278 => "mcl_banners:hanging_banner", // RED_WALL_BANNER
+        279 => "mcl_doors:door_birch_b_1",
+        280 => "mcl_pressureplates:pressure_plate_birch_off",
+        281 => "mcl_pressureplates:pressure_plate_stone_off",
+        282 => "mcl_blast_furnace:blast_furnace",
+        283 => "mcl_dispensers:dispenser",
+        284 => "mcl_hoppers:hopper",
+        285 => "mcl_banners:hanging_banner", // GREEN_WALL_BANNER
+        286 => "mcl_cauldrons:cauldron_3",   // WATER_CAULDRON (filled)
+        287 => "mcl_compass:lodestone",
+        288 => "mcl_redstone_torch:redstone_torch_on",
         289 => "mcl_wool:red_carpet",
-        293 => "mcl_doors:wooden_door_b_1",
+        290 => "mcl_blackstone:blackstone_chiseled_polished",
+        291 => "mcl_walls:stonebrickmossy",
+        292 => return conv_stair(props, "mcl_stairs:stair_bamboo"), // BAMBOO_STAIRS
+        293 => "mcl_doors:door_oak_b_1",
+        296 => "mcl_walls:endbricks",
+        297 => "mcl_stairs:slab_bamboo",
+        298 => "mcl_deepslate:deepslate_chiseled",
+        300 => "mcl_buttons:button_birch_off",
         301 => "mcl_core:cobweb",
+        302 => "mcl_stairs:slab_dark_oak",
+        303 => "mcl_stairs:slab_jungle",
+        304 => return conv_stair(props, "mcl_stairs:stair_jungle"), // JUNGLE_STAIRS
         305 | 316 | 320 | 326 => "mcl_books:bookshelf",
+        306 => "mcl_buttons:button_oak_off",
+        307 => "mcl_minecarts:golden_rail",
+        308 => "mcl_fences:spruce_fence",
+        309 => "mcl_stairs:slab_spruce",
+        310 => "mcl_stairs:slab_andesite",
+        311 => "mcl_stairs:slab_deepslate_cobbled",
+        312 => return conv_stair(props, "mcl_stairs:stair_deepslate_cobbled"), // COBBLED_DEEPSLATE_STAIRS
+        313 => "mcl_fences:dark_oak_fence",
+        314 => "mcl_pressureplates:pressure_plate_dark_oak_off",
+        317 => "mcl_banners:hanging_banner",
+        318 => "mcl_wool:grey",
+        319 => "mcl_nether:nether_wart_block",
+        321 => "mcl_blackstone:basalt_polished",
+        322 => "mcl_buttons:button_polished_blackstone_off",
+        323 => "mcl_pressureplates:pressure_plate_polished_blackstone_off",
+        324 => "mcl_stairs:slab_red_nether_brick",
+        325 => "mcl_buttons:button_spruce_off",
+        327 => {
+            return conv_trapdoor(
+                props,
+                "mcl_doors:trapdoor_acacia",
+                "mcl_doors:trapdoor_acacia_open",
+            )
+        } // ACACIA_TRAPDOOR
+        328 => "mcl_composters:composter",
+        329 => "mcl_wool:cyan_carpet",
+        330 => "mcl_buttons:button_dark_oak_off",
+        331 => "mcl_stairs:slab_end_bricks",
         332 => "mcl_anvils:anvil_damage_2",
+        333 => "mcl_wool:green_carpet",
+        334 => "mcl_wool:light_blue_carpet",
+        335 => "mcl_walls:netherbrick",
+        336 => "mcl_smoker:smoker",
+        337 => "mcl_core:redsandstonesmooth2",
+        338 => "mcl_stairs:slab_redsandstonesmooth2",
+        339 => "mcl_panes:pane_blue_flat",
+        340 => "mcl_wool:cyan",
+        341 => "mcl_wool:silver_carpet",
+        342 => "mcl_stairs:slab_mossycobble",
+        343 => "mcl_stairs:slab_stonebrickmossy",
+        344 => "mcl_ocean:prismarine",
         345 => "mcl_end:end_rod",
+        347 => "mcl_signs:wall_sign_spruce",
+        348 => return conv_stair(props, "mcl_stairs:stair_granite"), // GRANITE_STAIRS
+        349 => return conv_stair(props, "mcl_stairs:stair_diorite"), // DIORITE_STAIRS
+        350 => "mcl_deepslate:deepslate_tiles",
+        351 => "mcl_stairs:slab_deepslate_tiles",
+        352 => "mcl_deepslate:deepslatetileswall",
+        353 => "mcl_stairs:slab_blackstone_polished",
+        354 => "mcl_stairs:slab_diorite_smooth",
+        355 => "mcl_lanterns:soul_lantern_floor",
+        356 => "mcl_nether:quartz_chiseled",
+        357 => "mcl_nether:quartz_pillar",
+        358 => "mcl_redstone_torch:redstone_torch_on_wall",
         359 => "mcl_core:goldblock",
         360 => "mcl_wool:orange",
         361 => "mcl_wool:blue",
-        363 => "mcl_banners:hanging_banner_white", // WHITE_WALL_BANNER
-        364 => "mcl_doors:spruce_door_b_1",
-        365 => "mcl_doors:spruce_door_t_1",
-        366 => "mcl_doors:wooden_door_b_1",
+        363 => "mcl_banners:hanging_banner", // WHITE_WALL_BANNER
+        364 => "mcl_doors:door_spruce_b_1",
+        365 => "mcl_doors:door_spruce_t_1",
+        366 => "mcl_doors:door_oak_b_1",
         _ => "mcl_core:stone",
     };
     LuantiNode { name, param2: 0 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_definitions::STONE;
+
+    /// Blocks Mineclonia has no node for, so they can only fall back. Keep this
+    /// list short: every entry is a block that exports as plain stone.
+    const NO_MINECLONIA_NODE: &[&str] = &["tripwire_hook"];
+
+    /// The fallback arm is silent -- an unmapped block turns into stone in the
+    /// exported world rather than failing. Walk the whole palette so that adding
+    /// a block without a Mineclonia node fails here instead of in someone's map.
+    #[test]
+    fn every_block_maps_to_a_mineclonia_node() {
+        let mut unmapped = Vec::new();
+        for id in 0..=u16::MAX {
+            let block = Block::from_raw_id(id);
+            let Some(name) = block.try_name() else {
+                continue;
+            };
+            if block == STONE || NO_MINECLONIA_NODE.contains(&name) {
+                continue;
+            }
+            if to_mineclonia_node(block, None).name == "mcl_core:stone" {
+                unmapped.push(format!("{name} (id {id})"));
+            }
+        }
+        assert!(
+            unmapped.is_empty(),
+            "these blocks fall through to the mcl_core:stone fallback and would \
+             export as stone: {unmapped:?}. Add a Mineclonia node for each, or \
+             list it in NO_MINECLONIA_NODE if Mineclonia genuinely has none.",
+        );
+    }
 }


### PR DESCRIPTION
Follow-up to #1267. That PR only permuted ids; this one fills in the Luanti export gap the review of it pointed at.

## The gap

`to_mineclonia_node` fell back to `mcl_core:stone` for **104 of the 363** palette blocks. Mangrove logs and leaves, azalea leaves, the diamond/redstone/lapis ores, most walls, slabs and stairs, every button, pressure plate and fence gate, lanterns, hoppers and dispensers all exported as plain stone. All are mapped now.

Only `TRIPWIRE_HOOK` is left unmapped, because Mineclonia has no node for it.

## Names that pointed at nothing

While checking every name against the Mineclonia source, 35 entries in the existing table turned out not to resolve — those blocks were exporting as *unknown* nodes, which is worse than stone:

| was | is | why |
| --- | --- | --- |
| `mcl_redstone_lamps:lamp_on` | `mcl_redstone_lamp:lamp_on` | the mod is singular |
| `mcl_banners:hanging_banner_<colour>` (×6) | `mcl_banners:hanging_banner` | banners are one node; colour lives in metadata |
| `mcl_cherry_blossom:leaves` | `mcl_trees:leaves_cherry_blossom` | cherry moved into `mcl_trees` |
| `mcl_copper:block_cut_exposed` | `mcl_copper:block_exposed_cut` | variant comes before shape |
| `mcl_copper:waxed_*_cut_stair` (×3) | `mcl_stairs:stair_copper_*_cut` | cut-copper stairs live in `mcl_stairs` |
| `mcl_ocean:kelp` / `seagrass` / `tall_seagrass` / `sea_pickle` | `mcl_core:water_source` | see below |

Kelp, seagrass and sea pickles are `plantlike_rooted` in Mineclonia: the node sits in the sea floor and draws the plant in the space above it, so there is nothing to place in the water column itself. Water is the honest stand-in until the exporter can rewrite the sea floor instead.

The rest of the renames are legacy MineClone2 names (`mesecons_walllever:…`, `xpanes:bar_flat`, `mcl_doors:spruce_door_b_1`, …). Those still work, but only because the `mcl_aliases` compat mod maps them; they now use the current names directly.

## How the names were checked

Not guessed. Every name is resolved against a shallow checkout of the Mineclonia sources, including the ones built by registration helpers (`mcl_stairs.register_stair`, `mcl_trees.register_wood`, the `mcl_dyes.colors` loops, `mcl_deepslate.register_variants`, …) rather than written out literally.

## Guard

`every_block_maps_to_a_mineclonia_node` walks the whole palette and fails if any block reaches the fallback arm, with an explicit `NO_MINECLONIA_NODE` list for blocks Mineclonia genuinely lacks. This is the "make the fallback loud" suggestion from the #1267 review, in a form that can actually be committed now that the gap is closed.

## Attribution

The MC2MT LGPL-2.1 notice stays — the `conv_*` helpers are still direct ports of its C macros and most of the table is unchanged from it. Added a note that the newer entries come from the Mineclonia source instead (also LGPL-2.1-or-later).

`cargo test`: 444 passed. `cargo clippy --all-targets`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
