### PR TITLE
Speed up large-area generation

### DIFF
--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -485,7 +485,7 @@ fn process_element(
 /// Whether to stream regions to disk (lower peak RAM) for `num_regions` regions. Auto-enabled
 /// when the estimated resident world would crowd available RAM; trades some time for RAM, output
 /// unchanged (3D models + subways preserved). `ARNIS_STREAM_TO_DISK=1/0` overrides; constants tunable.
-fn should_stream_to_disk(num_regions: usize) -> bool {
+fn should_stream_to_disk(num_regions: usize, available_mb: u64) -> bool {
     match std::env::var("ARNIS_STREAM_TO_DISK").ok().as_deref() {
         Some("1") => return true,
         Some("0") => return false,
@@ -496,11 +496,15 @@ fn should_stream_to_disk(num_regions: usize) -> bool {
     const PER_REGION_MB: u64 = 26;
     let est_peak_mb = BASE_MB + PER_REGION_MB * num_regions as u64;
 
-    let mut sys = sysinfo::System::new();
-    sys.refresh_memory();
-    let available_mb = sys.available_memory() / (1024 * 1024);
     // Stream once the estimate would use >55% of available RAM (unknown memory -> fast path).
     available_mb > 0 && est_peak_mb * 100 > available_mb * 55
+}
+
+/// Free RAM in MB.
+fn available_memory_mb() -> u64 {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    sys.available_memory() / (1024 * 1024)
 }
 
 /// Generate world with explicit format options (used by GUI for Bedrock support)
@@ -600,14 +604,17 @@ pub fn generate_world_with_options(
     }
 
     let ground = Arc::new(ground);
+    let mut bench = crate::bench::Bench::new(args.benchmark);
+    crate::world_editor::reset_section_counters(args.benchmark);
     // Materialize the lazy water-blend mask now, before world memory peaks.
     ground.warm_water_blend();
+    bench.mark("ground_warm");
     // Load the schematic tree pack once (None keeps procedural trees); shared with tile editors.
     // Uses the ground's real base, not args: the montane check measures blocks above it, and
     // the base sinks when the relief needs the extended floor.
     let tree_pack =
         crate::trees::tree_pack::load(args, llbbox, args.scale, ground.base_level()).map(Arc::new);
-    let mut bench = crate::bench::Bench::new(args.benchmark);
+    bench.reset();
 
     // Per-cell water depth field from the LC_WATER mask; empty without land cover.
     let big_water_field = crate::water_depth::compute_big_water_field(&ground, &xzbbox);
@@ -773,8 +780,11 @@ pub fn generate_world_with_options(
         // Stream-to-disk: flush+evict each region once its owner + 8 neighbour tiles merge,
         // auto-enabled when the resident world would crowd available RAM. Java only; 3D models
         // are kept via region deferral.
-        eviction_active =
-            matches!(world_format, WorldFormat::JavaAnvil) && should_stream_to_disk(tiles.len());
+        // Read at the decision point: the precompute above allocates heavily, and an
+        // optimistic figure would skip streaming in exactly the runs that need it.
+        let available_mb = available_memory_mb();
+        eviction_active = matches!(world_format, WorldFormat::JavaAnvil)
+            && should_stream_to_disk(tiles.len(), available_mb);
 
         // Regions any 3D placement may write to: kept resident (not evicted in-loop)
         // so the post-merge placement pass lands in RAM, then flushed at finalize.
@@ -790,7 +800,17 @@ pub fn generate_world_with_options(
         };
 
         if eviction_active {
-            flush_worker = Some(FlushWorker::spawn(editor.region_write_ctx(), 3));
+            let (flush_threads, flush_queue) =
+                crate::world_editor::flush_pool_params(tile_batch_size, available_mb);
+            if args.benchmark {
+                eprintln!("[BENCHMARK] flush_threads={flush_threads} flush_queue={flush_queue}");
+            }
+            flush_worker = Some(FlushWorker::spawn(
+                editor.region_write_ctx(),
+                flush_queue,
+                flush_threads,
+                args.benchmark,
+            ));
         }
 
         let mut indexed_tiles: Vec<(usize, &tile::TileBounds)> = tiles.iter().enumerate().collect();
@@ -1289,6 +1309,7 @@ pub fn generate_world_with_options(
     if eviction_active {
         // Flush deferred (rail-tunnel-touched) regions now the global carve has run on them.
         // The spawn region stays resident so the map-item still lands on real ground.
+        let drain_start = args.benchmark.then(std::time::Instant::now);
         let mut leftover: Vec<(i32, i32)> = real_regions
             .difference(&evicted_regions)
             .copied()
@@ -1310,9 +1331,16 @@ pub fn generate_world_with_options(
                 hash_acc = hash_acc.wrapping_add(editor.region_content_hash(rx, rz));
             }
         }
+        if let Some(t) = drain_start {
+            bench.report("leftover_drain", t.elapsed());
+        }
         // Wait for all background writes to land (and surface any I/O error) before save.
+        let join_start = args.benchmark.then(std::time::Instant::now);
         if let Some(w) = flush_worker.take() {
             w.finish()?;
+        }
+        if let Some(t) = join_start {
+            bench.report("flush_join", t.elapsed());
         }
     }
 
@@ -1343,6 +1371,11 @@ pub fn generate_world_with_options(
         return Err(e.to_string());
     }
     bench.mark("save");
+
+    if args.benchmark {
+        let (built, slow) = crate::world_editor::section_counters();
+        eprintln!("[BENCHMARK] sections_built={built} sections_slow_path={slow}");
+    }
 
     // Map item, signage tiles and world settings are often longer than the region
     // write, so they get their own band instead of a frozen bar at the end of save.

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -1442,6 +1442,115 @@ fn gaussian_blur_grid_reported(
     out
 }
 
+/// Blur a binary `grid == target` mask straight to f32. Same kernel and f64
+/// arithmetic as `gaussian_blur_grid` on the equivalent mask, so it is bit-identical;
+/// it just skips the full-grid f64 copies that were the process memory peak.
+/// `width`/`height` clamp per row exactly as the caller's `.take()` did, which the
+/// edge renormalisation depends on.
+pub(crate) fn gaussian_blur_mask_to_f32(
+    grid: &[Vec<u8>],
+    target: u8,
+    width: usize,
+    height: usize,
+    sigma: f64,
+) -> Vec<Vec<f32>> {
+    let kernel_size: usize = (sigma * 3.0).ceil() as usize * 2 + 1;
+    let kernel = create_gaussian_kernel(kernel_size, sigma);
+    let half = kernel_size as i32 / 2;
+
+    let h = grid.len().min(height);
+    if h == 0 {
+        return Vec::new();
+    }
+    let w = grid[0].len().min(width);
+    if w == 0 {
+        return vec![Vec::new(); h];
+    }
+
+    const CHUNKS: usize = 10;
+
+    // Horizontal pass: rows are independent, mask read on the fly.
+    let row_chunk = h.div_ceil(CHUNKS);
+    let mut after_h: Vec<Vec<f64>> = Vec::with_capacity(h);
+    for rows in grid[..h].chunks(row_chunk) {
+        let mut part: Vec<Vec<f64>> = rows
+            .par_iter()
+            .map(|row| {
+                let len = row.len().min(width);
+                let row_len = len as i32;
+                (0..len)
+                    .map(|i| {
+                        let mut sum = 0.0;
+                        let mut wsum = 0.0;
+                        for (j, &k) in kernel.iter().enumerate() {
+                            let idx = i as i32 + j as i32 - half;
+                            if idx >= 0 && idx < row_len {
+                                let v = if row[idx as usize] == target {
+                                    1.0
+                                } else {
+                                    0.0
+                                };
+                                sum += v * k;
+                                wsum += k;
+                            }
+                        }
+                        if wsum > 0.0 {
+                            sum / wsum
+                        } else {
+                            f64::NAN
+                        }
+                    })
+                    .collect()
+            })
+            .collect();
+        after_h.append(&mut part);
+    }
+
+    // Vertical pass: f64 throughout, cast only on store.
+    let col_chunk = w.div_ceil(CHUNKS);
+    let mut out: Vec<Vec<f32>> = vec![vec![0.0; w]; h];
+    let mut x0 = 0usize;
+    while x0 < w {
+        let x1 = (x0 + col_chunk).min(w);
+        let blurred: Vec<(usize, Vec<f32>)> = (x0..x1)
+            .into_par_iter()
+            .map(|x| {
+                let column: Vec<f64> = after_h.iter().map(|row| row[x]).collect();
+                let col_len = column.len() as i32;
+                let col: Vec<f32> = (0..column.len())
+                    .map(|y| {
+                        let mut sum = 0.0;
+                        let mut wsum = 0.0;
+                        for (j, &k) in kernel.iter().enumerate() {
+                            let idx = y as i32 + j as i32 - half;
+                            if idx >= 0 && idx < col_len {
+                                let v = column[idx as usize];
+                                if v.is_finite() {
+                                    sum += v * k;
+                                    wsum += k;
+                                }
+                            }
+                        }
+                        if wsum > 0.0 {
+                            (sum / wsum) as f32
+                        } else {
+                            f64::NAN as f32
+                        }
+                    })
+                    .collect();
+                (x, col)
+            })
+            .collect();
+        for (x, col) in blurred {
+            for (y, v) in col.into_iter().enumerate() {
+                out[y][x] = v;
+            }
+        }
+        x0 = x1;
+    }
+    out
+}
+
 fn create_gaussian_kernel(size: usize, sigma: f64) -> Vec<f64> {
     let mut kernel = vec![0.0; size];
     // Centre tap, so the kernel is symmetric and the blur does not shift by half a cell.
@@ -1722,6 +1831,72 @@ pub fn scale_to_minecraft(
         0.0
     };
     (mc_heights, min_height, blocks_per_meter, ground_level)
+}
+
+#[cfg(test)]
+mod mask_blur_tests {
+    use super::*;
+
+    fn reference(
+        grid: &[Vec<u8>],
+        target: u8,
+        width: usize,
+        height: usize,
+        sigma: f64,
+    ) -> Vec<Vec<f32>> {
+        let binary: Vec<Vec<f64>> = grid
+            .iter()
+            .take(height)
+            .map(|row| {
+                row.iter()
+                    .take(width)
+                    .map(|&c| if c == target { 1.0 } else { 0.0 })
+                    .collect()
+            })
+            .collect();
+        gaussian_blur_grid(&binary, sigma)
+            .into_iter()
+            .map(|row| row.into_iter().map(|v| v as f32).collect())
+            .collect()
+    }
+
+    fn check(grid: &[Vec<u8>], width: usize, height: usize, sigma: f64) {
+        let got = gaussian_blur_mask_to_f32(grid, 1, width, height, sigma);
+        let want = reference(grid, 1, width, height, sigma);
+        assert_eq!(got.len(), want.len());
+        for (y, (a, b)) in got.iter().zip(want.iter()).enumerate() {
+            assert_eq!(a.len(), b.len(), "row {y} length");
+            for (x, (p, q)) in a.iter().zip(b.iter()).enumerate() {
+                assert_eq!(p.to_bits(), q.to_bits(), "cell ({x},{y})");
+            }
+        }
+    }
+
+    fn grid(w: usize, h: usize, seed: u64) -> Vec<Vec<u8>> {
+        let mut s = seed;
+        (0..h)
+            .map(|_| {
+                (0..w)
+                    .map(|_| {
+                        s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+                        ((s >> 60) % 2) as u8
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn mask_blur_is_bit_identical_to_building_the_f64_mask() {
+        check(&grid(37, 29, 1), 37, 29, 3.0);
+        check(&grid(64, 8, 7), 64, 8, 1.5);
+    }
+
+    #[test]
+    fn mask_blur_clamps_oversized_grids_like_the_take_did() {
+        // Both dimensions larger than the requested extent.
+        check(&grid(50, 40, 3), 37, 29, 3.0);
+    }
 }
 
 #[cfg(test)]

--- a/src/land_cover/mod.rs
+++ b/src/land_cover/mod.rs
@@ -134,23 +134,12 @@ fn compute_water_blend_smooth(
     if width == 0 || height == 0 {
         return Vec::new();
     }
-    let binary: Vec<Vec<f64>> = grid
-        .iter()
-        .take(height)
-        .map(|row| {
-            row.iter()
-                .take(width)
-                .map(|&c| if c == LC_WATER { 1.0 } else { 0.0 })
-                .collect()
-        })
-        .collect();
     // Gaussian blur runs in f64 for numerical stability, then we drop down to
     // f32 for storage — values land in [0, 1] and are only ever compared to a
-    // 0.5 threshold, so precision beyond f32 is wasted.
-    crate::elevation::postprocess::gaussian_blur_grid(&binary, sigma)
-        .into_iter()
-        .map(|row| row.into_iter().map(|v| v as f32).collect())
-        .collect()
+    // 0.5 threshold, so precision beyond f32 is wasted. The mask is read on the
+    // fly rather than materialized: on a city-sized grid the f64 copies were the
+    // process memory peak.
+    crate::elevation::postprocess::gaussian_blur_mask_to_f32(grid, LC_WATER, width, height, sigma)
 }
 
 /// Metadata parsed from a COG (Cloud-Optimized GeoTIFF) IFD.

--- a/src/map_item.rs
+++ b/src/map_item.rs
@@ -58,15 +58,19 @@ fn read_gzip_nbt(path: &Path) -> Result<Value, String> {
     fastnbt::from_bytes(&decompressed).map_err(|e| format!("parse {path:?}: {e}"))
 }
 
-fn write_gzip_nbt(path: &Path, value: &Value) -> Result<(), String> {
+fn gzip_nbt_bytes(path: &Path, value: &Value) -> Result<Vec<u8>, String> {
     let serialized = fastnbt::to_bytes(value).map_err(|e| format!("serialize {path:?}: {e}"))?;
     let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
     encoder
         .write_all(&serialized)
         .map_err(|e| format!("compress {path:?}: {e}"))?;
-    let compressed = encoder
+    encoder
         .finish()
-        .map_err(|e| format!("finish {path:?}: {e}"))?;
+        .map_err(|e| format!("finish {path:?}: {e}"))
+}
+
+fn write_gzip_nbt(path: &Path, value: &Value) -> Result<(), String> {
+    let compressed = gzip_nbt_bytes(path, value)?;
     std::fs::write(path, compressed).map_err(|e| format!("write {path:?}: {e}"))
 }
 
@@ -259,8 +263,12 @@ fn insert_into_inventory(world_path: &Path, map_id: i32) -> Result<(), String> {
 
 // Write the map .dat under both the pre- and post-26.1 filenames.
 fn write_map_dat_files(data_dir: &Path, map_id: i32, map_dat: &Value) -> Result<(), String> {
-    write_gzip_nbt(&data_dir.join(format!("map_{map_id}.dat")), map_dat)?;
-    write_gzip_nbt(&data_dir.join(format!("{map_id}.dat")), map_dat)
+    // Both filenames get identical bytes, so encode once.
+    let prefixed = data_dir.join(format!("map_{map_id}.dat"));
+    let compressed = gzip_nbt_bytes(&prefixed, map_dat)?;
+    std::fs::write(&prefixed, &compressed).map_err(|e| format!("write {prefixed:?}: {e}"))?;
+    let bare = data_dir.join(format!("{map_id}.dat"));
+    std::fs::write(&bare, &compressed).map_err(|e| format!("write {bare:?}: {e}"))
 }
 
 // Quantize a bundled PNG to a locked 128x128 map; alpha below 128 stays transparent.

--- a/src/world_editor/common.rs
+++ b/src/world_editor/common.rs
@@ -173,6 +173,30 @@ pub(crate) struct PaletteItem {
     pub properties: Option<Value>,
 }
 
+/// Section build counts for `--benchmark`. Gated, because `to_section` runs millions
+/// of times across every save thread and an unconditional `fetch_add` would contend.
+static BUILT_SECTIONS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static SLOW_PATH_SECTIONS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static SECTION_COUNTERS_ON: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Enable and zero the counters, so a second run in one process starts clean.
+pub(crate) fn reset_section_counters(on: bool) {
+    use std::sync::atomic::Ordering::Relaxed;
+    BUILT_SECTIONS.store(0, Relaxed);
+    SLOW_PATH_SECTIONS.store(0, Relaxed);
+    SECTION_COUNTERS_ON.store(on, Relaxed);
+}
+
+/// Sections built and sections that took the property slow path.
+pub(crate) fn section_counters() -> (u64, u64) {
+    use std::sync::atomic::Ordering::Relaxed;
+    (
+        BUILT_SECTIONS.load(Relaxed),
+        SLOW_PATH_SECTIONS.load(Relaxed),
+    )
+}
+
 /// Block storage strategy for a 16×16×16 section.
 ///
 /// **Memory optimisation**: instead of always allocating a 4 096-byte array,
@@ -195,6 +219,7 @@ pub(crate) struct PaletteItem {
 ///
 /// Both are heap-allocated via `Vec`, so the inline size inside the parent
 /// `FnvHashMap` entry is only 24 bytes.
+#[derive(Clone)]
 pub(crate) enum BlockStorage {
     /// Every position is the same block (commonly AIR).
     Uniform(Block),
@@ -392,6 +417,10 @@ impl SectionToModify {
 
     /// Convert to Java Edition section format
     pub fn to_section(&self, y: i8) -> Section {
+        let count = SECTION_COUNTERS_ON.load(std::sync::atomic::Ordering::Relaxed);
+        if count {
+            BUILT_SECTIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
         // Fast path: Uniform section → single palette entry, no data array needed.
         // Only valid when no per-index properties exist, otherwise we must
         // fall through to the general path so every index is checked.
@@ -477,29 +506,67 @@ impl SectionToModify {
             };
         }
 
-        // Slow path: mixed blocks with per-index properties.
-        // Single pass: build palette and per-block index array simultaneously.
+        if count {
+            SLOW_PATH_SECTIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+
+        // Slow path: mixed blocks with per-index properties. Few cells carry any, so
+        // resolve them up front into small ids (0 = none). That keys the per-cell lookup
+        // on (Block, u16) and renders each compound's Debug string once, not 4096 times.
+        let mut cell_props = [0u16; 4096];
+        if !self.properties.is_empty() {
+            // Borrowed for the whole call, so no Arc can be freed and its address reused.
+            let mut props_by_ptr: FnvHashMap<usize, u16> = FnvHashMap::default();
+            let mut props_by_repr: FnvHashMap<String, u16> = FnvHashMap::default();
+            let mut next_id: u16 = 1;
+            for (&i, p) in &self.properties {
+                if i >= 4096 {
+                    continue;
+                }
+                let id = match props_by_ptr.entry(Arc::as_ptr(p) as usize) {
+                    std::collections::hash_map::Entry::Occupied(e) => *e.get(),
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        // Distinct Arcs with equal Debug output must still collapse.
+                        let id = *props_by_repr.entry(format!("{p:?}")).or_insert_with(|| {
+                            let id = next_id;
+                            next_id += 1;
+                            id
+                        });
+                        e.insert(id);
+                        id
+                    }
+                };
+                cell_props[i] = id;
+            }
+        }
+
         let mut unique_blocks: Vec<(Block, Option<Arc<Value>>)> = Vec::new();
-        let mut palette_lookup: FnvHashMap<(Block, Option<String>), usize> = FnvHashMap::default();
-        let mut indices = Vec::with_capacity(4096);
+        let mut plain_palette = [u16::MAX; MAX_BLOCK_ID];
+        let mut props_palette: FnvHashMap<(Block, u16), u16> = FnvHashMap::default();
+        let mut indices = [0u16; 4096];
 
         for (i, block) in self.storage.iter().enumerate() {
-            let properties = self.properties.get(&i);
-
-            // Create a key for the lookup (block + properties debug string)
-            let props_key = properties.map(|p| format!("{p:?}"));
-            let lookup_key = (block, props_key);
-
-            let palette_index = match palette_lookup.entry(lookup_key) {
-                std::collections::hash_map::Entry::Occupied(e) => *e.get(),
-                std::collections::hash_map::Entry::Vacant(e) => {
-                    let idx = unique_blocks.len();
-                    e.insert(idx);
-                    unique_blocks.push((block, properties.cloned()));
-                    idx
+            let props_id = cell_props[i];
+            let id = block.id() as usize;
+            // An id past the array falls through to the map rather than panicking.
+            let palette_index = if props_id == 0 && id < MAX_BLOCK_ID {
+                if plain_palette[id] == u16::MAX {
+                    plain_palette[id] = unique_blocks.len() as u16;
+                    unique_blocks.push((block, None));
+                }
+                plain_palette[id]
+            } else {
+                match props_palette.entry((block, props_id)) {
+                    std::collections::hash_map::Entry::Occupied(e) => *e.get(),
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        let idx = unique_blocks.len() as u16;
+                        e.insert(idx);
+                        unique_blocks.push((block, self.properties.get(&i).cloned()));
+                        idx
+                    }
                 }
             };
-            indices.push(palette_index);
+            indices[i] = palette_index;
         }
 
         let mut bits_per_block = 4; // minimum allowed
@@ -1184,6 +1251,21 @@ impl WorldToModify {
         self_section: &mut SectionToModify,
         other_section: &SectionToModify,
     ) {
+        // Wholesale moves need both sides property-free: a clone would drop the
+        // source's properties, and the per-index loop is what clears stale ones.
+        let no_props = other_section.properties.is_empty() && self_section.properties.is_empty();
+        let dest_all_air = matches!(&self_section.storage, BlockStorage::Uniform(b) if *b == AIR);
+        if no_props && dest_all_air {
+            match &other_section.storage {
+                BlockStorage::Uniform(block) if *block == AIR => {}
+                _ => {
+                    debug_assert!(self_section.properties.is_empty());
+                    self_section.storage = other_section.storage.clone();
+                }
+            }
+            return;
+        }
+
         match &other_section.storage {
             BlockStorage::Uniform(block) if *block == AIR => {}
             BlockStorage::Uniform(block) => {
@@ -1226,6 +1308,28 @@ impl WorldToModify {
         self_section: &mut SectionToModify,
         other_section: &SectionToModify,
     ) {
+        // A uniform non-AIR source overwrites every index, so it needs no empty destination.
+        // A mixed source preserves halo data at its AIR indices, so it does.
+        let no_props = other_section.properties.is_empty() && self_section.properties.is_empty();
+        if no_props {
+            let dest_all_air =
+                matches!(&self_section.storage, BlockStorage::Uniform(b) if *b == AIR);
+            match &other_section.storage {
+                BlockStorage::Uniform(block) if *block == AIR => return,
+                BlockStorage::Uniform(block) => {
+                    debug_assert!(self_section.properties.is_empty());
+                    self_section.storage = BlockStorage::Uniform(*block);
+                    return;
+                }
+                _ if dest_all_air => {
+                    debug_assert!(self_section.properties.is_empty());
+                    self_section.storage = other_section.storage.clone();
+                    return;
+                }
+                _ => {}
+            }
+        }
+
         match &other_section.storage {
             BlockStorage::Uniform(block) if *block == AIR => {
                 // Auth tile is entirely AIR in this section; keep all halo data.
@@ -1335,6 +1439,280 @@ impl WorldToModify {
                     }
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod merge_reference {
+    //! Verbatim pre-fast-path mergers, so the optimized ones can be diffed against them.
+    use super::*;
+
+    pub fn write_if_air(self_section: &mut SectionToModify, other_section: &SectionToModify) {
+        match &other_section.storage {
+            BlockStorage::Uniform(block) if *block == AIR => {}
+            BlockStorage::Uniform(block) => {
+                let block = *block;
+                for idx in 0..4096usize {
+                    if self_section.storage.get(idx) == AIR {
+                        self_section.storage.set(idx, block);
+                        if let Some(props) = other_section.properties.get(&idx) {
+                            self_section.properties.insert(idx, props.clone());
+                        } else {
+                            self_section.properties.remove(&idx);
+                        }
+                    }
+                }
+            }
+            _ => {
+                for (idx, block) in other_section.storage.iter().enumerate() {
+                    if block == AIR {
+                        continue;
+                    }
+                    if self_section.storage.get(idx) == AIR {
+                        self_section.storage.set(idx, block);
+                        if let Some(props) = other_section.properties.get(&idx) {
+                            self_section.properties.insert(idx, props.clone());
+                        } else {
+                            self_section.properties.remove(&idx);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn auth_overwrite_nonair(
+        self_section: &mut SectionToModify,
+        other_section: &SectionToModify,
+    ) {
+        match &other_section.storage {
+            BlockStorage::Uniform(block) if *block == AIR => {}
+            BlockStorage::Uniform(block) => {
+                let block = *block;
+                for idx in 0..4096usize {
+                    self_section.storage.set(idx, block);
+                    if let Some(props) = other_section.properties.get(&idx) {
+                        self_section.properties.insert(idx, props.clone());
+                    } else {
+                        self_section.properties.remove(&idx);
+                    }
+                }
+            }
+            _ => {
+                for (idx, block) in other_section.storage.iter().enumerate() {
+                    if block == AIR {
+                        continue;
+                    }
+                    self_section.storage.set(idx, block);
+                    if let Some(props) = other_section.properties.get(&idx) {
+                        self_section.properties.insert(idx, props.clone());
+                    } else {
+                        self_section.properties.remove(&idx);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod to_section_tests {
+    use super::*;
+
+    type ReferencePalette = (Vec<(Block, Option<Arc<Value>>)>, Vec<usize>);
+
+    /// The pre-optimization slow path, kept so the palette can be diffed against it.
+    fn reference_palette(section: &SectionToModify) -> ReferencePalette {
+        let mut unique_blocks: Vec<(Block, Option<Arc<Value>>)> = Vec::new();
+        let mut palette_lookup: FnvHashMap<(Block, Option<String>), usize> = FnvHashMap::default();
+        let mut indices = Vec::with_capacity(4096);
+        for (i, block) in section.storage.iter().enumerate() {
+            let properties = section.properties.get(&i);
+            let props_key = properties.map(|p| format!("{p:?}"));
+            let palette_index = match palette_lookup.entry((block, props_key)) {
+                std::collections::hash_map::Entry::Occupied(e) => *e.get(),
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    let idx = unique_blocks.len();
+                    e.insert(idx);
+                    unique_blocks.push((block, properties.cloned()));
+                    idx
+                }
+            };
+            indices.push(palette_index);
+        }
+        (unique_blocks, indices)
+    }
+
+    /// Mixes shared Arcs, distinct-but-equal Arcs, and property-free cells.
+    fn section_with_props(seed: u64) -> SectionToModify {
+        let mut s = SectionToModify::default();
+        let mut rng = seed;
+        let mut next = || {
+            rng = rng.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (rng >> 33) as usize
+        };
+        for _ in 0..400 {
+            s.storage.set(next() % 4096, STONE);
+        }
+        for _ in 0..60 {
+            s.storage.set(next() % 4096, SMOOTH_STONE);
+        }
+        // One Arc reused across cells, plus separate Arcs with identical contents.
+        let shared = Arc::new(Value::String("half=top".to_string()));
+        for _ in 0..12 {
+            s.properties.insert(next() % 4096, Arc::clone(&shared));
+        }
+        for _ in 0..12 {
+            s.properties.insert(
+                next() % 4096,
+                Arc::new(Value::String("half=top".to_string())),
+            );
+        }
+        for k in 0..8 {
+            s.properties.insert(
+                next() % 4096,
+                Arc::new(Value::String(format!("facing={k}"))),
+            );
+        }
+        s
+    }
+
+    #[test]
+    fn slow_path_palette_matches_the_pre_optimization_reference() {
+        for seed in 0..40u64 {
+            let s = section_with_props(seed);
+            let (want_blocks, want_indices) = reference_palette(&s);
+            let got = s.to_section(0);
+
+            assert_eq!(
+                got.block_states.palette.len(),
+                want_blocks.len(),
+                "palette length, seed {seed}"
+            );
+            for (i, (block, stored)) in want_blocks.iter().enumerate() {
+                let item = &got.block_states.palette[i];
+                assert_eq!(
+                    item.name,
+                    format!("{}:{}", block.namespace(), block.name()),
+                    "palette[{i}] name, seed {seed}"
+                );
+                let want_props = stored
+                    .as_ref()
+                    .map(|p| (**p).clone())
+                    .or_else(|| block.properties());
+                assert_eq!(
+                    item.properties, want_props,
+                    "palette[{i}] props, seed {seed}"
+                );
+            }
+
+            // Same logical index per cell, decoded from the packed long array.
+            let mut bits = 4;
+            while (1 << bits) < want_blocks.len() {
+                bits += 1;
+            }
+            let data = got.block_states.data.as_ref().expect("packed data");
+            let longs: &[i64] = data;
+            let per_long = 64 / bits;
+            for (i, want) in want_indices.iter().enumerate() {
+                let long = longs[i / per_long];
+                let shift = (i % per_long) * bits;
+                let got_idx = ((long >> shift) & ((1i64 << bits) - 1)) as usize;
+                assert_eq!(got_idx, *want, "cell {i}, seed {seed}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod merge_fast_path_tests {
+    use super::*;
+
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn next(&mut self) -> u64 {
+            self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+            self.0 >> 33
+        }
+
+        fn below(&mut self, n: u64) -> u64 {
+            self.next() % n
+        }
+    }
+
+    /// Random section: varies storage variant, AIR density and property presence.
+    fn section(rng: &mut Lcg, shape: u64, with_props: bool) -> SectionToModify {
+        let mut s = SectionToModify::default();
+        match shape {
+            0 => {}
+            1 => s.storage = BlockStorage::Uniform(STONE),
+            2 => {
+                // Wide id forces FullWide.
+                s.storage
+                    .set(rng.below(4096) as usize, Block::from_raw_id(BYTE_ID_LIMIT));
+                for _ in 0..64 {
+                    s.storage.set(rng.below(4096) as usize, STONE);
+                }
+            }
+            _ => {
+                for _ in 0..(1 + rng.below(600)) {
+                    s.storage.set(rng.below(4096) as usize, STONE);
+                }
+            }
+        }
+        if with_props {
+            for _ in 0..(1 + rng.below(6)) {
+                let idx = rng.below(4096) as usize;
+                s.properties
+                    .insert(idx, Arc::new(Value::String(format!("p{}", idx % 3))));
+            }
+        }
+        s
+    }
+
+    fn dup(s: &SectionToModify) -> SectionToModify {
+        SectionToModify {
+            storage: s.storage.clone(),
+            properties: s.properties.clone(),
+        }
+    }
+
+    fn same(a: &SectionToModify, b: &SectionToModify) -> bool {
+        if (0..4096).any(|i| a.storage.get(i) != b.storage.get(i)) {
+            return false;
+        }
+        if a.properties.len() != b.properties.len() {
+            return false;
+        }
+        a.properties
+            .iter()
+            .all(|(k, v)| b.properties.get(k).is_some_and(|w| **v == **w))
+    }
+
+    #[test]
+    fn section_mergers_match_the_pre_fast_path_reference() {
+        let mut rng = Lcg(0x5eed);
+        for case in 0..4000u64 {
+            let dst_props = case % 3 == 0;
+            let src_props = case % 5 == 0;
+            let (dst_shape, src_shape) = (rng.below(4), rng.below(4));
+            let dst = section(&mut rng, dst_shape, dst_props);
+            let src = section(&mut rng, src_shape, src_props);
+
+            let (mut a, mut b) = (dup(&dst), dup(&dst));
+            WorldToModify::merge_section_write_if_air(&mut a, &src);
+            merge_reference::write_if_air(&mut b, &src);
+            assert!(same(&a, &b), "write_if_air diverged on case {case}");
+
+            let (mut a, mut b) = (dup(&dst), dup(&dst));
+            WorldToModify::merge_section_auth_overwrite_nonair(&mut a, &src);
+            merge_reference::auth_overwrite_nonair(&mut b, &src);
+            assert!(
+                same(&a, &b),
+                "auth_overwrite_nonair diverged on case {case}"
+            );
         }
     }
 }

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -22,7 +22,10 @@ pub use common::{
     base_chunk_y, min_y, set_base_chunk_y, set_terrain_floor_y, set_world_bounds, terrain_floor_y,
     world_section_range, DEFAULT_MAX_Y, DEFAULT_MIN_Y,
 };
-pub(crate) use common::{BlockStorage, RegionToModify, SectionToModify, MAX_BLOCK_ID};
+pub(crate) use common::{
+    reset_section_counters, section_counters, BlockStorage, RegionToModify, SectionToModify,
+    MAX_BLOCK_ID,
+};
 
 pub(crate) use bedrock::{BedrockSaveError, BedrockWriter};
 
@@ -2160,46 +2163,163 @@ const _: () = {
     }
 };
 
-/// Background writer for stream-to-disk eviction. Regions taken off the merge
-/// thread are compacted + serialized + written on a separate thread, overlapping
-/// disk I/O with the next tile batch's compute. A bounded channel applies
-/// backpressure so at most `capacity` evicted regions sit in RAM awaiting write.
+/// Thread count and queue depth for the flush pool. `threads` is throughput,
+/// `capacity` is RAM. One region is evicted per merged tile, so a batch produces a
+/// burst of that size; `capacity + threads >= tile_batch` stops the producer stalling.
+pub(crate) fn flush_pool_params(tile_batch: usize, available_mb: u64) -> (usize, usize) {
+    let cores = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4);
+    // `capacity + threads + 1` regions are alive at once, so budget the total rather
+    // than each knob. 26 MB/region matches should_stream_to_disk; measured is ~7.
+    const PER_REGION_MB: u64 = 26;
+    let budget = if available_mb > 0 {
+        // A tenth of free RAM, floored so the pool always beats the old single writer.
+        ((available_mb / 10 / PER_REGION_MB) as usize).clamp(5, 15)
+    } else {
+        15
+    };
+
+    let mut threads = cores.div_ceil(4).clamp(2, 6);
+    threads = threads.min(budget.saturating_sub(2).max(1));
+    if let Some(n) = std::env::var("ARNIS_FLUSH_THREADS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+    {
+        threads = n.clamp(1, 32);
+    }
+
+    // Evictions arrive one per merged tile, so a batch lands as a burst of that size.
+    let mut capacity = tile_batch.saturating_sub(threads).clamp(3, 8);
+    capacity = capacity.min(budget.saturating_sub(threads + 1).max(1));
+    if let Some(q) = std::env::var("ARNIS_FLUSH_QUEUE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+    {
+        capacity = q.clamp(1, 64);
+    }
+    (threads, capacity)
+}
+
+/// Resident block-storage bytes of a region, as queued (before `compact()`).
+fn region_storage_bytes(region: &common::RegionToModify) -> u64 {
+    let mut bytes = 0u64;
+    for chunk in region.chunks.values() {
+        for section in chunk.sections.values() {
+            bytes += match &section.storage {
+                BlockStorage::Uniform(_) => 0,
+                BlockStorage::Full(_) => 4096,
+                BlockStorage::FullWide(_) => 8192,
+            };
+        }
+    }
+    bytes
+}
+
+/// Background writer pool for stream-to-disk eviction. Regions taken off the merge
+/// thread are compacted, serialized and written here, overlapping I/O with the next
+/// batch's compute. At most `capacity + threads + 1` regions are alive at once; the
+/// `+1` is the one the producer holds across `send`.
 pub(crate) struct FlushWorker {
     tx: Option<std::sync::mpsc::SyncSender<(i32, i32, common::RegionToModify)>>,
-    handle: Option<std::thread::JoinHandle<Result<(), String>>>,
+    handles: Vec<std::thread::JoinHandle<Result<(), String>>>,
     // Real write error from the worker, so a failed handoff surfaces the cause
     // (disk full, permissions, ...) instead of a generic "terminated early".
     error: Arc<Mutex<Option<String>>>,
+    // With a shared receiver the channel only closes when the LAST worker exits,
+    // so a dead worker has to be advertised explicitly or errors go unnoticed.
+    failed: Arc<std::sync::atomic::AtomicBool>,
+    stall_ns: std::sync::atomic::AtomicU64,
+    write_ns: Arc<std::sync::atomic::AtomicU64>,
+    regions: Arc<std::sync::atomic::AtomicUsize>,
+    bytes: std::sync::atomic::AtomicU64,
+    bench: bool,
 }
 
 impl FlushWorker {
-    pub(crate) fn spawn(ctx: java::RegionWriteCtx, capacity: usize) -> Self {
+    pub(crate) fn spawn(
+        ctx: java::RegionWriteCtx,
+        capacity: usize,
+        threads: usize,
+        bench: bool,
+    ) -> Self {
+        use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
+        let threads = threads.max(1);
         let (tx, rx) =
             std::sync::mpsc::sync_channel::<(i32, i32, common::RegionToModify)>(capacity.max(1));
+        let rx = Arc::new(Mutex::new(rx));
+        let ctx = Arc::new(ctx);
         let error = Arc::new(Mutex::new(None));
-        let error_w = Arc::clone(&error);
-        let handle = std::thread::spawn(move || -> Result<(), String> {
-            while let Ok((rxx, rzz, mut region)) = rx.recv() {
-                for chunk in region.chunks.values_mut() {
-                    for section in chunk.sections.values_mut() {
-                        section.compact();
+        let failed = Arc::new(AtomicBool::new(false));
+        let write_ns = Arc::new(AtomicU64::new(0));
+        let regions = Arc::new(AtomicUsize::new(0));
+
+        let handles = (0..threads)
+            .map(|_| {
+                let rx = Arc::clone(&rx);
+                let ctx = Arc::clone(&ctx);
+                let error_w = Arc::clone(&error);
+                let failed_w = Arc::clone(&failed);
+                let write_ns = Arc::clone(&write_ns);
+                let regions = Arc::clone(&regions);
+                std::thread::spawn(move || -> Result<(), String> {
+                    loop {
+                        // Lock spans recv() only, never a write.
+                        let item = {
+                            let guard = rx.lock().unwrap_or_else(|p| p.into_inner());
+                            guard.recv()
+                        };
+                        let Ok((rxx, rzz, mut region)) = item else {
+                            return Ok(());
+                        };
+                        let started = bench.then(std::time::Instant::now);
+                        for chunk in region.chunks.values_mut() {
+                            for section in chunk.sections.values_mut() {
+                                section.compact();
+                            }
+                        }
+                        let result = ctx.write(rxx, rzz, &region);
+                        if let Some(t) = started {
+                            write_ns.fetch_add(
+                                t.elapsed().as_nanos() as u64,
+                                std::sync::atomic::Ordering::Relaxed,
+                            );
+                            regions.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
+                        if let Err(e) = result {
+                            let msg = e.to_string();
+                            if let Ok(mut slot) = error_w.lock() {
+                                if slot.is_none() {
+                                    *slot = Some(msg.clone());
+                                }
+                            }
+                            failed_w.store(true, std::sync::atomic::Ordering::Release);
+                            return Err(msg);
+                        }
                     }
-                }
-                if let Err(e) = ctx.write(rxx, rzz, &region) {
-                    let msg = e.to_string();
-                    if let Ok(mut slot) = error_w.lock() {
-                        *slot = Some(msg.clone());
-                    }
-                    return Err(msg);
-                }
-            }
-            Ok(())
-        });
+                })
+            })
+            .collect();
+
         Self {
             tx: Some(tx),
-            handle: Some(handle),
+            handles,
             error,
+            failed,
+            stall_ns: AtomicU64::new(0),
+            write_ns,
+            regions,
+            bytes: AtomicU64::new(0),
+            bench,
         }
+    }
+
+    fn error_msg(&self) -> String {
+        self.error
+            .lock()
+            .ok()
+            .and_then(|slot| slot.clone())
+            .unwrap_or_else(|| "flush worker terminated early".to_string())
     }
 
     /// Enqueue a region; blocks when the channel is full (backpressure). On
@@ -2211,29 +2331,77 @@ impl FlushWorker {
         rz: i32,
         region: common::RegionToModify,
     ) -> Result<(), (common::RegionToModify, String)> {
+        use std::sync::atomic::Ordering;
         let Some(tx) = self.tx.as_ref() else {
             return Err((region, "flush worker already finished".to_string()));
         };
-        match tx.send((rx, rz, region)) {
+        if self.failed.load(Ordering::Acquire) {
+            return Err((region, self.error_msg()));
+        }
+        if self.bench {
+            self.bytes
+                .fetch_add(region_storage_bytes(&region), Ordering::Relaxed);
+        }
+        let started = self.bench.then(std::time::Instant::now);
+        let sent = tx.send((rx, rz, region));
+        if let Some(t) = started {
+            self.stall_ns
+                .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
+        }
+        match sent {
             Ok(()) => Ok(()),
-            Err(std::sync::mpsc::SendError((_, _, region))) => {
-                let err = self
-                    .error
-                    .lock()
-                    .ok()
-                    .and_then(|slot| slot.clone())
-                    .unwrap_or_else(|| "flush worker terminated early".to_string());
-                Err((region, err))
-            }
+            Err(std::sync::mpsc::SendError((_, _, region))) => Err((region, self.error_msg())),
         }
     }
 
     /// Close the queue and wait for all pending writes; propagates the first error.
     pub(crate) fn finish(mut self) -> Result<(), String> {
+        use std::sync::atomic::Ordering;
         drop(self.tx.take());
-        match self.handle.take() {
-            Some(h) => h.join().map_err(|_| "flush worker panicked".to_string())?,
+        let mut first: Option<String> = None;
+        for handle in self.handles.drain(..) {
+            match handle.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    first.get_or_insert(e);
+                }
+                Err(_) => {
+                    first.get_or_insert_with(|| "flush worker panicked".to_string());
+                }
+            }
+        }
+        if self.bench {
+            eprintln!(
+                "[BENCHMARK] flush_stall_ms={}",
+                self.stall_ns.load(Ordering::Relaxed) / 1_000_000
+            );
+            eprintln!(
+                "[BENCHMARK] flush_write_ms={}",
+                self.write_ns.load(Ordering::Relaxed) / 1_000_000
+            );
+            eprintln!(
+                "[BENCHMARK] flush_regions={}",
+                self.regions.load(Ordering::Relaxed)
+            );
+            eprintln!(
+                "[BENCHMARK] flush_bytes_mb={}",
+                self.bytes.load(Ordering::Relaxed) / (1024 * 1024)
+            );
+        }
+        match first {
+            Some(e) => Err(e),
             None => Ok(()),
+        }
+    }
+}
+
+impl Drop for FlushWorker {
+    /// The error paths drop the worker instead of calling `finish`, and the GUI
+    /// deletes the world directory right after; detached writers would race it.
+    fn drop(&mut self) {
+        drop(self.tx.take());
+        for handle in self.handles.drain(..) {
+            let _ = handle.join();
         }
     }
 }
@@ -2252,6 +2420,99 @@ mod eviction_guard_tests {
     use super::*;
     use crate::coordinate_system::cartesian::XZBBox;
     use crate::coordinate_system::geographic::LLBBox;
+
+    fn flush_test_ctx(dir: &std::path::Path) -> java::RegionWriteCtx {
+        java::RegionWriteCtx::new(
+            dir.to_path_buf(),
+            LLBBox::new(54.6, 9.9, 54.61, 9.91).unwrap(),
+            None,
+            false,
+            None,
+        )
+    }
+
+    /// One region with a single non-AIR block, so the writer has real work to do.
+    fn flush_test_region() -> common::RegionToModify {
+        let mut region = common::RegionToModify::default();
+        let chunk = region.chunks.entry((0, 0)).or_default();
+        let section = chunk.sections.entry(0).or_default();
+        section.storage.set(0, SMOOTH_STONE);
+        region
+    }
+
+    #[test]
+    fn flush_pool_writes_every_region_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let worker = FlushWorker::spawn(flush_test_ctx(dir.path()), 4, 4, false);
+        for i in 0..32 {
+            assert!(worker.send(i, 0, flush_test_region()).is_ok());
+        }
+        worker.finish().unwrap();
+
+        for i in 0..32 {
+            let path = dir.path().join("region").join(format!("r.{i}.0.mca"));
+            let len = std::fs::metadata(&path)
+                .unwrap_or_else(|e| panic!("{path:?}: {e}"))
+                .len();
+            assert!(len > 0, "{path:?} is empty");
+        }
+    }
+
+    #[test]
+    fn flush_pool_reports_the_real_first_error() {
+        // A file where the region directory should go, so create_dir_all fails.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("region"), b"not a directory").unwrap();
+        let worker = FlushWorker::spawn(flush_test_ctx(dir.path()), 2, 3, false);
+        // Some sends may fail once a worker has died; the surfaced error must be the cause.
+        for i in 0..16 {
+            if let Err((_, msg)) = worker.send(i, 0, flush_test_region()) {
+                assert!(
+                    !msg.contains("terminated early"),
+                    "expected the real I/O cause, got {msg:?}"
+                );
+            }
+        }
+        let err = worker.finish().unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn flush_pool_fails_fast_after_a_worker_error() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("region"), b"not a directory").unwrap();
+        let worker = FlushWorker::spawn(flush_test_ctx(dir.path()), 1, 2, false);
+        // Keep sending until the failure is observed; with a shared receiver this only
+        // works because `failed` is published explicitly.
+        let mut refused = false;
+        for i in 0..64 {
+            if worker.send(i, 0, flush_test_region()).is_err() {
+                refused = true;
+                break;
+            }
+            std::thread::yield_now();
+        }
+        assert!(
+            refused,
+            "send kept accepting regions after every worker died"
+        );
+        let _ = worker.finish();
+    }
+
+    #[test]
+    fn dropping_a_flush_worker_joins_its_threads() {
+        // The error paths drop instead of calling finish, and the GUI deletes the world
+        // directory straight after; a detached writer would race that removal.
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let worker = FlushWorker::spawn(flush_test_ctx(dir.path()), 4, 3, false);
+            for i in 0..12 {
+                assert!(worker.send(i, 0, flush_test_region()).is_ok());
+            }
+        }
+        // Drop returned, so every write has landed and the directory is safe to remove.
+        std::fs::remove_dir_all(dir.path().join("region")).unwrap();
+    }
 
     // Writing an entity or chest to an already-evicted region must NOT resurrect it,
     // or the truncating final save wipes the region's real ground (the empty-spawn-chunk bug).

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -2164,8 +2164,10 @@ const _: () = {
 };
 
 /// Thread count and queue depth for the flush pool. `threads` is throughput,
-/// `capacity` is RAM. One region is evicted per merged tile, so a batch produces a
-/// burst of that size; `capacity + threads >= tile_batch` stops the producer stalling.
+/// `capacity` is RAM. One region is evicted per merged tile, so covering a whole
+/// batch without backpressure would need `capacity + threads >= tile_batch`. That is
+/// the target, not a guarantee: both are clamped and capped by the RAM budget below,
+/// so a wide batch still stalls the producer some. `flush_stall_ms` measures it.
 pub(crate) fn flush_pool_params(tile_batch: usize, available_mb: u64) -> (usize, usize) {
     let cores = std::thread::available_parallelism()
         .map(|n| n.get())
@@ -2338,10 +2340,12 @@ impl FlushWorker {
         if self.failed.load(Ordering::Acquire) {
             return Err((region, self.error_msg()));
         }
-        if self.bench {
-            self.bytes
-                .fetch_add(region_storage_bytes(&region), Ordering::Relaxed);
-        }
+        // Measured before the move, but only counted once the region is actually queued.
+        let bytes = if self.bench {
+            region_storage_bytes(&region)
+        } else {
+            0
+        };
         let started = self.bench.then(std::time::Instant::now);
         let sent = tx.send((rx, rz, region));
         if let Some(t) = started {
@@ -2349,7 +2353,10 @@ impl FlushWorker {
                 .fetch_add(t.elapsed().as_nanos() as u64, Ordering::Relaxed);
         }
         match sent {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                self.bytes.fetch_add(bytes, Ordering::Relaxed);
+                Ok(())
+            }
             Err(std::sync::mpsc::SendError((_, _, region))) => Err((region, self.error_msg())),
         }
     }


### PR DESCRIPTION
Write evicted regions from a thread pool instead of a single thread. The merge thread was blocking on the writer for 28s of a 400-region run.

Also: wholesale fast paths in the two section mergers, resolve per-index properties once in to_section instead of per cell, blur the water mask straight to f32 rather than building f64 copies, and encode each signage .dat once instead of twice.