### PR TITLE
Straighten ESA shorelines and keep water level with its terrain

### DIFF
--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -226,6 +226,7 @@ fn process_element(
     tunnel_cells: &mut Vec<highways::HighwayTunnelCell>,
     part_groups: &PartGroups,
     group_members: &FnvHashMap<u64, Vec<u64>>,
+    still_surfaces: &water_areas::StillWaterSurfaces,
 ) {
     let signage = editor.signage_enabled();
     match element {
@@ -314,14 +315,14 @@ fn process_element(
             } else if way.tags.contains_key("barrier") {
                 barriers::generate_barriers(editor, element, bridge_surface);
             } else if let Some(val) = way.tags.get("waterway") {
-                if val == "dock" {
-                    // docks count as water areas
+                if val == "dock" || val == "riverbank" {
+                    // docks and (legacy) riverbank areas count as water areas
                     water_areas::generate_water_area_from_way(
                         editor,
                         way,
-                        xzbbox,
                         big_water_field,
                         road_mask,
+                        still_surfaces,
                     );
                 } else {
                     waterways::generate_waterways(editor, way);
@@ -436,6 +437,7 @@ fn process_element(
                     xzbbox,
                     big_water_field,
                     road_mask,
+                    still_surfaces,
                 );
             } else if rel.tags.contains_key("natural") {
                 natural::generate_natural_from_relation(
@@ -601,6 +603,8 @@ pub fn generate_world_with_options(
 
     // Per-cell water depth field from the LC_WATER mask; empty without land cover.
     let big_water_field = crate::water_depth::compute_big_water_field(&ground, &xzbbox);
+    // Resolved once here: a body spanning many tiles must not be measured per tile.
+    let still_surfaces = water_areas::prescan_still_surfaces(&elements, &ground, &xzbbox);
 
     println!("{} Processing data...", "[4/7]".bold());
     emit_gui_progress_update(19.5, "Processing data...");
@@ -891,6 +895,7 @@ pub fn generate_world_with_options(
                             &mut tile_tunnel_cells,
                             &part_groups,
                             &group_members,
+                            &still_surfaces,
                         );
                     }
 
@@ -1170,6 +1175,7 @@ pub fn generate_world_with_options(
                 &mut tunnel_cells,
                 &part_groups,
                 &group_members,
+                &still_surfaces,
             );
 
             // Release flood fill cache entries for memory optimization.

--- a/src/element_processing/water_areas.rs
+++ b/src/element_processing/water_areas.rs
@@ -1,26 +1,39 @@
 use crate::clipping::clip_water_ring_to_bbox;
 use crate::floodfill_cache::RoadMaskBitmap;
+use crate::ground::Ground;
 use crate::water_depth::{carve_water_column, BigWaterField};
 use crate::{
     coordinate_system::cartesian::{XZBBox, XZPoint},
-    osm_parser::{ProcessedMemberRole, ProcessedNode, ProcessedRelation, ProcessedWay},
+    osm_parser::{
+        ProcessedElement, ProcessedMemberRole, ProcessedNode, ProcessedRelation, ProcessedWay,
+    },
     world_editor::WorldEditor,
 };
+use fnv::FnvHashMap;
+use rayon::prelude::*;
 
 pub fn generate_water_area_from_way(
     editor: &mut WorldEditor,
     element: &ProcessedWay,
-    _xzbbox: &XZBBox,
     bwf: &BigWaterField,
     road_mask: &RoadMaskBitmap,
+    surfaces: &StillWaterSurfaces,
 ) {
-    let outers = [element.nodes.clone()];
+    let Some(outers) = way_rings(element) else {
+        return;
+    };
+    let surface = surfaces.get("way", element.id);
+    generate_water_areas(editor, &outers, &[], bwf, road_mask, surface);
+}
+
+/// Outer rings of a water way, or None if the ring is not usable.
+fn way_rings(element: &ProcessedWay) -> Option<Vec<Vec<ProcessedNode>>> {
+    let outers = vec![element.nodes.clone()];
     if !verify_closed_rings(&outers) {
         println!("Skipping way {} due to invalid polygon", element.id);
-        return;
+        return None;
     }
-
-    generate_water_areas(editor, &outers, &[], bwf, road_mask);
+    Some(outers)
 }
 
 pub fn generate_water_areas_from_relation(
@@ -29,7 +42,21 @@ pub fn generate_water_areas_from_relation(
     xzbbox: &XZBBox,
     bwf: &BigWaterField,
     road_mask: &RoadMaskBitmap,
+    surfaces: &StillWaterSurfaces,
 ) {
+    let Some((outers, inners)) = relation_rings(element, xzbbox) else {
+        return;
+    };
+    let surface = surfaces.get("relation", element.id);
+    generate_water_areas(editor, &outers, &inners, bwf, road_mask, surface);
+}
+
+/// Outer and inner rings of a water relation, or None if it is not water or unusable.
+#[allow(clippy::type_complexity)]
+fn relation_rings(
+    element: &ProcessedRelation,
+    xzbbox: &XZBBox,
+) -> Option<(Vec<Vec<ProcessedNode>>, Vec<Vec<ProcessedNode>>)> {
     // Check if this is a water relation (either with water tag or natural=water)
     let is_water = element.tags.contains_key("water")
         || element
@@ -39,13 +66,13 @@ pub fn generate_water_areas_from_relation(
             .unwrap_or(false);
 
     if !is_water {
-        return;
+        return None;
     }
 
     // Don't handle water below layer 0
     if let Some(layer) = element.tags.get("layer") {
         if layer.parse::<i32>().map(|x| x < 0).unwrap_or(false) {
-            return;
+            return None;
         }
     }
 
@@ -105,23 +132,23 @@ pub fn generate_water_areas_from_relation(
 
         // If no valid outer loops remain, skip the relation
         if outers.is_empty() {
-            return;
+            return None;
         }
 
         // Verify again after filtering and closing
         if !verify_closed_rings(&outers) {
             println!("Skipping relation {} due to invalid polygon", element.id);
-            return;
+            return None;
         }
     }
 
     super::merge_way_segments(&mut inners);
     if !verify_closed_rings(&inners) {
         println!("Skipping relation {} due to invalid polygon", element.id);
-        return;
+        return None;
     }
 
-    generate_water_areas(editor, &outers, &inners, bwf, road_mask);
+    Some((outers, inners))
 }
 
 fn generate_water_areas(
@@ -130,6 +157,7 @@ fn generate_water_areas(
     inners: &[Vec<ProcessedNode>],
     bwf: &BigWaterField,
     road_mask: &RoadMaskBitmap,
+    still_surface: Option<i32>,
 ) {
     // Calculate polygon bounding box to limit fill area
     let mut poly_min_x = i32::MAX;
@@ -169,7 +197,16 @@ fn generate_water_areas(
         .collect();
 
     scanline_fill_water(
-        min_x, min_z, max_x, max_z, &outers_xz, &inners_xz, editor, bwf, road_mask,
+        min_x,
+        min_z,
+        max_x,
+        max_z,
+        &outers_xz,
+        &inners_xz,
+        editor,
+        bwf,
+        road_mask,
+        still_surface,
     );
 
     // Scatter boats over open water; grid on a global lattice with independent rolls, so the set is identical across parallel tiles.
@@ -389,11 +426,246 @@ fn subtract_spans(a: &[(i32, i32)], b: &[(i32, i32)]) -> Vec<(i32, i32)> {
     result
 }
 
+/// Polygon edges prepared for scanline filling: one edge list per outer ring
+/// (unioned per row, so overlapping outer rings still fill correctly) and the
+/// combined inner-ring edges (subtracted).
+struct PolygonEdges {
+    outer_groups: Vec<Vec<ScanlineEdge>>,
+    inner: Vec<ScanlineEdge>,
+}
+
+impl PolygonEdges {
+    fn new(outers: &[Vec<XZPoint>], inners: &[Vec<XZPoint>]) -> Self {
+        Self {
+            outer_groups: outers.iter().map(|ring| collect_ring_edges(ring)).collect(),
+            inner: collect_all_ring_edges(inners),
+        }
+    }
+
+    /// Filled x-spans of row `z`, clamped to `[min_x, max_x]`.
+    fn row_spans(&self, z: i32, min_x: i32, max_x: i32) -> Vec<(i32, i32)> {
+        let z_f = z as f64;
+        let mut outer_spans: Vec<(i32, i32)> = Vec::new();
+        for ring_edges in &self.outer_groups {
+            let ring_spans = compute_scanline_spans(ring_edges, z_f, min_x, max_x);
+            if !ring_spans.is_empty() {
+                outer_spans = union_spans(&outer_spans, &ring_spans);
+            }
+        }
+        if outer_spans.is_empty() || self.inner.is_empty() {
+            return outer_spans;
+        }
+        let inner_spans = compute_scanline_spans(&self.inner, z_f, min_x, max_x);
+        if inner_spans.is_empty() {
+            outer_spans
+        } else {
+            subtract_spans(&outer_spans, &inner_spans)
+        }
+    }
+}
+
+/// Filled spans of a polygon for a range of rows, computed once.
+struct SpanRows {
+    rows: Vec<Vec<(i32, i32)>>,
+    z0: i32,
+}
+
+impl SpanRows {
+    fn build(edges: &PolygonEdges, z0: i32, z1: i32, min_x: i32, max_x: i32) -> Self {
+        let rows = (z0..=z1)
+            .map(|z| edges.row_spans(z, min_x, max_x))
+            .collect();
+        Self { rows, z0 }
+    }
+
+    fn get(&self, z: i32) -> &[(i32, i32)] {
+        match usize::try_from(z - self.z0) {
+            Ok(i) if i < self.rows.len() => &self.rows[i],
+            _ => &[],
+        }
+    }
+
+    fn contains(&self, x: i32, z: i32) -> bool {
+        let spans = self.get(z);
+        spans
+            .binary_search_by(|&(a, b)| {
+                if x < a {
+                    std::cmp::Ordering::Greater
+                } else if x > b {
+                    std::cmp::Ordering::Less
+                } else {
+                    std::cmp::Ordering::Equal
+                }
+            })
+            .is_ok()
+    }
+
+    /// True if `(x, z)` and its four neighbours `margin` cells away are all inside.
+    fn contains_interior(&self, x: i32, z: i32, margin: i32) -> bool {
+        self.contains(x - margin, z)
+            && self.contains(x + margin, z)
+            && self.contains(x, z - margin)
+            && self.contains(x, z + margin)
+    }
+}
+
+/// How far a still body's surface may sit above the terrain before the column is left as
+/// land. Past this the carve and its backfill no longer reach the ground.
+const MAX_STILL_FILL_DROP: i32 = 20;
+
+/// How far from the polygon edge a column must be to count as interior rather than bank.
+/// Matches the water-level snap radius, so a snapped bank cell is never mistaken for one.
+const INTERIOR_MARGIN: i32 = 4;
+
+/// Share of a polygon's columns that must be ESA water to trust ESA's leveled surface.
+const STILL_SURFACE_MIN_LC_SHARE: f64 = 0.3;
+/// ...and at least this many such columns.
+const STILL_SURFACE_MIN_LC_COLUMNS: usize = 64;
+/// Rough cap on the number of columns sampled for the surface statistics.
+const STILL_SURFACE_MAX_SAMPLES: usize = 250_000;
+
+/// Water surface Y of every still OSM water body, resolved once per element.
+#[derive(Default)]
+pub struct StillWaterSurfaces(FnvHashMap<(&'static str, u64), i32>);
+
+impl StillWaterSurfaces {
+    fn get(&self, kind: &'static str, id: u64) -> Option<i32> {
+        self.0.get(&(kind, id)).copied()
+    }
+}
+
+/// Resolve every water polygon's surface before the tile fan-out, so a body spanning
+/// many tiles is measured once and every tile agrees.
+pub fn prescan_still_surfaces(
+    elements: &[ProcessedElement],
+    ground: &Ground,
+    xzbbox: &XZBBox,
+) -> StillWaterSurfaces {
+    if !ground.has_land_cover() || !ground.elevation_enabled {
+        return StillWaterSurfaces::default();
+    }
+    let entries: Vec<((&'static str, u64), i32)> = elements
+        .par_iter()
+        .filter_map(|element| {
+            let (key, outers, inners) = match element {
+                ProcessedElement::Way(way) if is_water_area_way(way) => {
+                    (("way", way.id), way_rings(way)?, Vec::new())
+                }
+                ProcessedElement::Relation(rel) => {
+                    let (outers, inners) = relation_rings(rel, xzbbox)?;
+                    (("relation", rel.id), outers, inners)
+                }
+                _ => return None,
+            };
+            let to_xz = |rings: &[Vec<ProcessedNode>]| -> Vec<Vec<XZPoint>> {
+                rings
+                    .iter()
+                    .map(|r| r.iter().map(|n| n.xz()).collect())
+                    .collect()
+            };
+            let surface = still_surface_level(ground, &to_xz(&outers), &to_xz(&inners), xzbbox)?;
+            Some((key, surface))
+        })
+        .collect();
+    StillWaterSurfaces(entries.into_iter().collect())
+}
+
+/// Whether a way is rendered as a water area (mirrors the dispatch in data_processing).
+fn is_water_area_way(way: &ProcessedWay) -> bool {
+    way.tags.contains_key("water")
+        || matches!(
+            way.tags.get("natural").map(String::as_str),
+            Some("water" | "bay")
+        )
+        || matches!(
+            way.tags.get("waterway").map(String::as_str),
+            Some("dock" | "riverbank")
+        )
+}
+
+/// The single water-surface Y of a polygon that ESA also sees as one still body.
+///
+/// OSM draws water at full pool while ESA and the DEM have today's water, so a
+/// drawn-down reservoir has columns well above it. Filling those at their own height
+/// terraces water up the exposed bank. When enough of the polygon is ESA water sitting
+/// at one leveled Y, that Y is the surface. Rivers are leveled per cell and never pass
+/// the single-Y test, so they keep the per-column fill.
+fn still_surface_level(
+    ground: &Ground,
+    outers: &[Vec<XZPoint>],
+    inners: &[Vec<XZPoint>],
+    xzbbox: &XZBBox,
+) -> Option<i32> {
+    let (mut min_x, mut min_z) = (i32::MAX, i32::MAX);
+    let (mut max_x, mut max_z) = (i32::MIN, i32::MIN);
+    for ring in outers {
+        for p in ring {
+            min_x = min_x.min(p.x);
+            max_x = max_x.max(p.x);
+            min_z = min_z.min(p.z);
+            max_z = max_z.max(p.z);
+        }
+    }
+    let min_x = min_x.max(xzbbox.min_x());
+    let min_z = min_z.max(xzbbox.min_z());
+    let max_x = max_x.min(xzbbox.max_x());
+    let max_z = max_z.min(xzbbox.max_z());
+    if min_x > max_x || min_z > max_z {
+        return None;
+    }
+
+    // Sample on a lattice so the cost follows the sample count, not the area.
+    let area = (i64::from(max_x - min_x) + 1) * (i64::from(max_z - min_z) + 1);
+    let stride = ((area as f64 / STILL_SURFACE_MAX_SAMPLES as f64)
+        .sqrt()
+        .ceil() as i32)
+        .max(1);
+    let edges = PolygonEdges::new(outers, inners);
+    let (off_x, off_z) = (xzbbox.min_x(), xzbbox.min_z());
+    let mut total = 0usize;
+    let mut lc_levels: Vec<i32> = Vec::new();
+    let mut z = min_z;
+    while z <= max_z {
+        for (start, end) in edges.row_spans(z, min_x, max_x) {
+            // Keep the lattice anchored to the world grid so it does not shift per polygon.
+            let mut x = start + (stride - start.rem_euclid(stride)).rem_euclid(stride);
+            while x <= end {
+                total += 1;
+                let coord = XZPoint::new(x - off_x, z - off_z);
+                if ground.cover_class(coord) == crate::land_cover::LC_WATER {
+                    lc_levels.push(ground.level(coord));
+                }
+                x += stride;
+            }
+        }
+        z += stride;
+    }
+    if lc_levels.len() < STILL_SURFACE_MIN_LC_COLUMNS
+        || (lc_levels.len() as f64) < STILL_SURFACE_MIN_LC_SHARE * total as f64
+    {
+        return None;
+    }
+    let n = lc_levels.len();
+    let (q1, q3) = (n / 4, (n * 3) / 4);
+    lc_levels.select_nth_unstable(q1);
+    let q1_val = lc_levels[q1];
+    lc_levels.select_nth_unstable(q3);
+    let q3_val = lc_levels[q3];
+    if q1_val != q3_val {
+        return None;
+    }
+    lc_levels.select_nth_unstable(n / 2);
+    Some(lc_levels[n / 2])
+}
+
 /// Fills water blocks using scanline rasterization.
 ///
 /// For each row z in [min_z, max_z], computes which x positions are inside
 /// any outer polygon ring but outside all inner polygon rings, and places
 /// water blocks at those positions.
+///
+/// With `still_surface`, columns above that Y are skipped and the rest filled at it.
+/// Otherwise each column is filled at its own water level.
 #[allow(clippy::too_many_arguments)]
 fn scanline_fill_water(
     min_x: i32,
@@ -405,52 +677,46 @@ fn scanline_fill_water(
     editor: &mut WorldEditor,
     bwf: &BigWaterField,
     road_mask: &RoadMaskBitmap,
+    still_surface: Option<i32>,
 ) {
-    // Collect edges per outer ring so we can union their spans correctly,
-    // even if multiple outer rings happen to overlap (invalid OSM, but
-    // we handle it gracefully).
-    let outer_edge_groups: Vec<Vec<ScanlineEdge>> =
-        outers.iter().map(|ring| collect_ring_edges(ring)).collect();
-    let inner_edges = collect_all_ring_edges(inners);
+    let edges = PolygonEdges::new(outers, inners);
+    // Widened by the interior margin so the interior test reads cached spans too.
+    let m = INTERIOR_MARGIN;
+    let spans = SpanRows::build(&edges, min_z - m, max_z + m, min_x - m, max_x + m);
 
     for z in min_z..=max_z {
-        let z_f = z as f64;
-
-        // Compute spans for each outer ring and union them together
-        let mut outer_spans: Vec<(i32, i32)> = Vec::new();
-        for ring_edges in &outer_edge_groups {
-            let ring_spans = compute_scanline_spans(ring_edges, z_f, min_x, max_x);
-            if !ring_spans.is_empty() {
-                outer_spans = union_spans(&outer_spans, &ring_spans);
-            }
-        }
-        if outer_spans.is_empty() {
-            continue;
-        }
-
-        let fill_spans = if inner_edges.is_empty() {
-            outer_spans
-        } else {
-            let inner_spans = compute_scanline_spans(&inner_edges, z_f, min_x, max_x);
-            if inner_spans.is_empty() {
-                outer_spans
-            } else {
-                subtract_spans(&outer_spans, &inner_spans)
-            }
-        };
-
-        for (start, end) in fill_spans {
+        for &(span_start, span_end) in spans.get(z) {
+            let (start, end) = (span_start.max(min_x), span_end.min(max_x));
             for x in start..=end {
                 // Keep road/bridge surfaces (carve would overwrite them).
                 if road_mask.contains(x, z) {
                     continue;
                 }
-                let water_y = editor.get_water_level(x, z);
                 let ground_y = editor.get_ground_level(x, z);
-                // Skip hillside blocks the polygon claims above the waterline.
-                if ground_y > water_y {
-                    continue;
-                }
+                let water_y = match still_surface {
+                    Some(surface) => {
+                        // Exposed bank above the body's surface, or terrain so far below it
+                        // that the fill would hang a slab over open air: no water.
+                        if ground_y > surface || surface - ground_y > MAX_STILL_FILL_DROP {
+                            continue;
+                        }
+                        surface
+                    }
+                    None => {
+                        let water_y = editor.get_water_level(x, z);
+                        if ground_y > water_y {
+                            // A lower neighbour within the snap radius: a bank the
+                            // polygon overclaims (skip), or well inside the polygon a
+                            // DEM step that stays water rather than a strip of grass.
+                            if !spans.contains_interior(x, z, m) {
+                                continue;
+                            }
+                            ground_y
+                        } else {
+                            water_y
+                        }
+                    }
+                };
                 // depth_at gives the carved depth (0 without land-cover water data).
                 carve_water_column(editor, x, z, water_y, bwf.depth_at(x, z), road_mask, bwf);
             }

--- a/src/element_processing/water_areas.rs
+++ b/src/element_processing/water_areas.rs
@@ -570,17 +570,14 @@ pub fn prescan_still_surfaces(
     StillWaterSurfaces(entries.into_iter().collect())
 }
 
-/// Whether a way is rendered as a water area (mirrors the dispatch in data_processing).
+/// Ways this renderer actually receives. `natural=water` and `landuse=reservoir` ways are
+/// taken by the natural and landuse arms of the dispatch first, so a surface resolved for
+/// them would never be read. Relations are not routed that way and keep the full predicate.
 fn is_water_area_way(way: &ProcessedWay) -> bool {
-    way.tags.contains_key("water")
-        || matches!(
-            way.tags.get("natural").map(String::as_str),
-            Some("water" | "bay")
-        )
-        || matches!(
-            way.tags.get("waterway").map(String::as_str),
-            Some("dock" | "riverbank")
-        )
+    matches!(
+        way.tags.get("waterway").map(String::as_str),
+        Some("dock" | "riverbank")
+    )
 }
 
 /// The single water-surface Y of a polygon that ESA also sees as one still body.

--- a/src/element_processing/waterways.rs
+++ b/src/element_processing/waterways.rs
@@ -2,26 +2,18 @@ use crate::block_definitions::*;
 use crate::bresenham::bresenham_line;
 use crate::osm_parser::ProcessedWay;
 use crate::world_editor::WorldEditor;
+use std::collections::HashMap;
 
 pub fn generate_waterways(editor: &mut WorldEditor, element: &ProcessedWay) {
     if let Some(waterway_type) = element.tags.get("waterway") {
-        let mut waterway_width = get_waterway_width(waterway_type);
-
-        // Check for custom width in tags
-        if let Some(width_str) = element.tags.get("width") {
-            waterway_width = width_str.parse::<i32>().unwrap_or_else(|_| {
-                width_str
-                    .parse::<f32>()
-                    .map(|f: f32| f as i32)
-                    .unwrap_or(waterway_width)
-            });
+        // waterway=* structures are not channels; outlining a dam draws canals down it.
+        if !is_channel_waterway(waterway_type) {
+            return;
         }
+        let waterway_width = waterway_width(waterway_type, &element.tags);
 
-        // Skip layers below the ground level
-        if matches!(
-            element.tags.get("layer").map(|s| s.as_str()),
-            Some("-1") | Some("-2") | Some("-3")
-        ) {
+        // Culverts and pipes are not open water; they would cut channels through banks.
+        if is_underground_waterway(&element.tags) {
             return;
         }
 
@@ -53,8 +45,45 @@ pub fn generate_waterways(editor: &mut WorldEditor, element: &ProcessedWay) {
     }
 }
 
+/// False for `waterway=*` values that are structures or points, not a channel.
+pub fn is_channel_waterway(waterway_type: &str) -> bool {
+    !matches!(
+        waterway_type,
+        "dam"
+            | "weir"
+            | "lock_gate"
+            | "waterfall"
+            | "rapids"
+            | "boatyard"
+            | "fuel"
+            | "dock"
+            | "riverbank"
+            | "water_point"
+            | "turning_point"
+            | "sluice_gate"
+            | "fish_pass"
+            | "security_lock"
+            | "milestone"
+            | "check_dam"
+            | "floating_barrier"
+    )
+}
+
+/// True for waterways underground: any `tunnel=*` other than `no`, or a negative layer.
+pub fn is_underground_waterway(tags: &std::collections::HashMap<String, String>) -> bool {
+    if tags
+        .get("tunnel")
+        .is_some_and(|v| !matches!(v.as_str(), "no" | "0" | "false"))
+    {
+        return true;
+    }
+    tags.get("layer")
+        .and_then(|l| l.trim().parse::<i32>().ok())
+        .is_some_and(|l| l < 0)
+}
+
 /// Determines channel width based on waterway type.
-fn get_waterway_width(waterway_type: &str) -> i32 {
+pub fn get_waterway_width(waterway_type: &str) -> i32 {
     match waterway_type {
         "river" => 8,
         "canal" => 6,
@@ -65,6 +94,24 @@ fn get_waterway_width(waterway_type: &str) -> i32 {
         "ditch" => 2,
         "drain" => 1,
         _ => 4,
+    }
+}
+
+/// Widest channel a `width=*` tag may ask for. Every renderer of a waterway walks its
+/// width squared per centreline point, so an unbounded tag value hangs generation.
+pub const MAX_WATERWAY_WIDTH: i32 = 128;
+
+/// Channel width in blocks, from `width=*` when it parses and the type default otherwise.
+pub fn waterway_width(waterway_type: &str, tags: &HashMap<String, String>) -> i32 {
+    let tagged = tags
+        .get("width")
+        .and_then(|s| s.trim().split(' ').next())
+        .and_then(|s| s.parse::<f64>().ok())
+        .filter(|w| w.is_finite())
+        .map(|w| w.round() as i64);
+    match tagged {
+        Some(w) if w >= 1 => w.min(i64::from(MAX_WATERWAY_WIDTH)) as i32,
+        _ => get_waterway_width(waterway_type),
     }
 }
 

--- a/src/elevation/mod.rs
+++ b/src/elevation/mod.rs
@@ -200,6 +200,7 @@ pub fn fetch_elevation_data(
             lc,
             built_up_sigma_cells,
             coastal_pull_cells,
+            m_per_cell,
             &|f| emit_gui_progress_update(14.0 + f * 2.0, "Processing elevation..."),
         );
     }

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -14,8 +14,12 @@ const MAX_STEEP_WATER_AREA_M2: f64 = 250_000.0;
 /// Median slope above which small water is shadow, not water. 19 degrees.
 const MIN_STEEP_WATER_SLOPE: f64 = 0.35;
 
-/// How far below the water nearby land must reach for it to be on a slope, not in a basin.
+/// How far below a cell the ground a step away must sit for that cell to count as perched.
 const STEEP_WATER_LAND_BELOW_M: f64 = 2.0;
+
+/// Share of a component's edge cells that must be perched. Only a blob's downhill side
+/// is, so this is low; the slope gate above is what does the separating.
+const MIN_PERCHED_FRACTION: f64 = 0.10;
 
 /// Repair terrain anomalies (LiDAR classification errors, tile seams, provider glitches).
 ///
@@ -840,6 +844,11 @@ fn set_bit(mask: &mut [u64], idx: usize) {
     mask[idx >> 6] |= 1u64 << (idx & 63);
 }
 
+#[inline(always)]
+fn clear_bit(mask: &mut [u64], idx: usize) {
+    mask[idx >> 6] &= !(1u64 << (idx & 63));
+}
+
 /// Class of the nearest non-water, non-nodata cell within `radius`, if any.
 fn nearest_non_water_class(lc_grid: &[Vec<u8>], x: usize, y: usize, radius: i32) -> Option<u8> {
     let h = lc_grid.len() as i32;
@@ -895,31 +904,38 @@ fn drop_water_on_steep_terrain(
     let max_cells = (MAX_STEEP_WATER_AREA_M2 / (m_per_cell * m_per_cell)) as usize;
     // Slope of the claimed water surface, sampled between water cells only. Sampling the
     // terrain instead would read the canyon walls across any channel narrower than the step.
+    // The farthest water within the step is used, so a patch smaller than the step still
+    // gets measured rather than falling through unjudged.
     let cell_slope = |x: usize, y: usize| -> Option<f64> {
         let here = heights[y][x];
         if !here.is_finite() {
             return None;
         }
-        let at = |nx: i64, ny: i64| -> Option<f64> {
-            if nx < 0 || ny < 0 || nx >= w as i64 || ny >= h as i64 {
-                return None;
+        let (x, y) = (x as i64, y as i64);
+        let at = |ux: i64, uy: i64| -> Option<(f64, f64)> {
+            for d in (1..=step).rev() {
+                let (nx, ny) = (x + ux * d, y + uy * d);
+                if nx < 0 || ny < 0 || nx >= w as i64 || ny >= h as i64 {
+                    continue;
+                }
+                if lc_grid[ny as usize][nx as usize] != LC_WATER {
+                    continue;
+                }
+                let v = heights[ny as usize][nx as usize];
+                if v.is_finite() {
+                    return Some((v, d as f64 * m_per_cell));
+                }
             }
-            if lc_grid[ny as usize][nx as usize] != LC_WATER {
-                return None;
-            }
-            let v = heights[ny as usize][nx as usize];
-            v.is_finite().then_some(v)
+            None
         };
-        let span = step as f64 * m_per_cell;
-        let axis = |lo: Option<f64>, hi: Option<f64>| match (lo, hi) {
-            (Some(a), Some(b)) => Some((b - a) / (2.0 * span)),
-            (Some(a), None) => Some((here - a) / span),
-            (None, Some(b)) => Some((b - here) / span),
+        let axis = |lo: Option<(f64, f64)>, hi: Option<(f64, f64)>| match (lo, hi) {
+            (Some((a, da)), Some((b, db))) => Some((b - a) / (da + db)),
+            (Some((a, da)), None) => Some((here - a) / da),
+            (None, Some((b, db))) => Some((b - here) / db),
             (None, None) => None,
         };
-        let (x, y) = (x as i64, y as i64);
-        let gx = axis(at(x - step, y), at(x + step, y));
-        let gz = axis(at(x, y - step), at(x, y + step));
+        let gx = axis(at(-1, 0), at(1, 0));
+        let gz = axis(at(0, -1), at(0, 1));
         if gx.is_none() && gz.is_none() {
             return None;
         }
@@ -933,6 +949,8 @@ fn drop_water_on_steep_terrain(
     };
 
     let mut visited = vec![0u64; (w * h).div_ceil(64)];
+    // Reused per component, always cleared again after the basin test below.
+    let mut in_component = vec![0u64; (w * h).div_ceil(64)];
     let mut dropped_cells: Vec<(usize, usize)> = Vec::new();
     let mut dropped_components = 0usize;
     let mut component: Vec<(u32, u32)> = Vec::new();
@@ -975,36 +993,51 @@ fn drop_water_on_steep_terrain(
             if slopes.is_empty() || median(&mut slopes) <= MIN_STEEP_WATER_SLOPE {
                 continue;
             }
-            // Water sits in a basin, so nothing around it is lower. A blob on a slope has
-            // the hillside continuing below it. Sampled at the slope step, so a narrow
-            // channel reads past its own banks rather than into them.
-            let (mut water_min, mut ring_min) = (f64::INFINITY, f64::INFINITY);
+            // Water sits in a basin, so nothing near it is lower. A blob on a slope has the
+            // hillside continuing below it. Measured per cell against ground a step away,
+            // because comparing whole components confuses a slope with a gradient: a
+            // stream's source is far above its mouth while its banks still rise beside it.
+            // Only this component's own cells are excluded, so a blob perched over a river
+            // reads that river as the ground below it while a stream only finds itself.
             for &(x, y) in &component {
-                let (x, y) = (x as i64, y as i64);
+                set_bit(&mut in_component, y as usize * w + x as usize);
+            }
+            let (mut edge_cells, mut perched) = (0usize, 0usize);
+            for &(x, y) in &component {
                 let here = heights[y as usize][x as usize];
-                if here.is_finite() {
-                    water_min = water_min.min(here);
+                if !here.is_finite() {
+                    continue;
                 }
+                let (x, y) = (x as i64, y as i64);
+                let mut lowest = f64::INFINITY;
                 for (dx, dy) in [(step, 0), (-step, 0), (0, step), (0, -step)] {
                     let (nx, ny) = (x + dx, y + dy);
                     if nx < 0 || ny < 0 || nx >= w as i64 || ny >= h as i64 {
                         continue;
                     }
-                    if lc_grid[ny as usize][nx as usize] == LC_WATER {
+                    if get_bit(&in_component, ny as usize * w + nx as usize) {
                         continue;
                     }
                     let v = heights[ny as usize][nx as usize];
                     if v.is_finite() {
-                        ring_min = ring_min.min(v);
+                        lowest = lowest.min(v);
                     }
                 }
+                if !lowest.is_finite() {
+                    continue;
+                }
+                edge_cells += 1;
+                if lowest < here - STEEP_WATER_LAND_BELOW_M {
+                    perched += 1;
+                }
             }
-            if !water_min.is_finite()
-                || !ring_min.is_finite()
-                || ring_min >= water_min - STEEP_WATER_LAND_BELOW_M
-            {
+            for &(x, y) in &component {
+                clear_bit(&mut in_component, y as usize * w + x as usize);
+            }
+            if edge_cells == 0 || (perched as f64) < MIN_PERCHED_FRACTION * edge_cells as f64 {
                 continue;
             }
+
             dropped_components += 1;
             dropped_cells.extend(component.iter().map(|&(x, y)| (x as usize, y as usize)));
         }

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -517,15 +517,31 @@ fn level_water_surfaces(
     is_water_surface
 }
 
+/// Downsampling step for the coarse field: fine enough for the blur, coarse enough that a
+/// component spanning the grid cannot materialize its whole bounding box.
+///
+/// A river crossing the map has a bounding box the size of the grid while holding only a
+/// ribbon of samples. At a coarse metres-per-cell the sigma alone leaves the step at 1, so
+/// the budget has to set it instead.
+fn coarse_step(bbox_w: usize, bbox_h: usize, sigma_cells: f64) -> usize {
+    // Coarse cells per sigma; below this the downsampling shows.
+    const COARSE_PER_SIGMA: f64 = 8.0;
+    const MAX_COARSE_CELLS: f64 = (4 << 20) as f64;
+
+    let from_sigma = (sigma_cells / COARSE_PER_SIGMA).floor().max(1.0);
+    let from_budget = (bbox_w as f64 * bbox_h as f64 / MAX_COARSE_CELLS)
+        .sqrt()
+        .ceil()
+        .max(1.0);
+    from_sigma.max(from_budget) as usize
+}
+
 /// Blur `cells` (grid x, grid z, value) at `sigma_cells`, one output per input cell.
 ///
 /// The samples are a thin ribbon in a grid up to 16k a side, so the blur runs on their
 /// downsampled bounding box and is sampled back. It is a low-pass either way, and the
 /// cost follows the ribbon instead of the grid.
 fn smooth_sparse_field(cells: &[(u32, u32, f32)], sigma_cells: f64) -> Vec<f64> {
-    // Coarse cells per sigma; below this the downsampling shows.
-    const COARSE_PER_SIGMA: f64 = 8.0;
-
     let (mut x0, mut x1, mut y0, mut y1) = (u32::MAX, 0u32, u32::MAX, 0u32);
     for &(x, y, _) in cells {
         x0 = x0.min(x);
@@ -533,9 +549,11 @@ fn smooth_sparse_field(cells: &[(u32, u32, f32)], sigma_cells: f64) -> Vec<f64> 
         y0 = y0.min(y);
         y1 = y1.max(y);
     }
-    let step = ((sigma_cells / COARSE_PER_SIGMA).floor() as usize).max(1);
-    let cw = ((x1 - x0) as usize) / step + 1;
-    let ch = ((y1 - y0) as usize) / step + 1;
+    let bw = (x1 - x0) as usize + 1;
+    let bh = (y1 - y0) as usize + 1;
+    let step = coarse_step(bw, bh, sigma_cells);
+    let cw = (bw - 1) / step + 1;
+    let ch = (bh - 1) / step + 1;
     let mut sum = vec![vec![0.0f64; cw]; ch];
     let mut count = vec![vec![0u32; cw]; ch];
     for &(x, y, v) in cells {
@@ -544,13 +562,14 @@ fn smooth_sparse_field(cells: &[(u32, u32, f32)], sigma_cells: f64) -> Vec<f64> 
         sum[cy][cx] += f64::from(v);
         count[cy][cx] += 1;
     }
+    // Consumed, so the two accumulators are gone before the blur allocates.
     let coarse: Vec<Vec<f64>> = sum
-        .iter()
-        .zip(count.iter())
+        .into_iter()
+        .zip(count)
         .map(|(srow, crow)| {
-            srow.iter()
-                .zip(crow.iter())
-                .map(|(&s, &c)| if c > 0 { s / f64::from(c) } else { f64::NAN })
+            srow.into_iter()
+                .zip(crow)
+                .map(|(s, c)| if c > 0 { s / f64::from(c) } else { f64::NAN })
                 .collect()
         })
         .collect();
@@ -1836,6 +1855,22 @@ mod tests {
             }
         }
         (heights, lc)
+    }
+
+    #[test]
+    fn coarse_field_stays_bounded_for_a_grid_spanning_river() {
+        // A thin river across the largest supported grid, at the metres-per-cell where the
+        // sigma alone leaves the step at 1 and the whole bounding box gets allocated.
+        const N: usize = 16384;
+        let step = coarse_step(N, N, 6.6);
+        let cw = (N - 1) / step + 1;
+        assert!(cw * cw <= 4 << 20, "coarse grid is {} cells", cw * cw);
+    }
+
+    #[test]
+    fn small_components_keep_the_sigma_step() {
+        // City scale must keep the sampling the blur was tuned for.
+        assert_eq!(coarse_step(1583, 2217, 40.0), 5);
     }
 
     #[test]

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -8,6 +8,15 @@ const MAX_Y: i32 = 319;
 /// Buffer at the top for buildings, trees, and other structures
 const TERRAIN_HEIGHT_BUFFER: i32 = 15;
 
+/// Largest water component a steep-slope shadow blob can be. Real bodies are bigger.
+const MAX_STEEP_WATER_AREA_M2: f64 = 250_000.0;
+
+/// Median slope above which small water is shadow, not water. 19 degrees.
+const MIN_STEEP_WATER_SLOPE: f64 = 0.35;
+
+/// How far below the water nearby land must reach for it to be on a slope, not in a basin.
+const STEEP_WATER_LAND_BELOW_M: f64 = 2.0;
+
 /// Repair terrain anomalies (LiDAR classification errors, tile seams, provider glitches).
 ///
 /// Uses a 5x5 median-based filter with MAD (median absolute deviation) to detect
@@ -129,6 +138,8 @@ pub fn repair_terrain_anomalies(heights: &mut [Vec<f64>]) {
 /// This runs after the general MAD/IQR cleanup to target artifacts that are
 /// too coherent for a small-window outlier filter:
 ///
+/// - **Small water blobs on steep terrain** (ESA shadow on cliff faces) are dropped
+///   from the mask first, so nothing below levels terrain around them.
 /// - **Water cells** are flattened to the median elevation of their connected
 ///   component. This kills coastal tile-boundary "rectangular spikes" offshore
 ///   and ensures oceans/lakes sit at a consistent surface level.
@@ -153,6 +164,7 @@ pub fn apply_land_cover_repair(
     land_cover: &mut LandCoverData,
     built_up_sigma_cells: f64,
     coastal_pull_distance_cells: u32,
+    m_per_cell: f64,
     report: &dyn Fn(f64),
 ) {
     let grid_h = heights.len();
@@ -172,12 +184,15 @@ pub fn apply_land_cover_repair(
         return;
     }
 
+    // Shadow blobs on slopes are not water; drop them before anything levels around them.
+    let dropped = drop_water_on_steep_terrain(heights, &mut land_cover.grid, m_per_cell);
+
     // Returns a bool grid marking which cells were actually flattened to the
     // water-surface level. Misclassified wall cells inside narrow canyon
     // rivers are skipped, so downstream passes (pull-down BFS, Gaussian
     // source-masking) use the real water surface and not the contaminated
     // classification.
-    let is_water_surface = level_water_surfaces(heights, &land_cover.grid);
+    let is_water_surface = level_water_surfaces(heights, &land_cover.grid, m_per_cell);
 
     // Reclassify LC_WATER cells that weren't actually flattened to water
     // surface (ESA-misclassified riverbank walls / piers / shoreline
@@ -190,7 +205,7 @@ pub fn apply_land_cover_repair(
     // `grid_is_water = water_distance > 0` in ground.rs doesn't still treat
     // these cells as water.
     let reclassified = reclassify_non_surface_water_cells(&mut land_cover.grid, &is_water_surface);
-    if reclassified > 0 {
+    if reclassified + dropped > 0 {
         land_cover.water_distance =
             crate::land_cover::compute_water_distance(&land_cover.grid, grid_w, grid_h);
         // The water-blend smoothing was derived from the pre-reclassify
@@ -243,10 +258,17 @@ pub fn apply_land_cover_repair(
 ///    elevation — they are real walls / piers / embankments and should
 ///    render as terrain, reclassified away from LC_WATER by the next pass.
 ///
+/// Flowing components get a per-cell local median instead of one level, smoothed at
+/// 40 m where that only removes DEM seams and left sharp at real drops.
+///
 /// The returned bool grid marks which cells actually became water surface,
 /// so the coastal pull-down and Gaussian source-masking operate on the
 /// real water surface rather than the ESA classification.
-fn level_water_surfaces(heights: &mut [Vec<f64>], lc_grid: &[Vec<u8>]) -> Vec<Vec<bool>> {
+fn level_water_surfaces(
+    heights: &mut [Vec<f64>],
+    lc_grid: &[Vec<u8>],
+    m_per_cell: f64,
+) -> Vec<Vec<bool>> {
     // Cells up to this many metres above the estimated surface are still
     // treated as water (covers noise / wave chop / 10 m ESA mixed-pixel
     // bleed). Beyond this they are real walls and kept as terrain.
@@ -273,6 +295,15 @@ fn level_water_surfaces(heights: &mut [Vec<f64>], lc_grid: &[Vec<u8>]) -> Vec<Ve
     // median for a flowing-component cell. Cells with fewer fall back
     // to the component's own median.
     const MIN_LOCAL_SAMPLES: usize = 8;
+    // A local median keeps every edge, and hydro-flattened DEMs are full of them:
+    // TIN facets and LiDAR project seams step 1-4 m along straight lines, which render
+    // as walls of water across open river. Blur at this width to take those out.
+    const FLOW_SMOOTH_SIGMA_M: f64 = 40.0;
+    // Below this many cells the blur would not do anything visible.
+    const FLOW_SMOOTH_MIN_SIGMA_CELLS: f64 = 1.5;
+    // Hard cap on how far the blur may move a cell. The blur sits near the middle of a
+    // step, so this removes seams up to twice as tall and only dents a real waterfall.
+    const FLOW_SMOOTH_MAX_M: f64 = 1.5;
 
     let h = heights.len();
     let w = heights[0].len();
@@ -289,6 +320,8 @@ fn level_water_surfaces(heights: &mut [Vec<f64>], lc_grid: &[Vec<u8>]) -> Vec<Ve
     let mut cells_leveled = 0usize;
     let mut cells_skipped = 0usize;
     let mut max_flowing_iqr = 0.0f64;
+    // Flattened after the scan, once smoothed: (x, y, local surface), per component.
+    let mut flowing_cells: Vec<Vec<(u32, u32, f32)>> = Vec::new();
 
     for start_y in 0..h {
         for start_x in 0..w {
@@ -363,6 +396,7 @@ fn level_water_surfaces(heights: &mut [Vec<f64>], lc_grid: &[Vec<u8>]) -> Vec<Ve
                 if iqr > max_flowing_iqr {
                     max_flowing_iqr = iqr;
                 }
+                flowing_cells.push(Vec::new());
                 for &(cx, cy) in &component {
                     let orig = heights_snapshot[cy][cx];
                     if !orig.is_finite() {
@@ -377,16 +411,8 @@ fn level_water_surfaces(heights: &mut [Vec<f64>], lc_grid: &[Vec<u8>]) -> Vec<Ve
                         MIN_LOCAL_SAMPLES,
                     )
                     .unwrap_or(fallback_median);
-
-                    let at_or_below = orig <= local_surface + WATER_UP_TOLERANCE_M;
-                    let flatten = at_or_below || !has_non_water_neighbor(lc_grid, cx, cy);
-                    if flatten {
-                        heights[cy][cx] = local_surface;
-                        is_water_surface[cy][cx] = true;
-                        cells_leveled += 1;
-                    } else {
-                        cells_skipped += 1;
-                    }
+                    let last = flowing_cells.last_mut().expect("component pushed above");
+                    last.push((cx as u32, cy as u32, local_surface as f32));
                 }
             } else {
                 // ── Still water (lake / fjord / ocean) ─────────────────
@@ -424,6 +450,51 @@ fn level_water_surfaces(heights: &mut [Vec<f64>], lc_grid: &[Vec<u8>]) -> Vec<Ve
         }
     }
 
+    // Smooth the local-median surface, then flatten as still water does.
+    // The scan is done, so the scratch grids go before the blur allocates.
+    drop(heights_snapshot);
+    drop(visited);
+    let sigma_cells = if m_per_cell > 0.0 && m_per_cell.is_finite() {
+        (FLOW_SMOOTH_SIGMA_M / m_per_cell).min(64.0)
+    } else {
+        0.0
+    };
+    for component in &flowing_cells {
+        if component.is_empty() {
+            continue;
+        }
+        // One blur per component, so a canal beside a river is not averaged into it.
+        let smoothed = (sigma_cells >= FLOW_SMOOTH_MIN_SIGMA_CELLS)
+            .then(|| smooth_sparse_field(component, sigma_cells));
+        for (i, &(cx, cy, local_surface)) in component.iter().enumerate() {
+            let (cx, cy) = (cx as usize, cy as usize);
+            let local_surface = f64::from(local_surface);
+            let mut surface = match &smoothed {
+                Some(g) if g[i].is_finite() => {
+                    local_surface
+                        + (g[i] - local_surface).clamp(-FLOW_SMOOTH_MAX_M, FLOW_SMOOTH_MAX_M)
+                }
+                _ => local_surface,
+            };
+            // Flowing cells are untouched until here, so heights still holds the input.
+            let orig = heights[cy][cx];
+            // Never raise water over the land beside it, which is what a one-sided kernel
+            // at the ends of the ribbon would otherwise do.
+            if let Some(land) = lowest_adjacent_land(heights, lc_grid, cx, cy) {
+                surface = surface.min(orig.max(land));
+            }
+            let at_or_below = orig <= surface + WATER_UP_TOLERANCE_M;
+            let flatten = at_or_below || !has_non_water_neighbor(lc_grid, cx, cy);
+            if flatten {
+                heights[cy][cx] = surface;
+                is_water_surface[cy][cx] = true;
+                cells_leveled += 1;
+            } else {
+                cells_skipped += 1;
+            }
+        }
+    }
+
     if components_leveled > 0 {
         if flowing_components > 0 {
             eprintln!(
@@ -444,6 +515,78 @@ fn level_water_surfaces(heights: &mut [Vec<f64>], lc_grid: &[Vec<u8>]) -> Vec<Ve
     }
 
     is_water_surface
+}
+
+/// Blur `cells` (grid x, grid z, value) at `sigma_cells`, one output per input cell.
+///
+/// The samples are a thin ribbon in a grid up to 16k a side, so the blur runs on their
+/// downsampled bounding box and is sampled back. It is a low-pass either way, and the
+/// cost follows the ribbon instead of the grid.
+fn smooth_sparse_field(cells: &[(u32, u32, f32)], sigma_cells: f64) -> Vec<f64> {
+    // Coarse cells per sigma; below this the downsampling shows.
+    const COARSE_PER_SIGMA: f64 = 8.0;
+
+    let (mut x0, mut x1, mut y0, mut y1) = (u32::MAX, 0u32, u32::MAX, 0u32);
+    for &(x, y, _) in cells {
+        x0 = x0.min(x);
+        x1 = x1.max(x);
+        y0 = y0.min(y);
+        y1 = y1.max(y);
+    }
+    let step = ((sigma_cells / COARSE_PER_SIGMA).floor() as usize).max(1);
+    let cw = ((x1 - x0) as usize) / step + 1;
+    let ch = ((y1 - y0) as usize) / step + 1;
+    let mut sum = vec![vec![0.0f64; cw]; ch];
+    let mut count = vec![vec![0u32; cw]; ch];
+    for &(x, y, v) in cells {
+        let cx = (x - x0) as usize / step;
+        let cy = (y - y0) as usize / step;
+        sum[cy][cx] += f64::from(v);
+        count[cy][cx] += 1;
+    }
+    let coarse: Vec<Vec<f64>> = sum
+        .iter()
+        .zip(count.iter())
+        .map(|(srow, crow)| {
+            srow.iter()
+                .zip(crow.iter())
+                .map(|(&s, &c)| if c > 0 { s / f64::from(c) } else { f64::NAN })
+                .collect()
+        })
+        .collect();
+    let blurred = gaussian_blur_grid(&coarse, sigma_cells / step as f64);
+
+    cells
+        .iter()
+        .map(|&(x, y, v)| {
+            // Bilinear in coarse coordinates, renormalised over finite corners.
+            let fx = (x - x0) as f64 / step as f64 - 0.5;
+            let fy = (y - y0) as f64 / step as f64 - 0.5;
+            let ix = fx.floor();
+            let iy = fy.floor();
+            let (tx, ty) = (fx - ix, fy - iy);
+            let (mut acc, mut wsum) = (0.0, 0.0);
+            for (dy, wy) in [(0i64, 1.0 - ty), (1, ty)] {
+                for (dx, wx) in [(0i64, 1.0 - tx), (1, tx)] {
+                    let sx = ix as i64 + dx;
+                    let sy = iy as i64 + dy;
+                    if sx < 0 || sy < 0 || sx >= cw as i64 || sy >= ch as i64 {
+                        continue;
+                    }
+                    let val = blurred[sy as usize][sx as usize];
+                    if val.is_finite() {
+                        acc += val * wx * wy;
+                        wsum += wx * wy;
+                    }
+                }
+            }
+            if wsum > 0.0 {
+                acc / wsum
+            } else {
+                f64::from(v)
+            }
+        })
+        .collect()
 }
 
 /// Compute the interquartile range of a slice of elevations.
@@ -509,6 +652,34 @@ fn local_water_median(
     let mid = samples.len() / 2;
     samples.select_nth_unstable_by(mid, |a, b| a.partial_cmp(b).unwrap());
     Some(samples[mid])
+}
+
+/// Lowest finite height among the cell's non-water 4-neighbours, if it has any.
+fn lowest_adjacent_land(
+    heights: &[Vec<f64>],
+    lc_grid: &[Vec<u8>],
+    x: usize,
+    y: usize,
+) -> Option<f64> {
+    let h = heights.len();
+    let w = heights[0].len();
+    let mut lowest: Option<f64> = None;
+    for (dx, dy) in [(1i32, 0i32), (-1, 0), (0, 1), (0, -1)] {
+        let nx = x as i32 + dx;
+        let ny = y as i32 + dy;
+        if nx < 0 || ny < 0 || nx >= w as i32 || ny >= h as i32 {
+            continue;
+        }
+        let (nxu, nyu) = (nx as usize, ny as usize);
+        if lc_grid[nyu][nxu] == LC_WATER {
+            continue;
+        }
+        let v = heights[nyu][nxu];
+        if v.is_finite() {
+            lowest = Some(lowest.map_or(v, |l: f64| l.min(v)));
+        }
+    }
+    lowest
 }
 
 /// Whether cell `(x, y)` has at least one 4-connected neighbor that is not
@@ -640,6 +811,208 @@ fn clamp_by_adjacent_land(
     proposed.min(land_p25)
 }
 
+#[inline(always)]
+fn get_bit(mask: &[u64], idx: usize) -> bool {
+    (mask[idx >> 6] >> (idx & 63)) & 1 != 0
+}
+
+#[inline(always)]
+fn set_bit(mask: &mut [u64], idx: usize) {
+    mask[idx >> 6] |= 1u64 << (idx & 63);
+}
+
+/// Class of the nearest non-water, non-nodata cell within `radius`, if any.
+fn nearest_non_water_class(lc_grid: &[Vec<u8>], x: usize, y: usize, radius: i32) -> Option<u8> {
+    let h = lc_grid.len() as i32;
+    let w = lc_grid.first().map_or(0, Vec::len) as i32;
+    for r in 1..=radius {
+        for dy in -r..=r {
+            for dx in -r..=r {
+                // Only sample cells on the ring at distance exactly `r`.
+                if dy.abs() != r && dx.abs() != r {
+                    continue;
+                }
+                let nx = x as i32 + dx;
+                let ny = y as i32 + dy;
+                if nx < 0 || ny < 0 || nx >= w || ny >= h {
+                    continue;
+                }
+                let c = lc_grid[ny as usize][nx as usize];
+                if c != LC_WATER && c != 0 {
+                    return Some(c);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Drop small `LC_WATER` components that sit on steep terrain.
+///
+/// ESA mistakes deeply shadowed slopes for water (canyon walls, alpine north faces).
+/// Left alone these get leveled into a flat ledge with the terrain pulled down around
+/// them, a pond hanging on a cliff. A component is dropped when it is small, the surface
+/// it claims is itself steep, and most of it is perched with its own land below it. A
+/// real watercourse fails both: its surface follows a gentle grade and its banks rise.
+/// Dropped cells take the nearest land class. Returns cells reclassified.
+fn drop_water_on_steep_terrain(
+    heights: &[Vec<f64>],
+    lc_grid: &mut [Vec<u8>],
+    m_per_cell: f64,
+) -> usize {
+    const SEARCH_RADIUS: i32 = 8;
+    const FALLBACK_CLASS: u8 = crate::land_cover::LC_BARE;
+    let h = heights.len();
+    if h == 0 || m_per_cell <= 0.0 || !m_per_cell.is_finite() {
+        return 0;
+    }
+    let w = heights[0].len();
+    if w == 0 || lc_grid.len() != h || lc_grid[0].len() != w {
+        return 0;
+    }
+    // Gradient step: about one ESA pixel, so DEM noise finer than the
+    // classification cannot masquerade as slope.
+    let step = ((10.0 / m_per_cell).round() as usize).clamp(1, 16) as i64;
+    let max_cells = (MAX_STEEP_WATER_AREA_M2 / (m_per_cell * m_per_cell)) as usize;
+    // Slope of the claimed water surface, sampled between water cells only. Sampling the
+    // terrain instead would read the canyon walls across any channel narrower than the step.
+    let cell_slope = |x: usize, y: usize| -> Option<f64> {
+        let here = heights[y][x];
+        if !here.is_finite() {
+            return None;
+        }
+        let at = |nx: i64, ny: i64| -> Option<f64> {
+            if nx < 0 || ny < 0 || nx >= w as i64 || ny >= h as i64 {
+                return None;
+            }
+            if lc_grid[ny as usize][nx as usize] != LC_WATER {
+                return None;
+            }
+            let v = heights[ny as usize][nx as usize];
+            v.is_finite().then_some(v)
+        };
+        let span = step as f64 * m_per_cell;
+        let axis = |lo: Option<f64>, hi: Option<f64>| match (lo, hi) {
+            (Some(a), Some(b)) => Some((b - a) / (2.0 * span)),
+            (Some(a), None) => Some((here - a) / span),
+            (None, Some(b)) => Some((b - here) / span),
+            (None, None) => None,
+        };
+        let (x, y) = (x as i64, y as i64);
+        let gx = axis(at(x - step, y), at(x + step, y));
+        let gz = axis(at(x, y - step), at(x, y + step));
+        if gx.is_none() && gz.is_none() {
+            return None;
+        }
+        let (gx, gz) = (gx.unwrap_or(0.0), gz.unwrap_or(0.0));
+        Some((gx * gx + gz * gz).sqrt())
+    };
+    let median = |v: &mut Vec<f64>| -> f64 {
+        let mid = v.len() / 2;
+        v.select_nth_unstable_by(mid, |a, b| a.partial_cmp(b).unwrap());
+        v[mid]
+    };
+
+    let mut visited = vec![0u64; (w * h).div_ceil(64)];
+    let mut dropped_cells: Vec<(usize, usize)> = Vec::new();
+    let mut dropped_components = 0usize;
+    let mut component: Vec<(u32, u32)> = Vec::new();
+    let mut queue: VecDeque<(usize, usize)> = VecDeque::new();
+    for start_y in 0..h {
+        for start_x in 0..w {
+            if get_bit(&visited, start_y * w + start_x) || lc_grid[start_y][start_x] != LC_WATER {
+                continue;
+            }
+            component.clear();
+            let mut size = 0usize;
+            queue.push_back((start_x, start_y));
+            set_bit(&mut visited, start_y * w + start_x);
+            while let Some((x, y)) = queue.pop_front() {
+                size += 1;
+                // Oversize components are rejected below, so stop storing their cells.
+                if size <= max_cells + 1 {
+                    component.push((x as u32, y as u32));
+                }
+                for (dx, dy) in [(1i32, 0i32), (-1, 0), (0, 1), (0, -1)] {
+                    let nx = x as i32 + dx;
+                    let ny = y as i32 + dy;
+                    if nx < 0 || ny < 0 || nx >= w as i32 || ny >= h as i32 {
+                        continue;
+                    }
+                    let (nxu, nyu) = (nx as usize, ny as usize);
+                    if !get_bit(&visited, nyu * w + nxu) && lc_grid[nyu][nxu] == LC_WATER {
+                        set_bit(&mut visited, nyu * w + nxu);
+                        queue.push_back((nxu, nyu));
+                    }
+                }
+            }
+            if size > max_cells {
+                continue;
+            }
+            let mut slopes: Vec<f64> = component
+                .iter()
+                .filter_map(|&(x, y)| cell_slope(x as usize, y as usize))
+                .collect();
+            if slopes.is_empty() || median(&mut slopes) <= MIN_STEEP_WATER_SLOPE {
+                continue;
+            }
+            // Water sits in a basin, so nothing around it is lower. A blob on a slope has
+            // the hillside continuing below it. Sampled at the slope step, so a narrow
+            // channel reads past its own banks rather than into them.
+            let (mut water_min, mut ring_min) = (f64::INFINITY, f64::INFINITY);
+            for &(x, y) in &component {
+                let (x, y) = (x as i64, y as i64);
+                let here = heights[y as usize][x as usize];
+                if here.is_finite() {
+                    water_min = water_min.min(here);
+                }
+                for (dx, dy) in [(step, 0), (-step, 0), (0, step), (0, -step)] {
+                    let (nx, ny) = (x + dx, y + dy);
+                    if nx < 0 || ny < 0 || nx >= w as i64 || ny >= h as i64 {
+                        continue;
+                    }
+                    if lc_grid[ny as usize][nx as usize] == LC_WATER {
+                        continue;
+                    }
+                    let v = heights[ny as usize][nx as usize];
+                    if v.is_finite() {
+                        ring_min = ring_min.min(v);
+                    }
+                }
+            }
+            if !water_min.is_finite()
+                || !ring_min.is_finite()
+                || ring_min >= water_min - STEEP_WATER_LAND_BELOW_M
+            {
+                continue;
+            }
+            dropped_components += 1;
+            dropped_cells.extend(component.iter().map(|&(x, y)| (x as usize, y as usize)));
+        }
+    }
+
+    // Reclassify after the scan so one blob's replacement never feeds
+    // another's neighbour search.
+    let replacements: Vec<(usize, usize, u8)> = dropped_cells
+        .iter()
+        .map(|&(x, y)| {
+            let c = nearest_non_water_class(lc_grid, x, y, SEARCH_RADIUS).unwrap_or(FALLBACK_CLASS);
+            (x, y, c)
+        })
+        .collect();
+    for (x, y, c) in &replacements {
+        lc_grid[*y][*x] = *c;
+    }
+    if dropped_components > 0 {
+        eprintln!(
+            "Land cover repair: dropped {} water blob(s) ({} cells) sitting on steep terrain (ESA shadow misclassification)",
+            dropped_components,
+            replacements.len()
+        );
+    }
+    replacements.len()
+}
+
 /// Reclassify `LC_WATER` cells that `level_water_surfaces` left at their
 /// original DSM elevation (because they were more than ±2 m off the
 /// component water-surface estimate — ESA shoreline misclassification of
@@ -685,28 +1058,7 @@ fn reclassify_non_surface_water_cells(
                 continue;
             }
 
-            // Expanding ring search for nearest non-water, non-zero class.
-            let mut found: Option<u8> = None;
-            'outer: for r in 1..=SEARCH_RADIUS {
-                for dy in -r..=r {
-                    for dx in -r..=r {
-                        // Only sample cells on the ring at distance exactly `r`.
-                        if dy.abs() != r && dx.abs() != r {
-                            continue;
-                        }
-                        let nx = x as i32 + dx;
-                        let ny = y as i32 + dy;
-                        if nx < 0 || ny < 0 || nx >= w as i32 || ny >= h as i32 {
-                            continue;
-                        }
-                        let c = lc_grid[ny as usize][nx as usize];
-                        if c != LC_WATER && c != 0 {
-                            found = Some(c);
-                            break 'outer;
-                        }
-                    }
-                }
-            }
+            let found = nearest_non_water_class(lc_grid, x, y, SEARCH_RADIUS);
             replacements.push((x, y, found.unwrap_or(FALLBACK_CLASS)));
         }
     }
@@ -1040,7 +1392,8 @@ fn gaussian_blur_grid_reported(
 
 fn create_gaussian_kernel(size: usize, sigma: f64) -> Vec<f64> {
     let mut kernel = vec![0.0; size];
-    let center = size as f64 / 2.0;
+    // Centre tap, so the kernel is symmetric and the blur does not shift by half a cell.
+    let center = (size - 1) as f64 / 2.0;
     for (i, value) in kernel.iter_mut().enumerate() {
         let x = i as f64 - center;
         *value = (-x * x / (2.0 * sigma * sigma)).exp();
@@ -1322,6 +1675,194 @@ pub fn scale_to_minecraft(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::land_cover::LC_GRASSLAND;
+
+    /// 200x200 m grid at 1 m/cell: a hillside rising 0.6 m per metre along
+    /// x (31 degrees) with land everywhere.
+    fn hillside(n: usize) -> (Vec<Vec<f64>>, Vec<Vec<u8>>) {
+        let heights = (0..n)
+            .map(|_| (0..n).map(|x| x as f64 * 0.6).collect())
+            .collect();
+        (heights, vec![vec![LC_GRASSLAND; n]; n])
+    }
+
+    #[test]
+    fn steep_water_blob_on_hillside_is_dropped() {
+        let (heights, mut lc) = hillside(200);
+        for row in lc.iter_mut().take(120).skip(80) {
+            for c in row.iter_mut().take(130).skip(90) {
+                *c = LC_WATER;
+            }
+        }
+        let dropped = drop_water_on_steep_terrain(&heights, &mut lc, 1.0);
+        assert_eq!(dropped, 40 * 40);
+        assert!(lc.iter().flatten().all(|&c| c != LC_WATER));
+        // Near the edge the surrounding class is adopted; deep inside the
+        // blob nothing is within reach and bare ground stands in.
+        assert_eq!(lc[82][92], LC_GRASSLAND);
+        assert_eq!(lc[100][110], crate::land_cover::LC_BARE);
+    }
+
+    #[test]
+    fn flat_lake_in_a_bowl_is_kept() {
+        // Bowl: terrain rises away from the centre; the lake floor is flat.
+        let n = 200usize;
+        let mut heights: Vec<Vec<f64>> = (0..n)
+            .map(|z| {
+                (0..n)
+                    .map(|x| {
+                        let d = (((x as f64 - 100.0).powi(2) + (z as f64 - 100.0).powi(2)).sqrt()
+                            - 30.0)
+                            .max(0.0);
+                        d * 0.5
+                    })
+                    .collect()
+            })
+            .collect();
+        let mut lc = vec![vec![LC_GRASSLAND; n]; n];
+        for z in 70..130 {
+            for x in 70..130 {
+                if ((x as f64 - 100.0).powi(2) + (z as f64 - 100.0).powi(2)).sqrt() <= 30.0 {
+                    lc[z][x] = LC_WATER;
+                    heights[z][x] = 0.0;
+                }
+            }
+        }
+        let dropped = drop_water_on_steep_terrain(&heights, &mut lc, 1.0);
+        assert_eq!(dropped, 0);
+        assert_eq!(lc[100][100], LC_WATER);
+    }
+
+    #[test]
+    fn steep_narrow_watercourse_is_kept() {
+        // An 11 m wide V-notch stream at 4 % grade with 50 degree walls: steep terrain,
+        // but the water surface is flat across it and the banks rise on both sides.
+        let n = 400usize;
+        let heights: Vec<Vec<f64>> = (0..n)
+            .map(|z| {
+                (0..n)
+                    .map(|x| {
+                        let wall = (((z as f64 - 200.0).abs()) - 5.0).max(0.0) * 1.2;
+                        1000.0 - x as f64 * 0.04 + wall
+                    })
+                    .collect()
+            })
+            .collect();
+        let mut lc = vec![vec![LC_GRASSLAND; n]; n];
+        for row in lc.iter_mut().take(206).skip(195) {
+            for c in row.iter_mut() {
+                *c = LC_WATER;
+            }
+        }
+        assert_eq!(drop_water_on_steep_terrain(&heights, &mut lc, 1.0), 0);
+        assert_eq!(lc[200][200], LC_WATER);
+    }
+
+    #[test]
+    fn flowing_surface_never_rises_over_its_banks() {
+        // A 4 m fall mid-river: the reach below it must not be lifted over its own bed.
+        let (mut heights, lc) = river(|x| x * 0.03 + if x >= 200.0 { 4.0 } else { 0.0 });
+        let before = heights.clone();
+        level_water_surfaces(&mut heights, &lc, 1.0);
+        for z in 170..231 {
+            for x in 0..400 {
+                let lowest = lowest_adjacent_land(&before, &lc, x, z);
+                let cap = before[z][x].max(lowest.unwrap_or(f64::INFINITY));
+                assert!(
+                    heights[z][x] <= cap + 1e-6,
+                    "({x},{z}) rose to {} over cap {cap}",
+                    heights[z][x]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn steep_water_wider_than_the_cap_is_kept() {
+        // Same hillside, but the water covers 0.5 km^2 (an ESA blob never
+        // does; a fjord with a steep bathymetric DEM might).
+        let (heights, mut lc) = hillside(1000);
+        for row in lc.iter_mut().take(900).skip(100) {
+            for c in row.iter_mut().take(900).skip(100) {
+                *c = LC_WATER;
+            }
+        }
+        assert_eq!(drop_water_on_steep_terrain(&heights, &mut lc, 1.0), 0);
+    }
+
+    #[test]
+    fn river_with_gradient_is_kept() {
+        // A river 20 m wide dropping 2 % along its length, banks rising
+        // steeply on both sides: median slope is the flat surface.
+        let n = 200usize;
+        let heights: Vec<Vec<f64>> = (0..n)
+            .map(|z| {
+                (0..n)
+                    .map(|x| {
+                        let along = x as f64 * 0.02;
+                        let across = ((z as f64 - 100.0).abs() - 10.0).max(0.0) * 0.8;
+                        along + across
+                    })
+                    .collect()
+            })
+            .collect();
+        let mut lc = vec![vec![LC_GRASSLAND; n]; n];
+        for row in lc.iter_mut().take(111).skip(90) {
+            for c in row.iter_mut() {
+                *c = LC_WATER;
+            }
+        }
+        assert_eq!(drop_water_on_steep_terrain(&heights, &mut lc, 1.0), 0);
+    }
+
+    /// A river 60 m wide running along x across a 400 m grid at 1 m/cell,
+    /// with the given surface profile along x; banks rise steeply.
+    fn river(profile: impl Fn(f64) -> f64) -> (Vec<Vec<f64>>, Vec<Vec<u8>>) {
+        let n = 400usize;
+        let heights: Vec<Vec<f64>> = (0..n)
+            .map(|z| {
+                (0..n)
+                    .map(|x| {
+                        let across = ((z as f64 - 200.0).abs() - 30.0).max(0.0) * 0.8;
+                        profile(x as f64) + across
+                    })
+                    .collect()
+            })
+            .collect();
+        let mut lc = vec![vec![LC_GRASSLAND; n]; n];
+        for row in lc.iter_mut().take(231).skip(170) {
+            for c in row.iter_mut() {
+                *c = LC_WATER;
+            }
+        }
+        (heights, lc)
+    }
+
+    #[test]
+    fn flowing_surface_smooths_dem_seam_steps() {
+        // 3 % gradient (flowing) with a 3 m project seam at x = 200.
+        let (mut heights, lc) = river(|x| x * 0.03 + if x >= 200.0 { 3.0 } else { 0.0 });
+        level_water_surfaces(&mut heights, &lc, 1.0);
+        let row = &heights[200];
+        let max_step = (150..250)
+            .map(|x| (row[x + 1] - row[x]).abs())
+            .fold(0.0, f64::max);
+        assert!(max_step < 0.5, "seam still steps by {max_step} m");
+        // The overall gradient survives.
+        assert!(row[350] - row[50] > 8.0);
+    }
+
+    #[test]
+    fn flowing_surface_keeps_a_real_drop() {
+        // 3 % gradient with a 30 m fall at x = 200: the edge must stay sharp.
+        let (mut heights, lc) = river(|x| x * 0.03 + if x >= 200.0 { 30.0 } else { 0.0 });
+        level_water_surfaces(&mut heights, &lc, 1.0);
+        let row = &heights[200];
+        let max_step = (150..250)
+            .map(|x| (row[x + 1] - row[x]).abs())
+            .fold(0.0, f64::max);
+        assert!(max_step > 20.0, "drop was smeared to {max_step} m/cell");
+    }
 
     /// Swiss relief: Lake Maggiore 193 m to Dufourspitze 4634 m.
     fn swiss_grid() -> Vec<Vec<f64>> {

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -377,41 +377,69 @@ impl Ground {
         (measured > 0).then(|| f64::from(wooded) / f64::from(measured))
     }
 
-    /// Force LC_WATER for every cell inside an OSM water polygon or waterway.
+    /// Force LC_WATER inside OSM water, sinking those cells onto that water's surface.
     pub fn apply_osm_water_override(&mut self, elements: &[ProcessedElement], xzbbox: &XZBBox) {
-        let Some(lc) = self.land_cover.as_mut() else {
+        let Ground {
+            land_cover,
+            elevation_data,
+            ..
+        } = self;
+        let (Some(lc), Some(data)) = (land_cover.as_mut(), elevation_data.as_mut()) else {
             return;
         };
-        let Some(data) = self.elevation_data.as_ref() else {
-            return;
-        };
+        let (world_width, world_height) = (data.world_width, data.world_height);
         crate::land_cover::osm_water_override::apply_osm_water_override(
             lc,
-            &data.heights,
-            data.world_width,
-            data.world_height,
+            &mut data.heights,
+            world_width,
+            world_height,
             elements,
             xzbbox,
         );
     }
 
-    /// Reclassify cells under OSM-tagged bridges to the surrounding class.
+    /// Trim ESA water back to land where OSM shows roads, buildings or its own shoreline.
+    pub fn apply_osm_land_override(
+        &mut self,
+        elements: &[ProcessedElement],
+        xzbbox: &XZBBox,
+        scale: f64,
+    ) {
+        let (world_width, world_height) = self.world_dims();
+        let Some(lc) = self.land_cover.as_mut() else {
+            return;
+        };
+        crate::land_cover::osm_land_override::apply_osm_land_override(
+            lc,
+            world_width,
+            world_height,
+            elements,
+            xzbbox,
+            scale,
+        );
+    }
+
+    /// Reclassify cells under bridges to the surrounding class, sinking new water.
     pub fn apply_bridge_land_cover_repair(
         &mut self,
         elements: &[ProcessedElement],
         xzbbox: &XZBBox,
         scale: f64,
     ) {
-        let Some(lc) = self.land_cover.as_mut() else {
+        let Ground {
+            land_cover,
+            elevation_data,
+            ..
+        } = self;
+        let (Some(lc), Some(data)) = (land_cover.as_mut(), elevation_data.as_mut()) else {
             return;
         };
-        let Some(data) = self.elevation_data.as_ref() else {
-            return;
-        };
+        let (world_width, world_height) = (data.world_width, data.world_height);
         crate::land_cover::bridge_repair::apply_bridge_land_cover_repair(
             lc,
-            data.world_width,
-            data.world_height,
+            &mut data.heights,
+            world_width,
+            world_height,
             elements,
             xzbbox,
             scale,
@@ -487,6 +515,17 @@ impl Ground {
         } else {
             0
         }
+    }
+
+    /// True for a water cell at least four cells from shore. `water_distance` is 0 past
+    /// its cap of 15, so 0 counts as interior here. Tells a step inside a body from a bank.
+    #[inline(always)]
+    pub fn is_interior_water(&self, coord: XZPoint) -> bool {
+        if self.cover_class(coord) != land_cover::LC_WATER {
+            return false;
+        }
+        let d = self.water_distance(coord);
+        d == 0 || d >= 4
     }
 
     /// Returns a continuous 0.0–1.0 value indicating how "watery" a block is,

--- a/src/ground_generation.rs
+++ b/src/ground_generation.rs
@@ -452,6 +452,11 @@ pub fn generate_ground_region(
                             if ground_y <= wy {
                                 water_y = wy;
                                 place_esa_water = true;
+                            } else if grid_is_water && ground.is_interior_water(coord) {
+                                // A step inside the body, not a bank the snap pulled
+                                // below: water here, not a line of grass across the river.
+                                water_y = ground_y;
+                                place_esa_water = true;
                             }
                         }
 

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1423,6 +1423,7 @@ fn gui_start_generation(
 
                     // OSM water override first, then bridge repair.
                     ground.apply_osm_water_override(&parsed_elements, &xzbbox);
+                    ground.apply_osm_land_override(&parsed_elements, &xzbbox, args.scale);
                     ground.apply_bridge_land_cover_repair(&parsed_elements, &xzbbox, args.scale);
 
                     // Transform map (parsed_elements). Operations are defined in a json file

--- a/src/land_cover/bridge_repair.rs
+++ b/src/land_cover/bridge_repair.rs
@@ -1,5 +1,9 @@
 //! Reclassify ESA built-up cells under OSM bridges to the nearest non-bridge
 //! class via BFS, preferring water so river-bridge footprints become LC_WATER.
+//!
+//! This runs after the elevation grid was leveled, so water only reaches cells close
+//! to the surface it descends from, and those are sunk onto it. Anything higher, such
+//! as a dam crest carrying a bridge road, takes a land class instead.
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
 
@@ -11,6 +15,9 @@ use crate::land_cover::{compute_water_distance, LandCoverData, LC_BUILT_UP, LC_W
 use crate::osm_parser::{ProcessedElement, ProcessedWay};
 
 const MAX_BFS_RINGS: usize = 64;
+/// How far above the water a bridge cell may sit and still become water. Decks are
+/// already smoothed and pulled down before this runs; a dam crest is far higher.
+const WATER_HEIGHT_TOLERANCE_BLOCKS: f32 = 6.0;
 const DEFAULT_RAIL_HALF_WIDTH: i32 = 1;
 const DEFAULT_GENERIC_HALF_WIDTH: i32 = 1;
 // Margin past highway_block_range to cover deck + parapets, not just the lane centreline.
@@ -19,6 +26,7 @@ const NEIGHBOURS: [(i32, i32); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
 
 pub fn apply_bridge_land_cover_repair(
     land_cover: &mut LandCoverData,
+    heights: &mut [Vec<f32>],
     world_width: usize,
     world_height: usize,
     elements: &[ProcessedElement],
@@ -30,6 +38,14 @@ pub fn apply_bridge_land_cover_repair(
     if width < 2 || height < 2 || world_width < 2 || world_height < 2 {
         return;
     }
+    if heights.len() < height || heights.iter().take(height).any(|r| r.len() < width) {
+        return;
+    }
+    // Water may descend to a cell only from a surface it sits close to.
+    let water_reachable = |idx: usize, level: f32| -> bool {
+        let h = heights[idx / width][idx % width];
+        !h.is_finite() || !level.is_finite() || h <= level + WATER_HEIGHT_TOLERANCE_BLOCKS
+    };
     if !elements
         .iter()
         .any(|e| matches!(e, ProcessedElement::Way(w) if is_bridge_way(w)))
@@ -93,7 +109,9 @@ pub fn apply_bridge_land_cover_repair(
     let height_i32 = height as i32;
 
     let mut assigned: HashMap<u32, u8> = HashMap::with_capacity(bridge_indices.len());
-    let mut current: VecDeque<(u32, u8)> = VecDeque::new();
+    // Surface Y a water assignment descends from (seed water cell's height).
+    let mut water_level: HashMap<u32, f32> = HashMap::new();
+    let mut current: VecDeque<(u32, u8, f32)> = VecDeque::new();
     // Pass 1: seed water-adjacent bridge cells first so water propagates first.
     for &b_idx in &bridge_indices {
         let bi = b_idx as usize;
@@ -110,8 +128,13 @@ pub fn apply_bridge_land_cover_repair(
                 continue;
             }
             if land_cover.grid[nz as usize][nx as usize] == LC_WATER {
+                let level = heights[nz as usize][nx as usize];
+                if !water_reachable(bi, level) {
+                    continue;
+                }
                 assigned.insert(b_idx, LC_WATER);
-                current.push_back((b_idx, LC_WATER));
+                water_level.insert(b_idx, level);
+                current.push_back((b_idx, LC_WATER, level));
                 break;
             }
         }
@@ -139,15 +162,15 @@ pub fn apply_bridge_land_cover_repair(
                 continue;
             }
             assigned.insert(b_idx, cls);
-            current.push_back((b_idx, cls));
+            current.push_back((b_idx, cls, f32::NAN));
             break;
         }
     }
 
-    let mut next: VecDeque<(u32, u8)> = VecDeque::new();
+    let mut next: VecDeque<(u32, u8, f32)> = VecDeque::new();
     let mut depth = 1usize;
     while !current.is_empty() && depth < MAX_BFS_RINGS {
-        while let Some((idx, cls)) = current.pop_front() {
+        while let Some((idx, cls, level)) = current.pop_front() {
             let bi = idx as usize;
             let x = (bi % width) as i32;
             let z = (bi / width) as i32;
@@ -161,10 +184,16 @@ pub fn apply_bridge_land_cover_repair(
                 if !get_bit(&bridge_mask, nidx_usize) {
                     continue;
                 }
+                if cls == LC_WATER && !water_reachable(nidx_usize, level) {
+                    continue;
+                }
                 let nidx = nidx_usize as u32;
                 if let Entry::Vacant(e) = assigned.entry(nidx) {
                     e.insert(cls);
-                    next.push_back((nidx, cls));
+                    if cls == LC_WATER {
+                        water_level.insert(nidx, level);
+                    }
+                    next.push_back((nidx, cls, level));
                 }
             }
         }
@@ -190,6 +219,13 @@ pub fn apply_bridge_land_cover_repair(
         mutated += 1;
         if new_class == LC_WATER {
             to_water += 1;
+            // Sink the cell onto the surface it now belongs to (never raise).
+            if let Some(&level) = water_level.get(&b_idx) {
+                let h = &mut heights[z][x];
+                if level.is_finite() && h.is_finite() && *h > level {
+                    *h = level;
+                }
+            }
         }
         if (old_class == LC_WATER) != (new_class == LC_WATER) {
             water_changed = true;

--- a/src/land_cover/mod.rs
+++ b/src/land_cover/mod.rs
@@ -381,13 +381,23 @@ impl EsaPixelRaster {
             );
             return None;
         }
+        // A country-scale bbox asks for a gigabyte here, so failing to get it has to drop
+        // land cover rather than abort the process the way an infallible alloc would.
+        let mut data: Vec<u8> = Vec::new();
+        if data.try_reserve_exact(pixels).is_err() {
+            eprintln!(
+                "Warning: could not allocate the {pixels}-pixel ESA WorldCover raster; skipping land cover"
+            );
+            return None;
+        }
+        data.resize(pixels, 0);
         Some(Self {
             x0: x0 as i64,
             y0: y0 as i64,
             width: width as usize,
             height: height as usize,
             ppd,
-            data: vec![0u8; pixels],
+            data,
         })
     }
 

--- a/src/land_cover/mod.rs
+++ b/src/land_cover/mod.rs
@@ -10,7 +10,9 @@
 //! downloading the full ~500MB tiles.
 
 pub mod bridge_repair;
+pub mod osm_land_override;
 pub mod osm_water_override;
+mod shoreline;
 
 #[cfg(feature = "gui")]
 use crate::telemetry::{send_log, LogLevel};
@@ -196,22 +198,20 @@ pub fn fetch_land_cover_data(
         return None;
     }
 
-    // Build the land cover grid by sampling each position
-    let mut grid = vec![vec![0u8; grid_width]; grid_height];
+    // Read the ESA pixels into one raster, then resample every grid cell from it.
+    // Sampling per cell is what keeps the grid gap-free at any --scale, and the raster
+    // also feeds the shoreline reconstruction below.
+    let mut raster: Option<EsaPixelRaster> = None;
     let cells_per_meter = cells_per_meter(bbox, grid_width);
-
     for (tile_lat, tile_lng, tile_url) in &tile_specs {
-        // Try to read pixels from this ESA tile for our bbox
-        match read_esa_tile_pixels(
+        match read_esa_tile_into_raster(
             &client,
             tile_url,
             &cache_dir,
             *tile_lat,
             *tile_lng,
             bbox,
-            grid_width,
-            grid_height,
-            &mut grid,
+            &mut raster,
         ) {
             Ok(()) => {}
             Err(e) => {
@@ -221,7 +221,9 @@ pub fn fetch_land_cover_data(
     }
 
     // Check if we got any valid data
-    let has_data = grid.iter().any(|row| row.iter().any(|&v| v != 0));
+    let has_data = raster
+        .as_ref()
+        .is_some_and(|r| r.data.iter().any(|&v| v != 0));
     if !has_data {
         eprintln!("Warning: No land cover data received for this area");
         #[cfg(feature = "gui")]
@@ -231,6 +233,13 @@ pub fn fetch_land_cover_data(
         );
         return None;
     }
+    let raster = raster?;
+    let mapping = GridMapping::new(bbox, raster.ppd, grid_width, grid_height)?;
+    let mut grid = raster.sample_grid(&mapping);
+
+    // Straighten the shore before anything else reads the water mask.
+    shoreline::reconstruct_water_shoreline(&raster, &mapping, &mut grid);
+    drop(raster);
 
     // Fill gaps (0 values surrounded by valid data) with nearest neighbor
     fill_gaps(&mut grid, grid_width, grid_height);
@@ -329,26 +338,161 @@ fn esa_tile_url(lat: f64, lng: f64) -> String {
 
 // ─── COG reading ──────────────────────────────────────────────────────────
 
-/// Read pixels from a single ESA tile into our grid.
-///
-/// This function reads the Cloud-Optimized GeoTIFF header to find internal tile
-/// offsets, then fetches only the tiles overlapping our bounding box via HTTP
-/// Range requests. Each fetched tile is decompressed and sampled into the grid.
-#[allow(clippy::too_many_arguments)]
-fn read_esa_tile_pixels(
+/// ESA pixels covering the bbox, in the product's global pixel grid:
+/// `x = floor((lng + 180) * ppd)`, `y = floor((90 - lat) * ppd)`. Class 0 = nodata.
+pub(crate) struct EsaPixelRaster {
+    /// Global pixel column of the first raster column.
+    pub x0: i64,
+    /// Global pixel row of the first raster row.
+    pub y0: i64,
+    pub width: usize,
+    pub height: usize,
+    /// Pixels per degree (12000 for the 10 m product).
+    pub ppd: f64,
+    /// Row-major classes, `height * width`.
+    pub data: Vec<u8>,
+}
+
+/// Raster cap, so a pathological bbox fails instead of allocating unbounded.
+const MAX_RASTER_PIXELS: usize = 1 << 31;
+
+impl EsaPixelRaster {
+    /// Raster covering `bbox` at `ppd`, filled with nodata.
+    fn covering(bbox: &LLBBox, ppd: f64) -> Option<Self> {
+        let x0 = ((bbox.min().lng() + 180.0) * ppd).floor();
+        let x1 = ((bbox.max().lng() + 180.0) * ppd).floor();
+        let y0 = ((90.0 - bbox.max().lat()) * ppd).floor();
+        let y1 = ((90.0 - bbox.min().lat()) * ppd).floor();
+        if !(x0.is_finite() && x1.is_finite() && y0.is_finite() && y1.is_finite()) {
+            return None;
+        }
+        // Inclusive on both ends: the cell at the bbox edge lies in the pixel
+        // containing max_lng / min_lat.
+        let width = (x1 - x0) as i64 + 1;
+        let height = (y1 - y0) as i64 + 1;
+        if width <= 0 || height <= 0 {
+            return None;
+        }
+        let pixels = (width as usize).checked_mul(height as usize)?;
+        if pixels > MAX_RASTER_PIXELS {
+            eprintln!(
+                "Warning: bounding box spans {} ESA WorldCover pixels, too many to hold; skipping land cover",
+                pixels
+            );
+            return None;
+        }
+        Some(Self {
+            x0: x0 as i64,
+            y0: y0 as i64,
+            width: width as usize,
+            height: height as usize,
+            ppd,
+            data: vec![0u8; pixels],
+        })
+    }
+
+    /// Nearest-neighbour resample: every grid cell takes the class of its pixel.
+    /// Nodata pixels leave 0 for `fill_gaps`.
+    pub(crate) fn sample_grid(&self, mapping: &GridMapping) -> Vec<Vec<u8>> {
+        let (gw, gh) = (mapping.grid_w, mapping.grid_h);
+        let mut grid = vec![vec![0u8; gw]; gh];
+        if gw == 0 || gh == 0 || self.width == 0 || self.height == 0 {
+            return grid;
+        }
+        // Grid column span [lo, hi) of every pixel column, computed once.
+        let col_spans: Vec<(usize, usize)> = (0..self.width)
+            .map(|px| {
+                let x = (self.x0 + px as i64) as f64;
+                mapping.cell_span(mapping.gx(x), mapping.gx(x + 1.0), gw)
+            })
+            .collect();
+        let mut row_buf = vec![0u8; gw];
+        for py in 0..self.height {
+            let y = (self.y0 + py as i64) as f64;
+            let (z_lo, z_hi) = mapping.cell_span(mapping.gz(y), mapping.gz(y + 1.0), gh);
+            if z_lo >= z_hi {
+                continue;
+            }
+            let src = &self.data[py * self.width..(py + 1) * self.width];
+            row_buf.fill(0);
+            for (px, &(lo, hi)) in col_spans.iter().enumerate() {
+                if lo < hi {
+                    row_buf[lo..hi].fill(src[px]);
+                }
+            }
+            for row in grid.iter_mut().take(z_hi).skip(z_lo) {
+                row.copy_from_slice(&row_buf);
+            }
+        }
+        grid
+    }
+}
+
+/// Global ESA pixel coordinates to grid cells, on the elevation grid's convention:
+/// cell `gx` sits at `min_lng + gx / (grid_w - 1) * (max_lng - min_lng)`.
+pub(crate) struct GridMapping {
+    /// Global pixel x of the bbox west edge (fractional).
+    pub x_origin: f64,
+    /// Global pixel y of the bbox north edge (fractional).
+    pub y_origin: f64,
+    /// Grid cells per pixel along x / y.
+    pub sx: f64,
+    pub sy: f64,
+    pub grid_w: usize,
+    pub grid_h: usize,
+}
+
+impl GridMapping {
+    fn new(bbox: &LLBBox, ppd: f64, grid_w: usize, grid_h: usize) -> Option<Self> {
+        let lng_px = (bbox.max().lng() - bbox.min().lng()) * ppd;
+        let lat_px = (bbox.max().lat() - bbox.min().lat()) * ppd;
+        if !(lng_px > 0.0 && lat_px > 0.0) || grid_w < 2 || grid_h < 2 {
+            return None;
+        }
+        Some(Self {
+            x_origin: (bbox.min().lng() + 180.0) * ppd,
+            y_origin: (90.0 - bbox.max().lat()) * ppd,
+            sx: (grid_w - 1) as f64 / lng_px,
+            sy: (grid_h - 1) as f64 / lat_px,
+            grid_w,
+            grid_h,
+        })
+    }
+
+    /// Grid x coordinate of global pixel x.
+    #[inline(always)]
+    pub(crate) fn gx(&self, px_x: f64) -> f64 {
+        (px_x - self.x_origin) * self.sx
+    }
+
+    /// Grid z coordinate of global pixel y.
+    #[inline(always)]
+    pub(crate) fn gz(&self, px_y: f64) -> f64 {
+        (px_y - self.y_origin) * self.sy
+    }
+
+    /// Cells `[lo, hi)` whose coordinate lies in `[a, b)`, clamped to `0..n`.
+    #[inline(always)]
+    fn cell_span(&self, a: f64, b: f64, n: usize) -> (usize, usize) {
+        let lo = a.ceil().max(0.0).min(n as f64) as usize;
+        let hi = b.ceil().max(0.0).min(n as f64) as usize;
+        (lo, hi)
+    }
+}
+
+/// Read the pixels of one ESA tile overlapping the bbox into `raster`, creating it from
+/// the tile's pixel size on first use. Only the COG tiles that overlap are fetched.
+fn read_esa_tile_into_raster(
     client: &reqwest::blocking::Client,
     url: &str,
     cache_dir: &Path,
     tile_lat: f64,
     tile_lng: f64,
     bbox: &LLBBox,
-    grid_width: usize,
-    grid_height: usize,
-    grid: &mut [Vec<u8>],
+    raster: &mut Option<EsaPixelRaster>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // The ESA tile covers [tile_lat, tile_lat+3] x [tile_lng, tile_lng+3]
     let tile_north = tile_lat + ESA_TILE_DEGREES;
-    let tile_east = tile_lng + ESA_TILE_DEGREES;
 
     // Generate a cache filename from the URL
     let cache_filename = url
@@ -406,34 +550,48 @@ fn read_esa_tile_pixels(
         return Err("Tile dimensions are zero".into());
     }
 
-    // Step 4: Calculate pixel coordinates for our bbox within this ESA tile
-    let pixels_per_degree_x = cog.image_width as f64 / ESA_TILE_DEGREES;
-    let pixels_per_degree_y = cog.image_height as f64 / ESA_TILE_DEGREES;
+    // Step 4: Place the tile in the global pixel grid. Tiles are 3 degrees square, so
+    // pixel size defines the raster; a tile with a different size cannot merge.
+    let ppd = cog.image_width as f64 / ESA_TILE_DEGREES;
+    if (cog.image_height as f64 / ESA_TILE_DEGREES - ppd).abs() > 1e-9 {
+        return Err("Non-square ESA tile pixels".into());
+    }
+    let raster = match raster {
+        Some(r) => {
+            if (r.ppd - ppd).abs() > 1e-9 {
+                return Err(format!(
+                    "Tile pixel size {ppd}/deg differs from the raster's {}/deg",
+                    r.ppd
+                )
+                .into());
+            }
+            r
+        }
+        slot @ None => {
+            let r = EsaPixelRaster::covering(bbox, ppd)
+                .ok_or("Cannot build a pixel raster for this bounding box")?;
+            slot.insert(r)
+        }
+    };
+    let tile_px_x0 = ((tile_lng + 180.0) * ppd).round() as i64;
+    let tile_px_y0 = ((90.0 - tile_north) * ppd).round() as i64;
 
-    // Clamp bbox to this tile's extent
-    let clip_min_lat = bbox.min().lat().max(tile_lat);
-    let clip_max_lat = bbox.max().lat().min(tile_north);
-    let clip_min_lng = bbox.min().lng().max(tile_lng);
-    let clip_max_lng = bbox.max().lng().min(tile_east);
-
-    // Convert geographic coords to pixel coords within this ESA tile
-    // Pixel (0,0) is top-left = (tile_lng, tile_north)
-    let px_min_x = ((clip_min_lng - tile_lng) * pixels_per_degree_x) as u64;
-    let px_max_x = ((clip_max_lng - tile_lng) * pixels_per_degree_x).ceil() as u64;
-    let px_min_y = ((tile_north - clip_max_lat) * pixels_per_degree_y) as u64;
-    let px_max_y = ((tile_north - clip_min_lat) * pixels_per_degree_y).ceil() as u64;
-
-    let px_min_x = px_min_x.min(cog.image_width - 1);
-    let px_max_x = px_max_x.min(cog.image_width);
-    let px_min_y = px_min_y.min(cog.image_height - 1);
-    let px_max_y = px_max_y.min(cog.image_height);
+    // Overlap of the raster with this tile, in tile-local pixels.
+    let lx_lo = (raster.x0 - tile_px_x0).max(0);
+    let lx_hi = (raster.x0 + raster.width as i64 - tile_px_x0).min(cog.image_width as i64);
+    let ly_lo = (raster.y0 - tile_px_y0).max(0);
+    let ly_hi = (raster.y0 + raster.height as i64 - tile_px_y0).min(cog.image_height as i64);
+    if lx_lo >= lx_hi || ly_lo >= ly_hi {
+        return Ok(());
+    }
+    let (lx_lo, lx_hi, ly_lo, ly_hi) = (lx_lo as u64, lx_hi as u64, ly_lo as u64, ly_hi as u64);
 
     // Step 5: Determine which internal tiles we need
     let tiles_across = cog.image_width.div_ceil(cog.tile_width);
-    let itile_min_x = px_min_x / cog.tile_width;
-    let itile_max_x = (px_max_x.saturating_sub(1)) / cog.tile_width;
-    let itile_min_y = px_min_y / cog.tile_height;
-    let itile_max_y = (px_max_y.saturating_sub(1)) / cog.tile_height;
+    let itile_min_x = lx_lo / cog.tile_width;
+    let itile_max_x = (lx_hi - 1) / cog.tile_width;
+    let itile_min_y = ly_lo / cog.tile_height;
+    let itile_max_y = (ly_hi - 1) / cog.tile_height;
 
     // Step 6: Fetch and decode each needed internal tile
     for ity in itile_min_y..=itile_max_y {
@@ -470,53 +628,28 @@ fn read_esa_tile_pixels(
             let pixel_count = (cog.tile_width * cog.tile_height) as usize;
             let pixels = decompress_tile(&compressed_data, pixel_count, cog.compression)?;
 
-            // Step 7: Map decompressed pixels into our grid
+            // Step 7: Copy the overlapping rows into the raster
             let tile_pixel_x0 = itx * cog.tile_width;
             let tile_pixel_y0 = ity * cog.tile_height;
-
-            for py in 0..cog.tile_height {
-                let abs_py = tile_pixel_y0 + py;
-                if abs_py < px_min_y || abs_py >= px_max_y {
-                    continue;
+            let x_from = lx_lo.max(tile_pixel_x0);
+            let x_to = lx_hi.min(tile_pixel_x0 + cog.tile_width);
+            let y_from = ly_lo.max(tile_pixel_y0);
+            let y_to = ly_hi.min(tile_pixel_y0 + cog.tile_height);
+            if x_from >= x_to {
+                continue;
+            }
+            for abs_py in y_from..y_to {
+                let src_start =
+                    ((abs_py - tile_pixel_y0) * cog.tile_width + (x_from - tile_pixel_x0)) as usize;
+                let src_end = src_start + (x_to - x_from) as usize;
+                if src_end > pixels.len() {
+                    break;
                 }
-
-                for px in 0..cog.tile_width {
-                    let abs_px = tile_pixel_x0 + px;
-                    if abs_px < px_min_x || abs_px >= px_max_x {
-                        continue;
-                    }
-
-                    let pixel_idx = (py * cog.tile_width + px) as usize;
-                    if pixel_idx >= pixels.len() {
-                        continue;
-                    }
-
-                    let class_value = pixels[pixel_idx];
-                    if class_value == 0 {
-                        continue; // No data
-                    }
-
-                    // Map pixel geographic position to grid coordinates
-                    // Pixel abs_px corresponds to longitude:
-                    let pixel_lng = tile_lng + (abs_px as f64 / pixels_per_degree_x);
-                    // Pixel abs_py corresponds to latitude (inverted):
-                    let pixel_lat = tile_north - (abs_py as f64 / pixels_per_degree_y);
-
-                    // Convert to grid coordinates (same mapping as elevation grid)
-                    let rel_x =
-                        (pixel_lng - bbox.min().lng()) / (bbox.max().lng() - bbox.min().lng());
-                    let rel_z = 1.0
-                        - (pixel_lat - bbox.min().lat()) / (bbox.max().lat() - bbox.min().lat());
-
-                    // Scale to grid indices using (size - 1) so rel==1.0 maps to
-                    // the last valid index (same approach as elevation_data.rs)
-                    let gx = (rel_x * (grid_width - 1) as f64).round() as i64;
-                    let gz = (rel_z * (grid_height - 1) as f64).round() as i64;
-
-                    if gx >= 0 && gx < grid_width as i64 && gz >= 0 && gz < grid_height as i64 {
-                        grid[gz as usize][gx as usize] = class_value;
-                    }
-                }
+                let ry = (tile_px_y0 + abs_py as i64 - raster.y0) as usize;
+                let rx = (tile_px_x0 + x_from as i64 - raster.x0) as usize;
+                let dst_start = ry * raster.width + rx;
+                raster.data[dst_start..dst_start + (x_to - x_from) as usize]
+                    .copy_from_slice(&pixels[src_start..src_end]);
             }
         }
     }
@@ -926,6 +1059,40 @@ fn fill_gaps(grid: &mut [Vec<u8>], width: usize, height: usize) {
             break;
         }
     }
+}
+
+/// Class of the nearest non-water, non-nodata cell (ring search), if any.
+pub(crate) fn nearest_land_class(
+    grid: &[Vec<u8>],
+    gw: usize,
+    gh: usize,
+    x: usize,
+    z: usize,
+    radius: i32,
+) -> Option<u8> {
+    for r in 1..=radius {
+        for dz in -r..=r {
+            let nz = z as i32 + dz;
+            if nz < 0 || nz >= gh as i32 {
+                continue;
+            }
+            let row = &grid[nz as usize];
+            // Only the ring at Chebyshev distance exactly r.
+            let step = if dz.abs() == r { 1 } else { 2 * r };
+            let mut dx = -r;
+            while dx <= r {
+                let nx = x as i32 + dx;
+                if nx >= 0 && nx < gw as i32 {
+                    let c = row[nx as usize];
+                    if c != LC_WATER && c != 0 {
+                        return Some(c);
+                    }
+                }
+                dx += step;
+            }
+        }
+    }
+    None
 }
 
 // ─── Water distance field ─────────────────────────────────────────────────

--- a/src/land_cover/mod.rs
+++ b/src/land_cover/mod.rs
@@ -409,11 +409,14 @@ impl EsaPixelRaster {
         if gw == 0 || gh == 0 || self.width == 0 || self.height == 0 {
             return grid;
         }
-        // Grid column span [lo, hi) of every pixel column, computed once.
-        let col_spans: Vec<(usize, usize)> = (0..self.width)
-            .map(|px| {
+        // Grid column span of every pixel column, computed once. Only the columns that
+        // land on a cell are kept, so a grid coarser than the pixels walks the grid width
+        // per row instead of the pixel width.
+        let col_spans: Vec<(usize, usize, usize)> = (0..self.width)
+            .filter_map(|px| {
                 let x = (self.x0 + px as i64) as f64;
-                mapping.cell_span(mapping.gx(x), mapping.gx(x + 1.0), gw)
+                let (lo, hi) = mapping.cell_span(mapping.gx(x), mapping.gx(x + 1.0), gw);
+                (lo < hi).then_some((px, lo, hi))
             })
             .collect();
         let mut row_buf = vec![0u8; gw];
@@ -425,10 +428,8 @@ impl EsaPixelRaster {
             }
             let src = &self.data[py * self.width..(py + 1) * self.width];
             row_buf.fill(0);
-            for (px, &(lo, hi)) in col_spans.iter().enumerate() {
-                if lo < hi {
-                    row_buf[lo..hi].fill(src[px]);
-                }
+            for &(px, lo, hi) in &col_spans {
+                row_buf[lo..hi].fill(src[px]);
             }
             for row in grid.iter_mut().take(z_hi).skip(z_lo) {
                 row.copy_from_slice(&row_buf);
@@ -1034,6 +1035,10 @@ fn read_u64(bytes: &[u8], offset: usize, big_endian: bool) -> u64 {
 /// Fill gaps (zero values) in the grid using nearest-neighbor interpolation.
 /// Iterates until no more gaps can be filled or a max number of passes is reached.
 fn fill_gaps(grid: &mut [Vec<u8>], width: usize, height: usize) {
+    // Checked up front so a gap-free grid never pays for the snapshot below.
+    if !grid.iter().any(|row| row.contains(&0)) {
+        return;
+    }
     for _ in 0..10 {
         let mut changed = false;
         // Make a snapshot to read from while writing

--- a/src/land_cover/osm_land_override.rs
+++ b/src/land_cover/osm_land_override.rs
@@ -1,0 +1,655 @@
+//! Trim ESA water back to land where OSM shows the shore is somewhere else.
+//!
+//! ESA WorldCover pixels are 10 m, and a shoreline pixel that is half water is classified
+//! as water, so promenades, quays and the first row of a town end up under water. Within a
+//! band of the ESA shore, water becomes land where OSM puts a road or a building on it, or
+//! where a mapped water area ends further out. Cells inside OSM water are never touched.
+use std::collections::HashMap;
+
+use crate::bresenham::bresenham_line;
+use crate::clipping::clip_water_ring_to_bbox;
+use crate::coordinate_system::cartesian::XZBBox;
+use crate::element_processing::bridges::is_bridge_way;
+use crate::element_processing::highways::highway_block_range;
+use crate::element_processing::waterways::{
+    is_channel_waterway, is_underground_waterway, waterway_width, MAX_WATERWAY_WIDTH,
+};
+use crate::land_cover::{compute_water_distance, nearest_land_class, LandCoverData, LC_WATER};
+use crate::osm_parser::{
+    ProcessedElement, ProcessedMemberRole, ProcessedNode, ProcessedRelation, ProcessedWay,
+};
+
+/// How far from the ESA shore the classification may be corrected. One and a half ESA
+/// pixels, which is the mixed-pixel band that gets misread as water.
+const SHORE_BAND_M: f64 = 15.0;
+const MIN_BAND_CELLS: i32 = 1;
+const MAX_BAND_CELLS: i32 = 64;
+
+pub fn apply_osm_land_override(
+    land_cover: &mut LandCoverData,
+    world_width: usize,
+    world_height: usize,
+    elements: &[ProcessedElement],
+    xzbbox: &XZBBox,
+    scale: f64,
+) {
+    let width = land_cover.width;
+    let height = land_cover.height;
+    if width < 2 || height < 2 || world_width < 2 || world_height < 2 {
+        return;
+    }
+    let n = width * height;
+    let grid = &land_cover.grid;
+    let is_water = |idx: usize| grid[idx / width][idx % width] == LC_WATER;
+    if !(0..n).any(is_water) {
+        return;
+    }
+
+    let map = GridMap {
+        min_x: xzbbox.min_x(),
+        min_z: xzbbox.min_z(),
+        sx: (width as f64 - 1.0) / (world_width as f64 - 1.0),
+        sz: (height as f64 - 1.0) / (world_height as f64 - 1.0),
+        width,
+        height,
+    };
+    let band = band_cells(land_cover.cells_per_meter);
+
+    // OSM water areas: authoritative for where the shore is, and never trimmed.
+    let mut water_area = vec![0u64; n.div_ceil(64)];
+    // Mapped channels: never trimmed, but a centreline says nothing about the true width.
+    let mut water_line = vec![0u64; n.div_ceil(64)];
+    // Roads and buildings, which only stand on land.
+    let mut land = vec![0u64; n.div_ceil(64)];
+    // Structures that carry a road out over water, which do not.
+    let mut over_water = vec![0u64; n.div_ceil(64)];
+    let mut any_area = false;
+    let mut any_land = false;
+
+    for elem in elements {
+        match elem {
+            ProcessedElement::Way(way) => {
+                if way.nodes.len() < 2 {
+                    continue;
+                }
+                if let Some(half) = over_water_half_width(way, scale) {
+                    stamp_line(&mut over_water, &way.nodes, half, &map, xzbbox);
+                    if is_ring_closed(&way.nodes) {
+                        if let Some(ring) = clip_water_ring_to_bbox(&way.nodes, xzbbox) {
+                            fill_rings(&mut over_water, &[ring], &map);
+                        }
+                    }
+                    continue;
+                }
+                if is_water_area_way(way) {
+                    if is_ring_closed(&way.nodes) {
+                        if let Some(ring) = clip_water_ring_to_bbox(&way.nodes, xzbbox) {
+                            fill_rings(&mut water_area, &[ring], &map);
+                            any_area = true;
+                        }
+                    }
+                } else if let Some(kind) = way.tags.get("waterway") {
+                    if is_channel_waterway(kind) && !is_underground_waterway(&way.tags) {
+                        let half = (waterway_width(kind, &way.tags) / 2).max(0);
+                        stamp_line(&mut water_line, &way.nodes, half, &map, xzbbox);
+                    }
+                } else if let Some(half) = land_line_half_width(way, scale) {
+                    stamp_line(&mut land, &way.nodes, half, &map, xzbbox);
+                    any_land = true;
+                } else if is_building(&way.tags) && is_ring_closed(&way.nodes) {
+                    if let Some(ring) = clip_water_ring_to_bbox(&way.nodes, xzbbox) {
+                        fill_rings(&mut land, &[ring], &map);
+                        any_land = true;
+                    }
+                }
+            }
+            ProcessedElement::Relation(rel) => {
+                let target = if is_water_area_relation(rel) {
+                    any_area = true;
+                    &mut water_area
+                } else if is_building(&rel.tags) {
+                    any_land = true;
+                    &mut land
+                } else {
+                    continue;
+                };
+                let rings = relation_rings(rel, xzbbox);
+                if !rings.is_empty() {
+                    fill_rings(target, &rings, &map);
+                }
+            }
+            _ => {}
+        }
+    }
+    if !any_area && !any_land {
+        return;
+    }
+
+    // A road stamped across a pier is not evidence of land under it.
+    for (l, o) in land.iter_mut().zip(over_water.iter()) {
+        *l &= !o;
+    }
+
+    // Water within `band` steps of ESA land: the rim the classification may have got wrong.
+    let rim = dilate(n, width, height, band, |idx| !is_water(idx), is_water);
+    // Water reachable from a mapped water area without leaving the water: the same body,
+    // past the outline OSM drew for it. Walking over land instead would let a mapped lake
+    // condemn a separate body across an isthmus.
+    let past_outline = if any_area {
+        dilate(
+            n,
+            width,
+            height,
+            band,
+            |idx| get_bit(&water_area, idx),
+            is_water,
+        )
+    } else {
+        vec![0u64; n.div_ceil(64)]
+    };
+
+    let radius = band + 2;
+    let mut changes: Vec<(usize, usize, u8)> = Vec::new();
+    for idx in 0..n {
+        if !get_bit(&rim, idx) || get_bit(&water_area, idx) || get_bit(&water_line, idx) {
+            continue;
+        }
+        if !(get_bit(&past_outline, idx) || get_bit(&land, idx)) {
+            continue;
+        }
+        let (x, z) = (idx % width, idx / width);
+        if let Some(c) = nearest_land_class(grid, width, height, x, z, radius) {
+            changes.push((x, z, c));
+        }
+    }
+    if changes.is_empty() {
+        return;
+    }
+    for &(x, z, c) in &changes {
+        land_cover.grid[z][x] = c;
+    }
+    eprintln!(
+        "OSM land override: {} shore cells reclassified from ESA water to land",
+        changes.len()
+    );
+    land_cover.water_distance = compute_water_distance(&land_cover.grid, width, height);
+    land_cover.invalidate_water_blend_grid();
+}
+
+/// The band in grid cells. Sized in real metres so it holds at any scale and latitude.
+fn band_cells(cells_per_meter: f64) -> i32 {
+    if !cells_per_meter.is_finite() || cells_per_meter <= 0.0 {
+        return MIN_BAND_CELLS;
+    }
+    ((SHORE_BAND_M * cells_per_meter).round() as i64)
+        .clamp(MIN_BAND_CELLS as i64, MAX_BAND_CELLS as i64) as i32
+}
+
+/// Cells within `band` 4-connected steps of a seed, expanding only through `pass` cells.
+/// Seeds are excluded from the result.
+fn dilate(
+    n: usize,
+    width: usize,
+    height: usize,
+    band: i32,
+    seed: impl Fn(usize) -> bool,
+    pass: impl Fn(usize) -> bool,
+) -> Vec<u64> {
+    let mut seen = vec![0u64; n.div_ceil(64)];
+    let mut out = vec![0u64; n.div_ceil(64)];
+    let mut frontier: Vec<u32> = Vec::new();
+    // Only a seed touching a passable cell can reach anything, so the rest stay out of the
+    // frontier. On a mostly-land grid that is the shore rather than every cell.
+    for idx in 0..n {
+        if !seed(idx) {
+            continue;
+        }
+        set_bit(&mut seen, idx);
+        let (x, z) = (idx % width, idx / width);
+        let touches = (x > 0 && pass(idx - 1))
+            || (x + 1 < width && pass(idx + 1))
+            || (z > 0 && pass(idx - width))
+            || (z + 1 < height && pass(idx + width));
+        if touches {
+            frontier.push(idx as u32);
+        }
+    }
+    let mut next: Vec<u32> = Vec::new();
+    for _ in 0..band.max(0) {
+        next.clear();
+        for &idx in &frontier {
+            let idx = idx as usize;
+            let (x, z) = (idx % width, idx / width);
+            let mut around: [Option<usize>; 4] = [None; 4];
+            if x > 0 {
+                around[0] = Some(idx - 1);
+            }
+            if x + 1 < width {
+                around[1] = Some(idx + 1);
+            }
+            if z > 0 {
+                around[2] = Some(idx - width);
+            }
+            if z + 1 < height {
+                around[3] = Some(idx + width);
+            }
+            for nb in around.into_iter().flatten() {
+                if !get_bit(&seen, nb) && pass(nb) {
+                    set_bit(&mut seen, nb);
+                    set_bit(&mut out, nb);
+                    next.push(nb as u32);
+                }
+            }
+        }
+        std::mem::swap(&mut frontier, &mut next);
+        if frontier.is_empty() {
+            break;
+        }
+    }
+    out
+}
+
+struct GridMap {
+    min_x: i32,
+    min_z: i32,
+    sx: f64,
+    sz: f64,
+    width: usize,
+    height: usize,
+}
+
+impl GridMap {
+    fn gx(&self, x: i32) -> f64 {
+        (x - self.min_x) as f64 * self.sx
+    }
+    fn gz(&self, z: i32) -> f64 {
+        (z - self.min_z) as f64 * self.sz
+    }
+}
+
+/// Even-odd scanline fill of rings given in world coordinates into a grid bitset.
+/// Spans are inclusive, matching the fill in `osm_water_override`.
+fn fill_rings(bits: &mut [u64], rings: &[Vec<ProcessedNode>], map: &GridMap) {
+    let (gw, gh) = (map.width, map.height);
+    let mut rows: HashMap<usize, Vec<f64>> = HashMap::new();
+    for ring in rings {
+        let m = ring.len();
+        if m < 3 {
+            continue;
+        }
+        for i in 0..m {
+            let a = &ring[i];
+            let b = &ring[(i + 1) % m];
+            let (ay, by) = (map.gz(a.z), map.gz(b.z));
+            if ay == by {
+                continue;
+            }
+            let (ax, bx) = (map.gx(a.x), map.gx(b.x));
+            let (y_lo, y_hi) = if ay < by { (ay, by) } else { (by, ay) };
+            let z_start = y_lo.ceil().max(0.0) as i64;
+            let z_end = (y_hi.ceil() as i64).min(gh as i64);
+            let mut z = z_start;
+            while z < z_end {
+                let t = (z as f64 - ay) / (by - ay);
+                rows.entry(z as usize).or_default().push(ax + t * (bx - ax));
+                z += 1;
+            }
+        }
+    }
+    for (z, xs) in rows.iter_mut() {
+        xs.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+        let mut i = 0;
+        while i + 1 < xs.len() {
+            let x_start = xs[i].ceil().max(0.0) as i64;
+            let x_end = (xs[i + 1].floor() as i64).min(gw as i64 - 1);
+            let mut x = x_start;
+            while x <= x_end {
+                set_bit(bits, z * gw + x as usize);
+                x += 1;
+            }
+            i += 2;
+        }
+    }
+}
+
+/// Stamp a polyline of the given half width (in world blocks) into a grid bitset.
+fn stamp_line(
+    bits: &mut [u64],
+    nodes: &[ProcessedNode],
+    half_width: i32,
+    map: &GridMap,
+    xzbbox: &XZBBox,
+) {
+    let half_width = half_width.clamp(0, MAX_WATERWAY_WIDTH);
+    let (w, h) = (map.width as i64, map.height as i64);
+    for pair in nodes.windows(2) {
+        let (x1, z1, x2, z2) = (pair[0].x, pair[0].z, pair[1].x, pair[1].z);
+        if x1.max(x2).saturating_add(half_width) < xzbbox.min_x()
+            || x1.min(x2).saturating_sub(half_width) > xzbbox.max_x()
+            || z1.max(z2).saturating_add(half_width) < xzbbox.min_z()
+            || z1.min(z2).saturating_sub(half_width) > xzbbox.max_z()
+        {
+            continue;
+        }
+        for (bx, _, bz) in bresenham_line(x1, 0, z1, x2, 0, z2) {
+            for dz in -half_width..=half_width {
+                for dx in -half_width..=half_width {
+                    let gx = map.gx(bx.saturating_add(dx)).round() as i64;
+                    let gz = map.gz(bz.saturating_add(dz)).round() as i64;
+                    if gx >= 0 && gz >= 0 && gx < w && gz < h {
+                        set_bit(bits, gz as usize * map.width + gx as usize);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn relation_rings(rel: &ProcessedRelation, xzbbox: &XZBBox) -> Vec<Vec<ProcessedNode>> {
+    let mut outer: Vec<Vec<ProcessedNode>> = Vec::new();
+    let mut inner: Vec<Vec<ProcessedNode>> = Vec::new();
+    for member in &rel.members {
+        if member.way.nodes.len() < 2 {
+            continue;
+        }
+        match member.role {
+            ProcessedMemberRole::Outer => outer.push(member.way.nodes.clone()),
+            ProcessedMemberRole::Inner => inner.push(member.way.nodes.clone()),
+            _ => {}
+        }
+    }
+    crate::element_processing::merge_way_segments(&mut outer);
+    crate::element_processing::merge_way_segments(&mut inner);
+    outer
+        .into_iter()
+        .chain(inner)
+        .filter(|r| is_ring_closed(r))
+        .filter_map(|r| clip_water_ring_to_bbox(&r, xzbbox))
+        .collect()
+}
+
+fn is_ring_closed(nodes: &[ProcessedNode]) -> bool {
+    if nodes.len() < 3 {
+        return false;
+    }
+    let (first, last) = (&nodes[0], nodes.last().unwrap());
+    first.id == last.id || ((first.x - last.x).abs() <= 1 && (first.z - last.z).abs() <= 1)
+}
+
+fn has_explicit_water_tag(tags: &HashMap<String, String>) -> bool {
+    tags.get("water")
+        .is_some_and(|v| !matches!(v.as_str(), "no" | "0" | "false"))
+}
+
+fn is_water_area_way(way: &ProcessedWay) -> bool {
+    let tags = &way.tags;
+    matches!(tags.get("natural").map(String::as_str), Some("water"))
+        || has_explicit_water_tag(tags)
+        || matches!(tags.get("landuse").map(String::as_str), Some("reservoir"))
+        || matches!(
+            tags.get("waterway").map(String::as_str),
+            Some("dock" | "riverbank")
+        )
+}
+
+fn is_water_area_relation(rel: &ProcessedRelation) -> bool {
+    matches!(
+        rel.tags.get("natural").map(String::as_str),
+        Some("water" | "bay")
+    ) || has_explicit_water_tag(&rel.tags)
+        || matches!(
+            rel.tags.get("landuse").map(String::as_str),
+            Some("reservoir")
+        )
+}
+
+fn is_building(tags: &HashMap<String, String>) -> bool {
+    tags.get("building")
+        .is_some_and(|v| !matches!(v.as_str(), "no" | "0" | "false"))
+        || tags.contains_key("building:part")
+}
+
+/// Half width of a structure that carries ground out over water, so anything stamped on
+/// it proves nothing about the shore.
+fn over_water_half_width(way: &ProcessedWay, scale: f64) -> Option<i32> {
+    let tags = &way.tags;
+    let structure = matches!(
+        tags.get("man_made").map(String::as_str),
+        Some("pier" | "breakwater" | "groyne" | "dolphin" | "quay")
+    ) || is_bridge_way(way)
+        || tags.get("floating").map(String::as_str) == Some("yes");
+    if !structure {
+        return None;
+    }
+    let road = tags
+        .get("highway")
+        .map(|kind| highway_block_range(kind, tags, scale));
+    Some(road.unwrap_or(2).max(2))
+}
+
+/// Half width of a road or rail line that only stands on land, or None for anything else.
+fn land_line_half_width(way: &ProcessedWay, scale: f64) -> Option<i32> {
+    let tags = &way.tags;
+    if tags
+        .get("tunnel")
+        .is_some_and(|v| !matches!(v.as_str(), "no" | "0" | "false"))
+        || tags.get("area").map(String::as_str) == Some("yes")
+        || tags.contains_key("man_made")
+    {
+        return None;
+    }
+    if let Some(kind) = tags.get("highway") {
+        if matches!(kind.as_str(), "proposed" | "construction" | "raceway") {
+            return None;
+        }
+        return Some(highway_block_range(kind, tags, scale).max(0));
+    }
+    if let Some(kind) = tags.get("railway") {
+        if matches!(
+            kind.as_str(),
+            "rail" | "light_rail" | "tram" | "subway" | "narrow_gauge" | "monorail"
+        ) && tags.get("location").map(String::as_str) != Some("underground")
+        {
+            return Some(1);
+        }
+    }
+    None
+}
+
+#[inline(always)]
+fn get_bit(mask: &[u64], idx: usize) -> bool {
+    (mask[idx >> 6] >> (idx & 63)) & 1 != 0
+}
+
+#[inline(always)]
+fn set_bit(mask: &mut [u64], idx: usize) {
+    mask[idx >> 6] |= 1u64 << (idx & 63);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::land_cover::LC_GRASSLAND;
+    use once_cell::sync::OnceCell;
+
+    fn node(id: u64, x: i32, z: i32) -> ProcessedNode {
+        ProcessedNode {
+            id,
+            tags: HashMap::new(),
+            x,
+            z,
+        }
+    }
+
+    fn way(id: u64, nodes: Vec<ProcessedNode>, tags: &[(&str, &str)]) -> ProcessedElement {
+        ProcessedElement::Way(ProcessedWay {
+            id,
+            nodes,
+            tags: tags
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        })
+    }
+
+    fn grid_from(f: impl Fn(usize, usize) -> u8) -> (LandCoverData, XZBBox) {
+        let grid: Vec<Vec<u8>> = (0..60)
+            .map(|z| (0..60).map(|x| f(x, z)).collect())
+            .collect();
+        let water_distance = compute_water_distance(&grid, 60, 60);
+        let lc = LandCoverData {
+            grid,
+            water_distance,
+            water_blend_cache: OnceCell::new(),
+            width: 60,
+            height: 60,
+            cells_per_meter: 1.0,
+        };
+        (lc, XZBBox::rect_from_min_max(0, 0, 59, 59).unwrap())
+    }
+
+    /// 60x60 grid over a 60x60 world; water for x >= 30, land west of it.
+    fn coast() -> (LandCoverData, XZBBox) {
+        grid_from(|x, _| if x >= 30 { LC_WATER } else { LC_GRASSLAND })
+    }
+
+    fn run(lc: &mut LandCoverData, bbox: &XZBBox, elements: &[ProcessedElement]) {
+        apply_osm_land_override(lc, 60, 60, elements, bbox, 1.0);
+    }
+
+    #[test]
+    fn road_along_the_shore_reclaims_water_under_it() {
+        let (mut lc, bbox) = coast();
+        let elements = vec![way(
+            1,
+            vec![node(1, 32, 0), node(2, 32, 59)],
+            &[("highway", "footway")],
+        )];
+        run(&mut lc, &bbox, &elements);
+        assert_eq!(lc.grid[30][32], LC_GRASSLAND);
+        assert_eq!(lc.grid[30][50], LC_WATER);
+    }
+
+    #[test]
+    fn water_area_boundary_trims_the_esa_rim() {
+        let (mut lc, bbox) = coast();
+        let ring = vec![
+            node(1, 34, -5),
+            node(2, 80, -5),
+            node(3, 80, 65),
+            node(4, 34, 65),
+            node(1, 34, -5),
+        ];
+        let elements = vec![way(2, ring, &[("natural", "water")])];
+        run(&mut lc, &bbox, &elements);
+        for x in 30..34 {
+            assert_ne!(lc.grid[30][x], LC_WATER, "x={x} should be land");
+        }
+        for x in 34..60 {
+            assert_eq!(lc.grid[30][x], LC_WATER, "x={x} should stay water");
+        }
+    }
+
+    #[test]
+    fn a_waterway_centreline_never_defines_the_shore() {
+        // ESA sees a 20 cell wide river, OSM maps only its centreline. The banks must not
+        // close in to the tagged channel width.
+        let (mut lc, bbox) = grid_from(|x, _| {
+            if (20..40).contains(&x) {
+                LC_WATER
+            } else {
+                LC_GRASSLAND
+            }
+        });
+        let elements = vec![way(
+            3,
+            vec![node(1, 30, 0), node(2, 30, 59)],
+            &[("waterway", "stream")],
+        )];
+        run(&mut lc, &bbox, &elements);
+        for x in 20..40 {
+            assert_eq!(lc.grid[30][x], LC_WATER, "x={x} should stay water");
+        }
+    }
+
+    #[test]
+    fn a_mapped_pond_does_not_condemn_water_across_land() {
+        // Two bodies separated by land. Only the mapped one may lose its rim.
+        let (mut lc, bbox) = grid_from(|x, _| {
+            if (5..15).contains(&x) || (40..55).contains(&x) {
+                LC_WATER
+            } else {
+                LC_GRASSLAND
+            }
+        });
+        let ring = vec![
+            node(1, 7, 5),
+            node(2, 13, 5),
+            node(3, 13, 55),
+            node(4, 7, 55),
+            node(1, 7, 5),
+        ];
+        let elements = vec![way(4, ring, &[("natural", "water")])];
+        run(&mut lc, &bbox, &elements);
+        for x in 40..55 {
+            assert_eq!(
+                lc.grid[30][x], LC_WATER,
+                "unmapped body at x={x} was trimmed"
+            );
+        }
+    }
+
+    #[test]
+    fn piers_and_bridges_are_not_land() {
+        let (mut lc, bbox) = coast();
+        let elements = vec![
+            way(
+                5,
+                vec![node(1, 32, 10), node(2, 32, 20)],
+                &[("highway", "footway"), ("bridge", "yes")],
+            ),
+            way(
+                6,
+                vec![node(3, 34, 30), node(4, 34, 40)],
+                &[("man_made", "pier")],
+            ),
+            // The footway drawn on top of that pier shares its geometry.
+            way(
+                7,
+                vec![node(5, 34, 30), node(6, 34, 40)],
+                &[("highway", "footway")],
+            ),
+        ];
+        run(&mut lc, &bbox, &elements);
+        assert_eq!(lc.grid[15][32], LC_WATER, "bridge deck became land");
+        assert_eq!(lc.grid[35][34], LC_WATER, "pier became land");
+    }
+
+    #[test]
+    fn open_water_far_from_shore_is_never_trimmed() {
+        let (mut lc, bbox) = coast();
+        let ring = vec![
+            node(1, 0, 0),
+            node(2, 59, 0),
+            node(3, 59, 59),
+            node(4, 0, 59),
+            node(1, 0, 0),
+        ];
+        let elements = vec![way(8, ring, &[("building", "yes")])];
+        run(&mut lc, &bbox, &elements);
+        assert_ne!(lc.grid[30][31], LC_WATER);
+        assert_eq!(lc.grid[30][50], LC_WATER);
+    }
+
+    #[test]
+    fn an_absurd_width_tag_is_clamped() {
+        let (mut lc, bbox) = coast();
+        let elements = vec![way(
+            9,
+            vec![node(1, 32, 0), node(2, 32, 59)],
+            &[("waterway", "river"), ("width", "999999999")],
+        )];
+        run(&mut lc, &bbox, &elements);
+        assert_eq!(lc.grid[30][50], LC_WATER);
+    }
+}

--- a/src/land_cover/osm_land_override.rs
+++ b/src/land_cover/osm_land_override.rs
@@ -129,6 +129,7 @@ pub fn apply_osm_land_override(
     for (l, o) in land.iter_mut().zip(over_water.iter()) {
         *l &= !o;
     }
+    drop(over_water);
 
     // Water within `band` steps of ESA land: the rim the classification may have got wrong.
     let rim = dilate(n, width, height, band, |idx| !is_water(idx), is_water);
@@ -149,7 +150,7 @@ pub fn apply_osm_land_override(
     };
 
     let radius = band + 2;
-    let mut changes: Vec<(usize, usize, u8)> = Vec::new();
+    let mut changes: Vec<(u32, u32, u8)> = Vec::new();
     for idx in 0..n {
         if !get_bit(&rim, idx) || get_bit(&water_area, idx) || get_bit(&water_line, idx) {
             continue;
@@ -159,14 +160,14 @@ pub fn apply_osm_land_override(
         }
         let (x, z) = (idx % width, idx / width);
         if let Some(c) = nearest_land_class(grid, width, height, x, z, radius) {
-            changes.push((x, z, c));
+            changes.push((x as u32, z as u32, c));
         }
     }
     if changes.is_empty() {
         return;
     }
     for &(x, z, c) in &changes {
-        land_cover.grid[z][x] = c;
+        land_cover.grid[z as usize][x as usize] = c;
     }
     eprintln!(
         "OSM land override: {} shore cells reclassified from ESA water to land",

--- a/src/land_cover/osm_water_override.rs
+++ b/src/land_cover/osm_water_override.rs
@@ -25,7 +25,7 @@ struct WaterContext {
 
 pub fn apply_osm_water_override(
     land_cover: &mut LandCoverData,
-    heights: &[Vec<f32>],
+    heights: &mut [Vec<f32>],
     world_width: usize,
     world_height: usize,
     elements: &[ProcessedElement],
@@ -51,6 +51,7 @@ pub fn apply_osm_water_override(
         scale_to_grid_x,
         scale_to_grid_z,
     );
+    let heights: &mut [Vec<f32>] = heights;
 
     let mut changed: usize = 0;
     for elem in elements {
@@ -82,7 +83,15 @@ pub fn apply_osm_water_override(
                         scale_to_grid_z,
                     );
                 } else if let Some(waterway_type) = way.tags.get("waterway") {
-                    let waterway_width = get_waterway_width(waterway_type, &way.tags);
+                    if !crate::element_processing::waterways::is_channel_waterway(waterway_type)
+                        || crate::element_processing::waterways::is_underground_waterway(&way.tags)
+                    {
+                        continue;
+                    }
+                    let waterway_width = crate::element_processing::waterways::waterway_width(
+                        waterway_type,
+                        &way.tags,
+                    );
                     let half_width = waterway_width / 2;
                     changed += rasterize_line(
                         &mut land_cover.grid,
@@ -171,6 +180,35 @@ pub fn apply_osm_water_override(
         );
         land_cover.water_distance = compute_water_distance(&land_cover.grid, width, height);
         land_cover.invalidate_water_blend_grid();
+        // The grid was leveled before this ran, so cells added here sit at their own
+        // terrain height and render as a rim above the body. Sink them onto the water
+        // they were judged against. ESA water is its own seed and stays put.
+        if let Some(nearest_y) = context.as_ref().and_then(|c| c.nearest_y.as_deref()) {
+            let mut sunk = 0usize;
+            for gz in 0..height {
+                for gx in 0..width {
+                    if land_cover.grid[gz][gx] != LC_WATER {
+                        continue;
+                    }
+                    let cell_y = heights[gz][gx];
+                    let water_y = nearest_y[gz][gx];
+                    if cell_y.is_finite()
+                        && water_y.is_finite()
+                        && cell_y > water_y
+                        && cell_y <= water_y + ELEVATION_TOLERANCE_BLOCKS
+                    {
+                        heights[gz][gx] = water_y;
+                        sunk += 1;
+                    }
+                }
+            }
+            if sunk > 0 {
+                eprintln!(
+                    "OSM water override: sank {} overridden cells onto the adjacent water surface",
+                    sunk
+                );
+            }
+        }
     }
 }
 
@@ -193,6 +231,10 @@ fn has_water_polygon_tags(tags: &HashMap<String, String>) -> bool {
     matches!(tags.get("natural").map(|s| s.as_str()), Some("water"))
         || has_explicit_water_tag(tags)
         || matches!(tags.get("landuse").map(|s| s.as_str()), Some("reservoir"))
+        || matches!(
+            tags.get("waterway").map(|s| s.as_str()),
+            Some("dock" | "riverbank")
+        )
 }
 
 // `water=no` and similar negatives must not count as water.
@@ -213,27 +255,6 @@ fn is_ring_closed(nodes: &[ProcessedNode]) -> bool {
     let dx = (first.x - last.x).abs();
     let dz = (first.z - last.z).abs();
     dx <= 1 && dz <= 1
-}
-
-fn get_waterway_width(waterway_type: &str, tags: &HashMap<String, String>) -> i32 {
-    if let Some(w) = tags.get("width").and_then(|s| {
-        s.parse::<f32>()
-            .ok()
-            .or_else(|| s.parse::<i32>().ok().map(|i| i as f32))
-    }) {
-        return w.round() as i32;
-    }
-    match waterway_type {
-        "river" => 8,
-        "canal" => 6,
-        "stream" => 3,
-        "fairway" => 12,
-        "flowline" => 2,
-        "brook" => 2,
-        "ditch" => 2,
-        "drain" => 1,
-        _ => 4,
-    }
 }
 
 #[allow(clippy::too_many_arguments, clippy::needless_range_loop)]

--- a/src/land_cover/osm_water_override.rs
+++ b/src/land_cover/osm_water_override.rs
@@ -36,6 +36,9 @@ pub fn apply_osm_water_override(
     if width < 2 || height < 2 || world_width < 2 || world_height < 2 {
         return;
     }
+    if heights.len() < height || heights.iter().take(height).any(|r| r.len() < width) {
+        return;
+    }
     let scale_to_grid_x = (width as f64 - 1.0) / (world_width as f64 - 1.0);
     let scale_to_grid_z = (height as f64 - 1.0) / (world_height as f64 - 1.0);
     let min_x = xzbbox.min_x();

--- a/src/land_cover/shoreline.rs
+++ b/src/land_cover/shoreline.rs
@@ -759,8 +759,9 @@ mod tests {
 
     #[test]
     fn single_pixel_bumps_and_notches_survive_on_straight_coasts() {
-        // A one-pixel bump or notch whose centre is clearly (>= 0.6 px) on the wrong side
-        // must survive, while the coast around it still simplifies.
+        // A one-pixel bump or notch must survive once its centre is clearly on the wrong
+        // side of the line. A stair corner already reaches 1/sqrt(2) = 0.71 px at 45
+        // degrees, so only past that is a feature something the fit can tell apart.
         let mut checked = 0;
         for angle_deg in [0.0f64, 12.0, 30.0, 45.0, 63.0, 80.0, 90.0] {
             let (s, c) = angle_deg.to_radians().sin_cos();
@@ -778,7 +779,7 @@ mod tests {
             for (px, py) in (0..40).flat_map(|px| (0..40).map(move |py| (px, py))) {
                 let d = signed(px as f64 + 0.5, py as f64 + 0.5);
                 // Bump: land pixel touching water on the land side. Notch: the mirror.
-                let (is_bump, is_notch) = ((0.6..1.0).contains(&d), (-1.0..=-0.6).contains(&d));
+                let (is_bump, is_notch) = ((0.8..1.0).contains(&d), (-1.0..=-0.8).contains(&d));
                 if !(is_bump || is_notch) || !(3..=36).contains(&px) || !(3..=36).contains(&py) {
                     continue;
                 }

--- a/src/land_cover/shoreline.rs
+++ b/src/land_cover/shoreline.rs
@@ -1,0 +1,886 @@
+//! Straighten the ESA WorldCover shoreline below its 10 m pixel size.
+//!
+//! Sampled to blocks, an ESA shoreline is a staircase with 10-block steps that
+//! a few-block blur only rounds off. Instead: trace the water mask boundary as
+//! pixel rings, simplify each ring against a fitted line, rasterize back to the
+//! block grid. Straight coasts collapse to one segment at any angle; a real
+//! one-pixel bump or notch deviates far enough to survive.
+
+use super::{nearest_land_class, EsaPixelRaster, GridMapping, LC_WATER};
+
+/// Midpoint tolerance in ESA pixels: above a stair (0.5 px), below a real feature (1 px).
+const MIDPOINT_TOLERANCE_PX: f64 = 0.72;
+
+/// Corner tolerance in ESA pixels; stair corners reach 0.71 px. Catches corners in
+/// two-edge runs, where any two midpoints fit a line.
+const CORNER_TOLERANCE_PX: f64 = 1.0;
+
+/// Below this many cells per pixel the stairs are too small to matter.
+const MIN_CELLS_PER_PIXEL: f64 = 2.0;
+
+/// The shoreline may move but the water area may not change much; more means a bug.
+const MAX_AREA_CHANGE_FRACTION: f64 = 0.10;
+
+/// Ring vertex in raster-local pixel-corner coordinates.
+type Pt = (i32, i32);
+/// Sub-pixel ring vertex in raster-local pixel coordinates.
+type FPt = (f64, f64);
+
+/// Replace the water mask in `grid`, which must be the nearest-neighbour sample of
+/// `raster`, with its sub-pixel reconstruction. Other classes move only where a cell flips.
+pub(super) fn reconstruct_water_shoreline(
+    raster: &EsaPixelRaster,
+    mapping: &GridMapping,
+    grid: &mut [Vec<u8>],
+) {
+    if mapping.sx.max(mapping.sy) < MIN_CELLS_PER_PIXEL {
+        return;
+    }
+    let (w, h) = (raster.width, raster.height);
+    if w == 0 || h == 0 || mapping.grid_w == 0 || mapping.grid_h == 0 {
+        return;
+    }
+    let water: Vec<bool> = raster.data.iter().map(|&c| c == LC_WATER).collect();
+    if !water.iter().any(|&b| b) {
+        return;
+    }
+
+    let Some(rings) = trace_boundaries(&water, w, h) else {
+        eprintln!(
+            "Shoreline reconstruction: boundary tracing failed; keeping the pixel-exact water mask"
+        );
+        return;
+    };
+    let simplified: Vec<Vec<FPt>> = rings.iter().map(|r| simplify_ring(r)).collect();
+    let mask = rasterize_rings(&simplified, raster.x0, raster.y0, mapping);
+
+    let (gw, gh) = (mapping.grid_w, mapping.grid_h);
+    let before = grid
+        .iter()
+        .take(gh)
+        .map(|row| row.iter().take(gw).filter(|&&c| c == LC_WATER).count())
+        .sum::<usize>();
+    let after = mask.iter().map(|b| b.count_ones() as usize).sum::<usize>();
+    let allowed = MAX_AREA_CHANGE_FRACTION * before as f64 + 4.0 * mapping.sx * mapping.sy;
+    if (after as f64 - before as f64).abs() > allowed {
+        eprintln!(
+            "Shoreline reconstruction: water area changed {} -> {} cells; keeping the pixel-exact water mask",
+            before, after
+        );
+        return;
+    }
+
+    // Collect against the untouched grid so land classes come from the exact mask.
+    let search_radius = ((1.5 * mapping.sx.max(mapping.sy)).ceil() as i32).clamp(2, 64);
+    let mut to_land: Vec<(usize, usize, u8)> = Vec::new();
+    let mut to_water: Vec<(usize, usize)> = Vec::new();
+    for z in 0..gh {
+        for x in 0..gw {
+            let is_water = get_bit(&mask, z * gw + x);
+            let cur = grid[z][x];
+            if is_water && cur != LC_WATER {
+                to_water.push((x, z));
+            } else if !is_water && cur == LC_WATER {
+                if let Some(c) = nearest_land_class(grid, gw, gh, x, z, search_radius) {
+                    to_land.push((x, z, c));
+                }
+            }
+        }
+    }
+    let (to_water_n, to_land_n) = (to_water.len(), to_land.len());
+    for (x, z) in to_water {
+        grid[z][x] = LC_WATER;
+    }
+    for (x, z, c) in to_land {
+        grid[z][x] = c;
+    }
+    if to_water_n + to_land_n > 0 {
+        eprintln!(
+            "Shoreline reconstruction: {} rings, {} cells to water, {} cells to land",
+            rings.len(),
+            to_water_n,
+            to_land_n
+        );
+    }
+}
+
+// ─── Boundary tracing ─────────────────────────────────────────────────────
+
+/// Sides of a pixel, clockwise in screen coordinates (y down).
+const TOP: u8 = 0;
+const RIGHT: u8 = 1;
+const BOTTOM: u8 = 2;
+const LEFT: u8 = 3;
+
+/// Start corner of a pixel side, walking clockwise around the pixel.
+#[inline]
+fn side_start(x: i32, y: i32, side: u8) -> Pt {
+    match side {
+        TOP => (x, y),
+        RIGHT => (x + 1, y),
+        BOTTOM => (x + 1, y + 1),
+        _ => (x, y + 1),
+    }
+}
+
+/// End corner of a pixel side, walking clockwise around the pixel.
+#[inline]
+fn side_end(x: i32, y: i32, side: u8) -> Pt {
+    side_start(x, y, (side + 1) % 4)
+}
+
+/// Boundaries of the 4-connected water regions as closed pixel-corner rings, holes
+/// included. `None` if a walk fails to close, so the caller can fall back.
+fn trace_boundaries(water: &[bool], w: usize, h: usize) -> Option<Vec<Vec<Pt>>> {
+    let (wi, hi) = (w as i32, h as i32);
+    let is_water = |x: i32, y: i32| -> bool {
+        x >= 0 && y >= 0 && x < wi && y < hi && water[y as usize * w + x as usize]
+    };
+    // A water pixel's side is boundary when the cell across it is land or outside.
+    let is_boundary = |x: i32, y: i32, side: u8| -> bool {
+        if !is_water(x, y) {
+            return false;
+        }
+        let (nx, ny) = match side {
+            TOP => (x, y - 1),
+            RIGHT => (x + 1, y),
+            BOTTOM => (x, y + 1),
+            _ => (x - 1, y),
+        };
+        !is_water(nx, ny)
+    };
+    let edge_id =
+        |x: i32, y: i32, side: u8| -> usize { (y as usize * w + x as usize) * 4 + side as usize };
+
+    let mut visited = vec![0u64; (w * h * 4).div_ceil(64)];
+    let mut rings: Vec<Vec<Pt>> = Vec::new();
+    let max_steps = w * h * 4 + 4;
+
+    for y in 0..hi {
+        for x in 0..wi {
+            if !water[y as usize * w + x as usize] {
+                continue;
+            }
+            for side in 0..4u8 {
+                if !is_boundary(x, y, side) || get_bit(&visited, edge_id(x, y, side)) {
+                    continue;
+                }
+                let mut ring: Vec<Pt> = Vec::new();
+                let (mut cx, mut cy, mut cs) = (x, y, side);
+                let mut steps = 0usize;
+                loop {
+                    let id = edge_id(cx, cy, cs);
+                    if get_bit(&visited, id) {
+                        break;
+                    }
+                    set_bit(&mut visited, id);
+                    push_merged(&mut ring, side_start(cx, cy, cs));
+
+                    // Prefer this pixel's next side, so diagonal touches stay separate rings.
+                    let next_side = (cs + 1) % 4;
+                    if is_boundary(cx, cy, next_side) {
+                        cs = next_side;
+                    } else {
+                        let (vx, vy) = side_end(cx, cy, cs);
+                        let candidates = [
+                            (vx - 1, vy - 1, BOTTOM),
+                            (vx, vy - 1, LEFT),
+                            (vx - 1, vy, RIGHT),
+                            (vx, vy, TOP),
+                        ];
+                        let mut found: Option<(i32, i32, u8)> = None;
+                        for (qx, qy, qs) in candidates {
+                            if (qx, qy) == (cx, cy) || !is_boundary(qx, qy, qs) {
+                                continue;
+                            }
+                            if found.is_some() {
+                                return None;
+                            }
+                            found = Some((qx, qy, qs));
+                        }
+                        let (nx, ny, ns) = found?;
+                        cx = nx;
+                        cy = ny;
+                        cs = ns;
+                    }
+                    steps += 1;
+                    if steps > max_steps {
+                        return None;
+                    }
+                }
+                if (cx, cy, cs) != (x, y, side) {
+                    return None;
+                }
+                close_merged(&mut ring);
+                if ring.len() >= 3 {
+                    rings.push(ring);
+                }
+            }
+        }
+    }
+    Some(rings)
+}
+
+/// True if `b` lies on the straight axis-aligned run from `a` to `c`.
+#[inline]
+fn collinear_axis(a: Pt, b: Pt, c: Pt) -> bool {
+    (a.0 == b.0 && b.0 == c.0) || (a.1 == b.1 && b.1 == c.1)
+}
+
+/// Append a vertex, dropping the previous one if it was a run midpoint.
+#[inline]
+fn push_merged(ring: &mut Vec<Pt>, p: Pt) {
+    let n = ring.len();
+    if n >= 2 && collinear_axis(ring[n - 2], ring[n - 1], p) {
+        ring[n - 1] = p;
+    } else {
+        ring.push(p);
+    }
+}
+
+/// Merge runs across the ring's start, which is an arbitrary boundary edge.
+fn close_merged(ring: &mut Vec<Pt>) {
+    loop {
+        let n = ring.len();
+        if n < 3 {
+            return;
+        }
+        if collinear_axis(ring[n - 1], ring[0], ring[1]) {
+            ring.remove(0);
+        } else if collinear_axis(ring[n - 2], ring[n - 1], ring[0]) {
+            ring.pop();
+        } else {
+            return;
+        }
+    }
+}
+
+// ─── Simplification ───────────────────────────────────────────────────────
+
+/// Simplify a closed ring of pixel corners into sub-pixel vertices.
+///
+/// Douglas-Peucker recursion, but a run is accepted as straight when its edge
+/// midpoints sit within tolerance of the run's fitted line rather than of the chord.
+/// A stair oscillates symmetrically about the true edge, so the fit recovers it; a
+/// real bump throws a midpoint a full pixel off and forces a split. Kept vertices
+/// then move onto their two fitted lines, and each rendered segment is re-checked.
+/// Rings of four or fewer vertices are single pixels and pass through.
+fn simplify_ring(ring: &[Pt]) -> Vec<FPt> {
+    let n = ring.len();
+    let as_f = |p: Pt| (p.0 as f64, p.1 as f64);
+    if n <= 4 {
+        return ring.iter().map(|&p| as_f(p)).collect();
+    }
+    // Closed polyline: ext[n] == ext[0].
+    let mut ext: Vec<Pt> = ring.to_vec();
+    ext.push(ring[0]);
+    // Seed the recursion at the first vertex and the one farthest from it so
+    // both halves have distinct, well-separated endpoints.
+    let p0 = ring[0];
+    let mut k = 1;
+    let mut best = -1i64;
+    for (i, &p) in ring.iter().enumerate().skip(1) {
+        let dx = (p.0 - p0.0) as i64;
+        let dy = (p.1 - p0.1) as i64;
+        let d = dx * dx + dy * dy;
+        if d > best {
+            best = d;
+            k = i;
+        }
+    }
+    let mut keep = vec![false; n + 1];
+    keep[0] = true;
+    keep[k] = true;
+    keep[n] = true;
+    let mut stack: Vec<(usize, usize)> = vec![(0, k), (k, n)];
+    while let Some((i, j)) = stack.pop() {
+        if j <= i + 1 {
+            continue;
+        }
+        if let Some(m) = split_point(&ext[i..=j], None) {
+            keep[i + m] = true;
+            stack.push((i, i + m));
+            stack.push((i + m, j));
+        }
+    }
+    // Drop a seed whose neighbours merge into one run, else the trace start leaves a kink.
+    for seed in [k, 0usize] {
+        let kept: Vec<usize> = (0..n).filter(|&i| keep[i]).collect();
+        if kept.len() <= 3 {
+            break;
+        }
+        let pos = kept.iter().position(|&i| i == seed).unwrap();
+        let prev = kept[(pos + kept.len() - 1) % kept.len()];
+        let next = kept[(pos + 1) % kept.len()];
+        if split_point(&cyclic_points(&ext, prev, next), None).is_none() {
+            keep[seed] = false;
+        }
+    }
+    // Place vertices on their fitted lines, then split any segment that still strays.
+    // Each round only adds vertices, so this terminates.
+    loop {
+        let kept: Vec<usize> = (0..n).filter(|&i| keep[i]).collect();
+        let m = kept.len();
+        if m < 3 {
+            return ring.iter().map(|&p| as_f(p)).collect();
+        }
+        let runs: Vec<Vec<Pt>> = (0..m)
+            .map(|s| cyclic_points(&ext, kept[s], kept[(s + 1) % m]))
+            .collect();
+        let lines: Vec<FitLine> = runs.iter().map(|r| FitLine::fit_run(r)).collect();
+        let placed: Vec<FPt> = (0..m)
+            .map(|s| {
+                let orig = as_f(ext[kept[s]]);
+                lines[(s + m - 1) % m].join(&lines[s], orig)
+            })
+            .collect();
+        let mut split_any = false;
+        for s in 0..m {
+            let (a, b) = (placed[s], placed[(s + 1) % m]);
+            let rendered = FitLine::through(a, b);
+            if let Some(local) = split_point(&runs[s], Some(&rendered)) {
+                keep[(kept[s] + local) % n] = true;
+                split_any = true;
+            }
+        }
+        if !split_any {
+            return placed;
+        }
+    }
+}
+
+/// Where to split a run, or `None` if it is straight against `against` (the rendered
+/// segment) or against its own fitted line.
+fn split_point(pts: &[Pt], against: Option<&FitLine>) -> Option<usize> {
+    let n = pts.len();
+    if n < 3 {
+        return None;
+    }
+    let fitted;
+    let line = match against {
+        Some(l) => l,
+        None => {
+            fitted = FitLine::fit_run(pts);
+            &fitted
+        }
+    };
+    let mut worst_mid = 0.0f64;
+    let mut worst_edge = 0;
+    for e in 0..n - 1 {
+        let (a, b) = (pts[e], pts[e + 1]);
+        let mid = ((a.0 + b.0) as f64 * 0.5, (a.1 + b.1) as f64 * 0.5);
+        let r = line.residual(mid);
+        if r > worst_mid {
+            worst_mid = r;
+            worst_edge = e;
+        }
+    }
+    let corner_res: Vec<f64> = pts
+        .iter()
+        .map(|&p| line.residual((p.0 as f64, p.1 as f64)))
+        .collect();
+    let mut worst_corner = -1.0;
+    let mut worst_corner_at = 1;
+    for (i, &r) in corner_res.iter().enumerate().take(n - 1).skip(1) {
+        if r > worst_corner {
+            worst_corner = r;
+            worst_corner_at = i;
+        }
+    }
+    let mut split = if worst_corner > CORNER_TOLERANCE_PX {
+        worst_corner_at
+    } else if worst_mid > MIDPOINT_TOLERANCE_PX {
+        // Split at the offending edge, not the worst corner: on a 45-degree stair every
+        // corner ties and the run would peel apart one stair at a time.
+        let (u, v) = (worst_edge, worst_edge + 1);
+        match (u >= 1, v <= n - 2) {
+            (true, true) => {
+                if corner_res[u] >= corner_res[v] {
+                    u
+                } else {
+                    v
+                }
+            }
+            (true, false) => u,
+            (false, true) => v,
+            (false, false) => return None,
+        }
+    } else {
+        return None;
+    };
+    let worst_corner = corner_res[split];
+    // Among near-tied corners take the one with the longest flanking edges: a stair never
+    // has two long edges in a row, so this splits at the real corner.
+    let flank = |i: usize| -> i64 {
+        let (a, b, c) = (pts[i - 1], pts[i], pts[i + 1]);
+        ((a.0 - b.0).abs() + (a.1 - b.1).abs() + (c.0 - b.0).abs() + (c.1 - b.1).abs()) as i64
+    };
+    let mut best_flank = flank(split);
+    let lo = split.saturating_sub(2).max(1);
+    let hi = (split + 2).min(n - 2);
+    for (cand, &res) in corner_res.iter().enumerate().take(hi + 1).skip(lo) {
+        if cand != split && res >= worst_corner - 0.75 {
+            let f = flank(cand);
+            if f > best_flank {
+                best_flank = f;
+                split = cand;
+            }
+        }
+    }
+    Some(split)
+}
+
+/// Vertices from index `i` to index `j` walking forward around the ring
+/// (`ext` has the closing duplicate at the end), inclusive of both ends.
+fn cyclic_points(ext: &[Pt], i: usize, j: usize) -> Vec<Pt> {
+    let n = ext.len() - 1;
+    if i < j {
+        ext[i..=j].to_vec()
+    } else {
+        let mut v = ext[i..=n].to_vec();
+        v.extend_from_slice(&ext[1..=j]);
+        v
+    }
+}
+
+/// A line through `(cx, cy)` with unit direction `(dx, dy)`.
+struct FitLine {
+    cx: f64,
+    cy: f64,
+    dx: f64,
+    dy: f64,
+}
+
+impl FitLine {
+    /// Orthogonal least-squares fit over edge midpoints, weighted by edge length.
+    fn fit_run(pts: &[Pt]) -> Self {
+        let n = pts.len();
+        let a = (pts[0].0 as f64, pts[0].1 as f64);
+        let b = (pts[n - 1].0 as f64, pts[n - 1].1 as f64);
+        let through_ends = || {
+            let (dx, dy) = (b.0 - a.0, b.1 - a.1);
+            let len = (dx * dx + dy * dy).sqrt();
+            if len > 0.0 {
+                Self {
+                    cx: a.0,
+                    cy: a.1,
+                    dx: dx / len,
+                    dy: dy / len,
+                }
+            } else {
+                Self {
+                    cx: a.0,
+                    cy: a.1,
+                    dx: 1.0,
+                    dy: 0.0,
+                }
+            }
+        };
+        if n < 3 {
+            return through_ends();
+        }
+        let (mut wsum, mut cx, mut cy) = (0.0, 0.0, 0.0);
+        let mids: Vec<(f64, f64, f64)> = (0..n - 1)
+            .map(|e| {
+                let (p, q) = (pts[e], pts[e + 1]);
+                let w = (((q.0 - p.0) as f64).powi(2) + ((q.1 - p.1) as f64).powi(2)).sqrt();
+                let m = ((p.0 + q.0) as f64 * 0.5, (p.1 + q.1) as f64 * 0.5);
+                wsum += w;
+                cx += w * m.0;
+                cy += w * m.1;
+                (m.0, m.1, w)
+            })
+            .collect();
+        if wsum <= 0.0 {
+            return through_ends();
+        }
+        cx /= wsum;
+        cy /= wsum;
+        let (mut sxx, mut syy, mut sxy) = (0.0, 0.0, 0.0);
+        for &(mx, my, w) in &mids {
+            let (ux, uy) = (mx - cx, my - cy);
+            sxx += w * ux * ux;
+            syy += w * uy * uy;
+            sxy += w * ux * uy;
+        }
+        if sxx + syy <= 1e-12 {
+            return through_ends();
+        }
+        let theta = 0.5 * (2.0 * sxy).atan2(sxx - syy);
+        Self {
+            cx,
+            cy,
+            dx: theta.cos(),
+            dy: theta.sin(),
+        }
+    }
+
+    /// Perpendicular distance of a point from the line.
+    #[inline]
+    fn residual(&self, p: FPt) -> f64 {
+        ((p.0 - self.cx) * self.dy - (p.1 - self.cy) * self.dx).abs()
+    }
+
+    /// Line through two points (a degenerate pair gets a horizontal line).
+    fn through(a: FPt, b: FPt) -> Self {
+        let (dx, dy) = (b.0 - a.0, b.1 - a.1);
+        let len = (dx * dx + dy * dy).sqrt();
+        if len > 0.0 {
+            Self {
+                cx: a.0,
+                cy: a.1,
+                dx: dx / len,
+                dy: dy / len,
+            }
+        } else {
+            Self {
+                cx: a.0,
+                cy: a.1,
+                dx: 1.0,
+                dy: 0.0,
+            }
+        }
+    }
+
+    /// Foot of the perpendicular from `p` onto the line.
+    fn project(&self, p: FPt) -> FPt {
+        let t = (p.0 - self.cx) * self.dx + (p.1 - self.cy) * self.dy;
+        (self.cx + t * self.dx, self.cy + t * self.dy)
+    }
+
+    /// Where a vertex shared by two segments belongs: their intersection when usable,
+    /// else midway between the projections, unless `orig` is off both lines (a real corner).
+    fn join(&self, next: &FitLine, orig: FPt) -> FPt {
+        let cross = self.dx * next.dy - self.dy * next.dx;
+        if cross.abs() >= 0.087 {
+            let (wx, wy) = (next.cx - self.cx, next.cy - self.cy);
+            let t = (wx * next.dy - wy * next.dx) / cross;
+            let p = (self.cx + t * self.dx, self.cy + t * self.dy);
+            if ((p.0 - orig.0).powi(2) + (p.1 - orig.1).powi(2)).sqrt() <= 1.0 {
+                return p;
+            }
+        }
+        if self.residual(orig) > MIDPOINT_TOLERANCE_PX
+            || next.residual(orig) > MIDPOINT_TOLERANCE_PX
+        {
+            return orig;
+        }
+        let a = self.project(orig);
+        let b = next.project(orig);
+        ((a.0 + b.0) * 0.5, (a.1 + b.1) * 0.5)
+    }
+}
+
+// ─── Rasterization ────────────────────────────────────────────────────────
+
+/// Even-odd scanline fill of the rings onto the block grid, as a row-major bitset.
+/// `px_x0`/`px_y0` shift raster-local vertices into global ESA pixel coordinates.
+fn rasterize_rings(rings: &[Vec<FPt>], px_x0: i64, px_y0: i64, mapping: &GridMapping) -> Vec<u64> {
+    let (gw, gh) = (mapping.grid_w, mapping.grid_h);
+    let mut mask = vec![0u64; (gw * gh).div_ceil(64)];
+    if gw == 0 || gh == 0 {
+        return mask;
+    }
+    let mut rows: Vec<Vec<f64>> = vec![Vec::new(); gh];
+    for ring in rings {
+        let n = ring.len();
+        if n < 3 {
+            continue;
+        }
+        for i in 0..n {
+            let a = ring[i];
+            let b = ring[(i + 1) % n];
+            let ay = mapping.gz(a.1 + px_y0 as f64);
+            let by = mapping.gz(b.1 + px_y0 as f64);
+            if ay == by {
+                continue;
+            }
+            let ax = mapping.gx(a.0 + px_x0 as f64);
+            let bx = mapping.gx(b.0 + px_x0 as f64);
+            let (y_lo, y_hi) = if ay < by { (ay, by) } else { (by, ay) };
+            // Half-open y_lo..y_hi, matching the nearest-neighbour cell assignment.
+            let z_start = y_lo.ceil().max(0.0) as i64;
+            let z_end = (y_hi.ceil() as i64).min(gh as i64);
+            let mut z = z_start;
+            while z < z_end {
+                let t = (z as f64 - ay) / (by - ay);
+                rows[z as usize].push(ax + t * (bx - ax));
+                z += 1;
+            }
+        }
+    }
+    for (z, xs) in rows.iter_mut().enumerate() {
+        if xs.len() < 2 {
+            continue;
+        }
+        xs.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+        let mut i = 0;
+        while i + 1 < xs.len() {
+            let x_start = xs[i].ceil().max(0.0) as i64;
+            let x_end = (xs[i + 1].ceil() as i64).min(gw as i64);
+            let mut x = x_start;
+            while x < x_end {
+                set_bit(&mut mask, z * gw + x as usize);
+                x += 1;
+            }
+            i += 2;
+        }
+    }
+    mask
+}
+
+#[inline(always)]
+fn get_bit(mask: &[u64], idx: usize) -> bool {
+    (mask[idx >> 6] >> (idx & 63)) & 1 != 0
+}
+
+#[inline(always)]
+fn set_bit(mask: &mut [u64], idx: usize) {
+    mask[idx >> 6] |= 1u64 << (idx & 63);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::land_cover::{LC_GRASSLAND, LC_TREE_COVER};
+
+    /// Raster of `w`x`h` pixels; `mapping` puts `cells` grid cells on every
+    /// pixel along both axes, with the grid origin on the raster origin.
+    fn setup(w: usize, h: usize, cells_x: f64, cells_y: f64) -> (EsaPixelRaster, GridMapping) {
+        let raster = EsaPixelRaster {
+            x0: 1000,
+            y0: 2000,
+            width: w,
+            height: h,
+            ppd: 12000.0,
+            data: vec![LC_GRASSLAND; w * h],
+        };
+        let mapping = GridMapping {
+            x_origin: 1000.0,
+            y_origin: 2000.0,
+            sx: cells_x,
+            sy: cells_y,
+            grid_w: (w as f64 * cells_x).round() as usize,
+            grid_h: (h as f64 * cells_y).round() as usize,
+        };
+        (raster, mapping)
+    }
+
+    fn water_cells(grid: &[Vec<u8>]) -> usize {
+        grid.iter()
+            .map(|r| r.iter().filter(|&&c| c == LC_WATER).count())
+            .sum()
+    }
+
+    fn run(raster: &EsaPixelRaster, mapping: &GridMapping) -> Vec<Vec<u8>> {
+        let mut grid = raster.sample_grid(mapping);
+        reconstruct_water_shoreline(raster, mapping, &mut grid);
+        grid
+    }
+
+    #[test]
+    fn unsimplified_rings_reproduce_the_nearest_neighbour_mask() {
+        // Trace and rasterize with no simplification must reproduce the exact mask.
+        let (mut raster, mapping) = setup(23, 17, 3.7, 5.2);
+        let mut seed = 0x9E3779B97F4A7C15u64;
+        for v in raster.data.iter_mut() {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            if seed % 5 < 2 {
+                *v = LC_WATER;
+            }
+        }
+        let grid = raster.sample_grid(&mapping);
+        let water: Vec<bool> = raster.data.iter().map(|&c| c == LC_WATER).collect();
+        let rings = trace_boundaries(&water, raster.width, raster.height).expect("trace");
+        let exact: Vec<Vec<FPt>> = rings
+            .iter()
+            .map(|r| r.iter().map(|&(x, y)| (x as f64, y as f64)).collect())
+            .collect();
+        let mask = rasterize_rings(&exact, raster.x0, raster.y0, &mapping);
+        for (z, row) in grid.iter().enumerate() {
+            for (x, &cell) in row.iter().enumerate() {
+                assert_eq!(
+                    get_bit(&mask, z * mapping.grid_w + x),
+                    cell == LC_WATER,
+                    "mismatch at ({x},{z})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn straight_coasts_become_straight_at_any_angle() {
+        // A rasterized half-plane must come back as one straight edge at every angle.
+        for angle_deg in [
+            3.0f64, 8.0, 15.0, 22.0, 30.0, 38.0, 45.0, 52.0, 60.0, 68.0, 75.0, 82.0, 87.0,
+        ] {
+            let (mut raster, mapping) = setup(40, 40, 10.0, 10.0);
+            let (s, c) = angle_deg.to_radians().sin_cos();
+            // Water where the pixel centre is below the line through (20,20).
+            let inside = |x: f64, y: f64| (x - 20.0) * s - (y - 20.0) * c < 0.0;
+            for py in 0..40 {
+                for px in 0..40 {
+                    if inside(px as f64 + 0.5, py as f64 + 0.5) {
+                        raster.data[py * 40 + px] = LC_WATER;
+                    }
+                }
+            }
+            let water: Vec<bool> = raster.data.iter().map(|&c| c == LC_WATER).collect();
+            let rings = trace_boundaries(&water, 40, 40).unwrap();
+            assert_eq!(rings.len(), 1, "angle {angle_deg}: one ring");
+            let simplified = simplify_ring(&rings[0]);
+            assert!(
+                simplified.len() <= 5,
+                "angle {angle_deg}: {} vertices left after RDP",
+                simplified.len()
+            );
+            let grid = run(&raster, &mapping);
+            // Every water/land boundary cell must be within one pixel of the line.
+            let mut worst = 0.0f64;
+            for z in 1..mapping.grid_h - 1 {
+                for x in 1..mapping.grid_w - 1 {
+                    let here = grid[z][x] == LC_WATER;
+                    if here != (grid[z][x + 1] == LC_WATER) || here != (grid[z + 1][x] == LC_WATER)
+                    {
+                        // Cell (x, z) sits at pixel coordinate (x/10, z/10).
+                        let d = ((x as f64 / 10.0 - 20.0) * s - (z as f64 / 10.0 - 20.0) * c).abs();
+                        worst = worst.max(d);
+                    }
+                }
+            }
+            assert!(
+                worst <= 1.0,
+                "angle {angle_deg}: shoreline strays {worst} px from the line"
+            );
+        }
+    }
+
+    #[test]
+    fn single_pixel_bumps_and_notches_survive_on_straight_coasts() {
+        // A one-pixel bump or notch whose centre is clearly (>= 0.6 px) on the wrong side
+        // must survive, while the coast around it still simplifies.
+        let mut checked = 0;
+        for angle_deg in [0.0f64, 12.0, 30.0, 45.0, 63.0, 80.0, 90.0] {
+            let (s, c) = angle_deg.to_radians().sin_cos();
+            // Signed distance of a point from the line; > 0 is the land side.
+            let signed = |x: f64, y: f64| (x - 20.0) * s - (y - 20.0) * c;
+            let base = |raster: &mut EsaPixelRaster| {
+                for py in 0..40 {
+                    for px in 0..40 {
+                        if signed(px as f64 + 0.5, py as f64 + 0.5) < 0.0 {
+                            raster.data[py * 40 + px] = LC_WATER;
+                        }
+                    }
+                }
+            };
+            for (px, py) in (0..40).flat_map(|px| (0..40).map(move |py| (px, py))) {
+                let d = signed(px as f64 + 0.5, py as f64 + 0.5);
+                // Bump: land pixel touching water on the land side. Notch: the mirror.
+                let (is_bump, is_notch) = ((0.6..1.0).contains(&d), (-1.0..=-0.6).contains(&d));
+                if !(is_bump || is_notch) || !(3..=36).contains(&px) || !(3..=36).contains(&py) {
+                    continue;
+                }
+                let (mut raster, mapping) = setup(40, 40, 10.0, 10.0);
+                base(&mut raster);
+                let touches_shore =
+                    [(1i32, 0i32), (-1, 0), (0, 1), (0, -1)]
+                        .iter()
+                        .any(|(dx, dy)| {
+                            let (nx, ny) = (px as i32 + dx, py as i32 + dy);
+                            (raster.data[ny as usize * 40 + nx as usize] == LC_WATER) == is_bump
+                        });
+                if !touches_shore {
+                    continue;
+                }
+                raster.data[py * 40 + px] = if is_bump { LC_WATER } else { LC_TREE_COVER };
+                let grid = run(&raster, &mapping);
+                let centre = grid[py * 10 + 5][px * 10 + 5];
+                if is_bump {
+                    assert_eq!(
+                        centre, LC_WATER,
+                        "angle {angle_deg}: bump at ({px},{py}) d={d:.2} lost"
+                    );
+                } else {
+                    assert_ne!(
+                        centre, LC_WATER,
+                        "angle {angle_deg}: notch at ({px},{py}) d={d:.2} filled"
+                    );
+                }
+                let water: Vec<bool> = raster.data.iter().map(|&c| c == LC_WATER).collect();
+                let rings = trace_boundaries(&water, 40, 40).unwrap();
+                let verts: usize = rings.iter().map(|r| simplify_ring(r).len()).sum();
+                assert!(verts <= 14, "angle {angle_deg}: {verts} vertices");
+                checked += 1;
+            }
+        }
+        assert!(checked >= 20, "only {checked} features exercised");
+    }
+
+    #[test]
+    fn single_pixel_pond_and_island_survive() {
+        let (mut raster, mapping) = setup(12, 12, 8.0, 8.0);
+        // Pond: one water pixel in land.
+        raster.data[3 * 12 + 3] = LC_WATER;
+        // Lake with a one-pixel island.
+        for py in 6..11 {
+            for px in 6..11 {
+                raster.data[py * 12 + px] = LC_WATER;
+            }
+        }
+        raster.data[8 * 12 + 8] = LC_TREE_COVER;
+        let grid = run(&raster, &mapping);
+        // The pond keeps its full pixel footprint (8x8 cells).
+        let pond: usize = (24..32)
+            .map(|z| (24..32).filter(|&x| grid[z][x] == LC_WATER).count())
+            .sum();
+        assert_eq!(pond, 64);
+        // The island still exists and kept its class.
+        assert_eq!(grid[68][68], LC_TREE_COVER);
+        assert_eq!(grid[68][60], LC_WATER);
+    }
+
+    #[test]
+    fn one_pixel_river_keeps_its_area() {
+        let (mut raster, mapping) = setup(30, 10, 6.0, 9.0);
+        // A river one pixel wide, running diagonally-ish across the raster.
+        for px in 2..28 {
+            let py = 2 + (px * 5) / 26;
+            raster.data[py * 30 + px] = LC_WATER;
+        }
+        let nn = raster.sample_grid(&mapping);
+        let grid = run(&raster, &mapping);
+        let before = water_cells(&nn);
+        let after = water_cells(&grid);
+        assert!(after > 0);
+        let ratio = after as f64 / before as f64;
+        assert!((0.8..=1.2).contains(&ratio), "river area ratio {ratio}");
+        // Land cells that turned to water and back must carry a land class.
+        assert!(grid.iter().flatten().all(|&c| c != 0));
+    }
+
+    #[test]
+    fn coarse_grid_is_left_alone() {
+        // Grid coarser than 2 cells/pixel: reconstruction is a no-op.
+        let (mut raster, mapping) = setup(20, 20, 1.5, 1.5);
+        for py in 5..15 {
+            for px in 0..20 {
+                if px + py < 18 {
+                    raster.data[py * 20 + px] = LC_WATER;
+                }
+            }
+        }
+        let nn = raster.sample_grid(&mapping);
+        let grid = run(&raster, &mapping);
+        assert_eq!(nn, grid);
+    }
+
+    #[test]
+    fn diagonal_pixels_trace_as_separate_rings() {
+        let water = vec![true, false, false, true];
+        let rings = trace_boundaries(&water, 2, 2).unwrap();
+        assert_eq!(rings.len(), 2);
+        assert!(rings.iter().all(|r| r.len() == 4));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,6 +432,7 @@ fn run_cli() {
 
     // OSM water override first, then bridge repair handles remaining bridge-shadow cells.
     ground.apply_osm_water_override(&parsed_elements, &xzbbox);
+    ground.apply_osm_land_override(&parsed_elements, &xzbbox, args.scale);
     if args.debug {
         ground.save_land_cover_debug_image("landcover_debug_post_osm_water");
     }

--- a/src/water_depth.rs
+++ b/src/water_depth.rs
@@ -730,10 +730,15 @@ pub fn carve_lc_water_region(
             if ground.cover_class(coord) != LC_WATER {
                 continue;
             }
-            let water_y = ground.water_level(coord);
-            // Skip land bumps an over-claiming water polygon sits above.
-            if editor.get_ground_level(x, z) > water_y {
-                continue;
+            let mut water_y = ground.water_level(coord);
+            let ground_y = editor.get_ground_level(x, z);
+            if ground_y > water_y {
+                // A bank cell the snap pulled below its terrain: skip. Interior water
+                // above a dip is a step inside the body: keep it at its own level.
+                if !ground.is_interior_water(coord) {
+                    continue;
+                }
+                water_y = ground_y;
             }
             carve_water_column(editor, x, z, water_y, bwf.depth_at(x, z), road_mask, bwf);
         }


### PR DESCRIPTION
Reconstruct the ESA WorldCover water mask below its 10 m pixel size, so a coast is a clean line instead of a staircase, and fix the cases where water ended up above or below the ground it sits on.

- Trace the ESA water mask as pixel rings, simplify each against a fitted line and rasterize back to blocks. Straight coasts collapse to one segment at any angle, a one-pixel bump or notch survives.
- Sample the block grid from the ESA pixel raster, which also fixes the land cover turning into a lattice above --scale 2.2.
- Trim ESA water back to land where OSM puts a road or building on it, or where a mapped water area ends further out.
- Drop shadow blobs ESA reads as water on cliff faces, keeping real watercourses by testing the water surface slope, not the terrain.
- Smooth DEM facet and project seams out of flowing water, capped so a real waterfall keeps its edge and water never rises over its own banks.
- Sink cells that become water after the elevation grid was leveled, so piers and bridge footprints stop leaving a rim a block above the body.
- Keep dam crests, weirs, culverts and drawn-down reservoirs out of the water fill, and clamp the waterway width tag that could hang generation.