### PR TITLE
Add opt-in floating nametags above named/categorized OSM elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ GUI Build: ```cargo run --release```<br>
 | `geo-only` | OSM objects on flat ground |
 | `terrain-only` | Real elevation terrain, no objects at all (skips the OpenStreetMap query and the Overture fetch entirely, so `--overture` has no effect) |
 
+`--nametags` (Java only, off by default) floats a name/category label above every named or address-tagged OSM element, plus a category label (e.g. "Restaurant") above any element carrying a recognized OSM tag even without a name. Labels are `minecraft:text_display` entities, so they render at a distance and always face the viewer. Capped at 3000 labeled elements per world.
+
 After your pull request is merged, I will take care of regularly creating update releases which will include your changes.
 
 If you are using Nix, you can run the program directly with `nix run github:louis-e/arnis -- --output-dir=YOUR_PATH/.minecraft/saves/worldname --bbox="min_lat,min_lng,max_lat,max_lng"`

--- a/src/args.rs
+++ b/src/args.rs
@@ -139,6 +139,11 @@ pub struct Args {
     /// Initial time of day in ticks (0 = dawn, 6000 = noon, 18000 = midnight)
     #[arg(long, default_value_t = 6000, value_parser = clap::value_parser!(i64).range(0..24000))]
     pub world_time: i64,
+
+    /// Float a floating name/category tag above every named or categorized OSM
+    /// element (optional, off unless requested). Java only.
+    #[arg(long, default_value_t = false)]
+    pub nametags: bool,
 }
 
 /// Generation mode, matching the GUI's dropdown (src/gui/js/main.js).
@@ -389,6 +394,25 @@ mod tests {
         // interior is opt-in (off by default); overture defaults to true
         assert!(!args.interior);
         assert!(args.overture);
+        // nametags is opt-in (off by default)
+        assert!(!args.nametags);
+    }
+
+    #[test]
+    fn test_nametags_flag() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let tmp_path = tmpdir.path().to_str().unwrap();
+
+        let cmd = [
+            "arnis",
+            "--output-dir",
+            tmp_path,
+            "--bbox",
+            "1,2,3,4",
+            "--nametags",
+        ];
+        let args = Args::parse_from(cmd.iter());
+        assert!(args.nametags);
     }
 
     #[test]

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -7,6 +7,7 @@ use crate::ground::Ground;
 use crate::ground_generation;
 use crate::map_preview;
 use crate::map_renderer::PreviewAccumulator;
+use crate::nametags;
 use crate::osm_parser::{
     OutlineSuppression, PartGroups, ProcessedElement, ProcessedMemberRole, ProcessedNode,
     ProcessedRelation, ProcessedWay,
@@ -563,6 +564,14 @@ pub fn generate_world_with_options(
     // Collect building footprints to prevent trees from spawning inside buildings
     // Uses a memory-efficient bitmap (~1 bit per coordinate) instead of a HashSet (~24 bytes per coordinate)
     let building_footprints = flood_fill_cache.collect_building_footprints(&elements, &xzbbox);
+
+    // Collected up front: `elements` is dropped (or moved into the tile loop) below,
+    // long before the block/entity-writing phase where labels actually get placed.
+    let nametag_labels = if args.nametags && world_format == WorldFormat::JavaAnvil {
+        nametags::collect_nametag_labels(&elements)
+    } else {
+        Vec::new()
+    };
 
     // Collect coordinates covered by tunnel=building_passage highways so that
     // building generation can cut ground-level openings through walls and floors.
@@ -1152,6 +1161,10 @@ pub fn generate_world_with_options(
         } else {
             editor.place_branding_map_only(sx, sz, 0);
         }
+    }
+
+    if !nametag_labels.is_empty() {
+        nametags::place_nametags(&mut editor, &nametag_labels);
     }
 
     // Save world

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1214,6 +1214,7 @@ fn gui_start_generation(
                 // Frontend refuses previews for rotated worlds, skip the work there.
                 map_preview: world_format != WorldFormat::LuantiWorld
                     && rotation_angle.abs() <= f64::EPSILON,
+                nametags: false,
             };
 
             // If skip_osm_objects is true (terrain-only mode), skip fetching and processing OSM data

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod map_preview;
 mod map_renderer;
 mod map_transformation;
 mod models_3d;
+mod nametags;
 mod ore_generation;
 mod osm_parser;
 mod overture;

--- a/src/nametags.rs
+++ b/src/nametags.rs
@@ -1,0 +1,286 @@
+//! Floats a name/category label above every named or categorized OSM element,
+//! independent of any other feature — enabled with `--nametags`. Java only.
+
+use std::collections::HashMap;
+
+use fastnbt::Value;
+
+use crate::osm_parser::ProcessedElement;
+use crate::world_editor::WorldEditor;
+
+/// Checked in priority order against each element's tags to pick a category label;
+/// the first one present wins.
+const CATEGORY_TAGS: &[&str] = &[
+    "amenity", "shop", "leisure", "tourism", "railway", "highway", "building", "office", "craft",
+    "landuse", "natural", "man_made",
+];
+
+/// `fast_food` -> "Fast Food".
+fn title_case_tag_value(value: &str) -> String {
+    value
+        .replace('_', " ")
+        .split(' ')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// The first `CATEGORY_TAGS` value present on `tags`, title-cased
+/// (`amenity=fast_food` -> "Fast Food"), or `None` if none of them are present.
+fn find_category_tag(tags: &HashMap<String, String>) -> Option<String> {
+    // OSM's boolean-flag convention (`building=yes`, `building=no`) is by far the
+    // most common `building` value and carries no information — skip to the next
+    // candidate tag instead of surfacing a meaningless "Yes" label.
+    const BOOLEAN_PLACEHOLDERS: &[&str] = &["yes", "no", "true", "false"];
+    CATEGORY_TAGS
+        .iter()
+        .filter_map(|key| tags.get(*key))
+        .find(|value| !BOOLEAN_PLACEHOLDERS.contains(&value.as_str()))
+        .map(|value| title_case_tag_value(value))
+}
+
+/// The `name` tag if present, else `"<housenumber> <street>"` synthesized from
+/// `addr:housenumber`/`addr:street` (common on buildings that carry an address but
+/// no proper name — "123 Main Street" is still a meaningful label). Elements with
+/// neither are skipped entirely; a bare category label like "Restaurant" alone is
+/// handled separately by `find_category_tag`.
+fn element_display_name(tags: &HashMap<String, String>) -> Option<String> {
+    if let Some(name) = tags.get("name") {
+        return Some(name.clone());
+    }
+    let house_number = tags.get("addr:housenumber")?;
+    let street = tags.get("addr:street")?;
+    Some(format!("{house_number} {street}"))
+}
+
+/// Average of an element's node coordinates, or `None` for a relation (which carries
+/// no nodes of its own — see `ProcessedElement::nodes`).
+fn element_centroid(element: &ProcessedElement) -> Option<(i32, i32)> {
+    let mut sum_x: i64 = 0;
+    let mut sum_z: i64 = 0;
+    let mut count: i64 = 0;
+    for node in element.nodes() {
+        sum_x += node.x as i64;
+        sum_z += node.z as i64;
+        count += 1;
+    }
+    if count == 0 {
+        return None;
+    }
+    Some(((sum_x / count) as i32, (sum_z / count) as i32))
+}
+
+/// Safety ceiling on how many *elements* get labeled (each can produce up to two
+/// physical labels) — nametags aren't gated behind any name/category allowlist, so a
+/// dense city could otherwise want a label on nearly every element.
+const NAMETAG_MAX_ELEMENTS: usize = 3000;
+
+/// How far above ground each element's floating nametag hovers — high enough to
+/// clear most rooftops without needing per-building height data.
+const NAMETAG_HEIGHT: i32 = 5;
+/// The category tag floats a couple blocks above the name/address tag, so an element
+/// with both shows two stacked labels instead of one overwriting the other.
+const CATEGORY_NAMETAG_HEIGHT: i32 = NAMETAG_HEIGHT + 2;
+
+/// A floating label pair for one real-world location: its name/address (if any) and
+/// its OSM category tag (if any). An element needs only one of the two to qualify.
+pub struct NametagLabel {
+    pub name: Option<String>,
+    pub category: Option<String>,
+    pub x: i32,
+    pub z: i32,
+}
+
+/// Every element with a name (or address fallback) or a `CATEGORY_TAGS` tag. Elements
+/// with a name are kept ahead of category-only elements when `NAMETAG_MAX_ELEMENTS`
+/// caps the list, since a name is strictly more useful than a bare "Restaurant".
+pub fn collect_nametag_labels(elements: &[ProcessedElement]) -> Vec<NametagLabel> {
+    let mut named = Vec::new();
+    let mut category_only = Vec::new();
+
+    for element in elements {
+        let tags = element.tags();
+        let name = element_display_name(tags);
+        let category = find_category_tag(tags);
+        if name.is_none() && category.is_none() {
+            continue;
+        }
+        let Some((x, z)) = element_centroid(element) else {
+            continue;
+        };
+        let is_named = name.is_some();
+        let label = NametagLabel {
+            name,
+            category,
+            x,
+            z,
+        };
+        if is_named {
+            named.push(label);
+        } else {
+            category_only.push(label);
+        }
+    }
+
+    named.extend(category_only);
+    named.truncate(NAMETAG_MAX_ELEMENTS);
+    named
+}
+
+/// Floats `minecraft:text_display` label(s) over each location's real in-world
+/// coordinates — the name/address at `NAMETAG_HEIGHT`, its category stacked above at
+/// `CATEGORY_NAMETAG_HEIGHT` when both are present. `billboard: "center"` always
+/// faces the viewer; `see_through: 1` keeps it legible through light terrain/foliage.
+/// Must run before `editor.save()` — plain entity API, no post-save NBT surgery needed.
+pub fn place_nametags(editor: &mut WorldEditor, labels: &[NametagLabel]) {
+    for label in labels {
+        if let Some(name) = &label.name {
+            place_text_display(editor, name, label.x, NAMETAG_HEIGHT, label.z);
+        }
+        if let Some(category) = &label.category {
+            place_text_display(editor, category, label.x, CATEGORY_NAMETAG_HEIGHT, label.z);
+        }
+    }
+}
+
+fn place_text_display(editor: &mut WorldEditor, text: &str, x: i32, y: i32, z: i32) {
+    let mut extra = HashMap::new();
+    extra.insert("text".to_string(), Value::String(format!("\"{text}\"")));
+    extra.insert("billboard".to_string(), Value::String("center".to_string()));
+    extra.insert("see_through".to_string(), Value::Byte(1));
+    editor.add_entity("minecraft:text_display", x, y, z, Some(extra));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinate_system::cartesian::XZBBox;
+    use crate::coordinate_system::geographic::LLBBox;
+    use crate::osm_parser::{ProcessedNode, ProcessedWay};
+
+    fn node_with_tags(tags: Vec<(&str, &str)>, x: i32, z: i32) -> ProcessedElement {
+        let tags = tags
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        ProcessedElement::Node(ProcessedNode { id: 1, tags, x, z })
+    }
+
+    #[test]
+    fn collects_named_and_category_only_elements() {
+        let elements = vec![
+            node_with_tags(vec![("amenity", "restaurant")], 0, 0), // no name -> category only
+            node_with_tags(
+                vec![("name", "Joe's Diner"), ("amenity", "restaurant")],
+                1,
+                0,
+            ), // both
+            node_with_tags(vec![("landuse", "residential")], 2, 0), // no name, category only
+        ];
+        let labels = collect_nametag_labels(&elements);
+        assert_eq!(labels.len(), 3);
+        // Named elements are ordered ahead of category-only ones.
+        assert_eq!(labels[0].name.as_deref(), Some("Joe's Diner"));
+        assert_eq!(labels[0].category.as_deref(), Some("Restaurant"));
+        assert!(labels[1].name.is_none());
+        assert!(labels[2].name.is_none());
+        let categories: Vec<&str> = labels[1..]
+            .iter()
+            .map(|l| l.category.as_deref().unwrap())
+            .collect();
+        assert!(categories.contains(&"Restaurant"));
+        assert!(categories.contains(&"Residential"));
+    }
+
+    #[test]
+    fn falls_back_to_address_when_name_is_missing() {
+        let elements = vec![
+            // No name, but has both address tags -> synthesized "123 Main Street".
+            node_with_tags(
+                vec![
+                    ("amenity", "cafe"),
+                    ("addr:housenumber", "123"),
+                    ("addr:street", "Main Street"),
+                ],
+                0,
+                0,
+            ),
+        ];
+        let labels = collect_nametag_labels(&elements);
+        assert_eq!(labels[0].name.as_deref(), Some("123 Main Street"));
+    }
+
+    #[test]
+    fn skips_boolean_flag_tags_like_building_yes() {
+        // building=yes carries no information; landuse=residential (further down the
+        // priority list) should be surfaced instead of a meaningless "Yes" label.
+        let elements = vec![node_with_tags(
+            vec![("building", "yes"), ("landuse", "residential")],
+            0,
+            0,
+        )];
+        let labels = collect_nametag_labels(&elements);
+        assert_eq!(labels.len(), 1);
+        assert_eq!(labels[0].category.as_deref(), Some("Residential"));
+
+        // No usable tag at all once the boolean flag is skipped -> no label.
+        let elements = vec![node_with_tags(vec![("building", "yes")], 0, 0)];
+        assert!(collect_nametag_labels(&elements).is_empty());
+    }
+
+    #[test]
+    fn way_uses_node_centroid() {
+        let mut tags = HashMap::new();
+        tags.insert("name".to_string(), "Terminal Building".to_string());
+        let way = ProcessedElement::Way(ProcessedWay {
+            id: 1,
+            tags,
+            nodes: vec![
+                ProcessedNode {
+                    id: 1,
+                    tags: HashMap::new(),
+                    x: 0,
+                    z: 0,
+                },
+                ProcessedNode {
+                    id: 2,
+                    tags: HashMap::new(),
+                    x: 10,
+                    z: 20,
+                },
+            ],
+        });
+        let labels = collect_nametag_labels(&[way]);
+        assert_eq!(labels.len(), 1);
+        assert_eq!((labels[0].x, labels[0].z), (5, 10));
+    }
+
+    #[test]
+    fn place_nametags_does_not_panic_on_name_and_category_labels() {
+        let xzbbox = XZBBox::rect_from_min_max(-50, -50, 50, 50).unwrap();
+        let llbbox = LLBBox::new(54.6, 9.9, 54.61, 9.91).unwrap();
+        let mut editor = WorldEditor::new(std::env::temp_dir(), &xzbbox, llbbox);
+
+        let labels = vec![
+            NametagLabel {
+                name: Some("Central Station".to_string()),
+                category: Some("Station".to_string()),
+                x: 20,
+                z: 20,
+            },
+            NametagLabel {
+                name: None,
+                category: Some("Restaurant".to_string()),
+                x: -30,
+                z: 15,
+            },
+        ];
+        place_nametags(&mut editor, &labels);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new `--nametags` flag (Java only, off by default) that floats a `minecraft:text_display` label above every OSM element with a name (or a synthesized `<housenumber> <street>` address) and/or a recognized OSM category tag (amenity, shop, leisure, tourism, railway, highway, building, office, craft, landuse, natural, man_made).
- Purely additive and self-contained in a new `src/nametags.rs` module — no changes to existing block/entity APIs, no interaction with any other feature.
- Capped at 3000 labeled elements per world; named elements are prioritized over category-only ones when the cap applies.

## Test plan
- [x] `cargo test --release --no-default-features nametags` — 6 new unit tests pass (label collection, address fallback, boolean-tag skipping, way centroid, entity placement)
- [x] `cargo build --release --no-default-features` — clean build, no new warnings
- [x] `cargo fmt --check` / `cargo clippy` — clean
- [x] Verified in a real generated world (1-mile-radius area around a Philadelphia address) that nametags render correctly alongside other features

🤖 Generated with [Claude Code](https://claude.com/claude-code)