### PR TITLE
fix(barriers): use IRON_BARS for metal fences instead of STONE_BRICK_WALL

### DIFF
--- a/src/element_processing/barriers.rs
+++ b/src/element_processing/barriers.rs
@@ -39,7 +39,7 @@ pub fn generate_barriers(
                     "chain_link" | "metal" | "wire" | "barbed_wire" | "corrugated_metal"
                     | "electric" | "metal_bars",
                 ) => {
-                    barrier_material = STONE_BRICK_WALL; // IRON_BARS
+                    barrier_material = IRON_BARS;
                     barrier_height = 2;
                 }
                 Some("slatted" | "paling") => {


### PR DESCRIPTION
## What

The metal-fence family (`chain_link`, `metal`, `wire`, `barbed_wire`, `corrugated_metal`, `electric`, `metal_bars`) currently renders as `STONE_BRICK_WALL`, with a leftover `// IRON_BARS` comment marking the original intent (flagged by @matkoniecz on #1259).

This switches that branch to `IRON_BARS` (block id 36) and removes the stale comment.

## Why

`IRON_BARS` is the semantically correct block for metal fences and is already used across the codebase (`power.rs`, `amenities.rs`, `bridge_styles.rs`, …). Metal fences rendering as stone brick walls is a bug — iron bars are the right visual and semantic match.

## Scope

Single-line material change + comment removal. No other behavior change.

Follow-up to #1259 (`material=wood` → `OAK_FENCE`).