### PR TITLE
Restore Ground Level setting in the GUI

### DIFF
--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -297,6 +297,17 @@
           <span data-localize="world_scale_objects_skipped">Below 0.30 buildings and roads are too small to render, so only terrain and land cover are generated.</span>
         </div>
 
+        <!-- Ground Level -->
+        <div class="settings-row">
+          <label for="ground-level">
+            <span data-localize="ground_level">Ground Level</span>
+            <span class="tooltip-icon" data-tooltip="Y level the generated terrain is anchored to. Match your world's actual floor if it isn't vanilla's -64 (e.g. a mod, or Extend build height's -2032).">?</span>
+          </label>
+          <div class="settings-control">
+            <input type="number" id="ground-level" name="ground-level" min="-2032" max="2031" value="-62" placeholder="Ground Level">
+          </div>
+        </div>
+
         <!-- Rotation Angle -->
         <div class="settings-row">
           <label for="rotation-angle-input">

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -118,8 +118,7 @@ async function applyLocalization(localization) {
     "span[data-localize='world_scale']": "world_scale",
     "span[data-localize='world_scale_objects_skipped']": "world_scale_objects_skipped",
     "span[data-localize='custom_bounding_box']": "custom_bounding_box",
-    // DEPRECATED: Ground level localization removed
-    // "label[data-localize='ground_level']": "ground_level",
+    "span[data-localize='ground_level']": "ground_level",
     "span[data-localize='language']": "language",
     "span[data-localize='generation_mode']": "generation_mode",
     "option[data-localize='mode_geo_terrain']": "mode_geo_terrain",
@@ -175,8 +174,7 @@ async function applyLocalization(localization) {
 
     // Placeholder strings
     "input[id='bbox-coords']": "placeholder_bbox",
-    // DEPRECATED: Ground level placeholder removed
-    // "input[id='ground-level']": "placeholder_ground"
+    "input[id='ground-level']": "placeholder_ground"
   };
 
   for (const selector in localizationElements) {
@@ -1764,12 +1762,10 @@ async function startGeneration() {
     var aws_only_elevation = document.getElementById("aws-only-elevation-toggle").checked;
     var bake_lighting = document.getElementById("bake-lighting-toggle").checked;
     var scale = parseFloat(document.getElementById("scale-value-slider").value);
-    // var ground_level = parseInt(document.getElementById("ground-level").value, 10);
-    // DEPRECATED: Ground level input removed from UI
-    var ground_level = -62;
+    var ground_level = parseInt(document.getElementById("ground-level").value, 10);
 
     // Validate ground_level
-    ground_level = isNaN(ground_level) || ground_level < -62 ? -62 : ground_level;
+    ground_level = isNaN(ground_level) ? -62 : ground_level;
 
     // Get telemetry consent (defaults to false if not set)
     const telemetryConsent = window.getTelemetryConsent ? window.getTelemetryConsent() : false;

--- a/src/gui/js/settings-store.js
+++ b/src/gui/js/settings-store.js
@@ -38,6 +38,7 @@ const SETTINGS = [
   { id: 'aws-only-elevation-toggle', kind: 'checkbox', store: OWN },
   { id: 'bake-lighting-toggle', kind: 'checkbox', store: OWN },
   { id: 'scale-value-slider', kind: 'number', store: OWN },
+  { id: 'ground-level', kind: 'number', store: OWN },
 
   // Not persisted: picking a bbox force-resets the angle to 0 anyway.
   { id: 'rotation-angle-input', kind: 'number', store: NONE },


### PR DESCRIPTION
### Problem

`ground_level` (the Y level generation is anchored to) is a real, fully-wired CLI setting (`--ground-level`, default `-62`) that flows through the entire backend, but the GUI hardcoded it:

```js
var ground_level = -62;
```

The Settings panel input, its label/placeholder localization, and its `settings-store.js` persistence entry were all removed in a prior commit ("Deprecate ground level input"). This mattered beyond cosmetics: the project already supports worlds whose floor isn't vanilla's `-64` (the bundled datapack extends the range to `-2032..2031` via "Extend build height", and mods can shift a world's floor too), and GUI users had no way to match that — only `--ground-level` on the CLI could.

### Fix

Reverts that removal, adapted to the current code:

* `src/gui/index.html`: re-adds the Ground Level row (between World Scale and Rotation Angle), using the current `<span data-localize>` label convention. Widens `min`/`max` from the old `-64..290` to `-2032..2031` to actually cover the extended-height range — the old bounds predate that feature and would have defeated the point of restoring this control.
* `src/gui/js/main.js`: reads the live input value instead of the hardcoded `-62`; fixes the localization selector map (the old entry used a stale `label[data-localize=...]` selector that doesn't match current markup); drops a clamp that silently forced any value below `-62` back to `-62`, which would have defeated the whole point of exposing this control.
* `src/gui/js/settings-store.js`: registers `ground-level` (`kind: 'number', store: OWN`) in the `SETTINGS` array, so it persists/reverts/resets exactly like `world_scale` — no other change needed, default/validation/revert/reset all fall out of the existing generic machinery reading the HTML attributes.

No Rust changes — the backend already accepted and forwarded this value; only the GUI was disconnected from it.

Fixes #1305

### Testing

- Manually tested in the running GUI: the Ground Level row appears in Settings between World Scale and Rotation Angle, accepts input, and the value is correctly picked up by generation.
- No Rust files changed, so the CLI/build is unaffected.