### PR TITLE
Add Linux one-time zink fallback for EGL startup failures

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -101,7 +101,7 @@ impl Drop for NewWorldCleanup {
     }
 }
 
-pub fn run_gui() {
+pub fn run_gui() -> Result<(), String> {
     // Configure thread pool with 90% CPU cap to keep system responsive
     crate::floodfill_cache::configure_rayon_thread_pool(0.9);
 
@@ -176,7 +176,7 @@ pub fn run_gui() {
             Ok(())
         })
         .run(tauri::generate_context!())
-        .expect("Error while starting the application UI (Tauri)");
+        .map_err(|e| format!("Error while starting the application UI (Tauri): {e}"))
 }
 
 /// Detects the default Minecraft Java Edition saves directory for the current OS.

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -171,7 +171,7 @@ pub fn run_gui() -> Result<(), String> {
         .setup(|app| {
             let app_handle = app.handle();
             let main_window = tauri::Manager::get_webview_window(app_handle, "main")
-                .expect("Failed to get main window");
+                .ok_or_else(|| std::io::Error::other("Failed to get main window"))?;
             progress::set_main_window(main_window);
             Ok(())
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,8 @@ fn retry_gui_with_zink() -> Result<(), String> {
     let status = Command::new(executable)
         .env(EGL_ZINK_RETRY_MARKER, "1")
         .env("MESA_LOADER_DRIVER_OVERRIDE", "zink")
+        .env("LIBGL_ALWAYS_SOFTWARE", "0")
+        .env("GALLIUM_DRIVER", "zink")
         .status()
         .map_err(|e| format!("Failed to relaunch with zink EGL workaround: {e}"))?;
 
@@ -667,6 +669,8 @@ fn main() {
                 eprintln!("{} {}", "Error:".red().bold(), e);
                 std::process::exit(1);
             }
+
+            return;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,8 @@ use args::Args;
 use clap::Parser;
 use colored::*;
 use std::path::PathBuf;
+#[cfg(all(feature = "gui", target_os = "linux"))]
+use std::process::Command;
 use std::{env, fs, io::Write};
 
 // mimalloc scales far better than the system allocator under the concurrent
@@ -82,6 +84,41 @@ mod progress {
 }
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Console::{AttachConsole, ATTACH_PARENT_PROCESS};
+
+#[cfg(all(feature = "gui", target_os = "linux"))]
+const EGL_ZINK_RETRY_MARKER: &str = "ARNIS_EGL_ZINK_RETRY";
+
+#[cfg(all(feature = "gui", target_os = "linux"))]
+fn has_user_rendering_override() -> bool {
+    [
+        "MESA_LOADER_DRIVER_OVERRIDE",
+        "LIBGL_ALWAYS_SOFTWARE",
+        "GALLIUM_DRIVER",
+    ]
+    .iter()
+    .any(|name| env::var_os(name).is_some())
+}
+
+#[cfg(all(feature = "gui", target_os = "linux"))]
+fn is_egl_startup_failure(error_message: &str) -> bool {
+    let lowered = error_message.to_ascii_lowercase();
+    lowered.contains("egl_not_initialized")
+        || lowered.contains("surfaceless egl")
+        || (lowered.contains("libegl") && lowered.contains("failed"))
+}
+
+#[cfg(all(feature = "gui", target_os = "linux"))]
+fn retry_gui_with_zink() -> Result<(), String> {
+    let executable = env::current_exe()
+        .map_err(|e| format!("Failed to locate current executable for EGL fallback retry: {e}"))?;
+    let status = Command::new(executable)
+        .env(EGL_ZINK_RETRY_MARKER, "1")
+        .env("MESA_LOADER_DRIVER_OVERRIDE", "zink")
+        .status()
+        .map_err(|e| format!("Failed to relaunch with zink EGL workaround: {e}"))?;
+
+    std::process::exit(status.code().unwrap_or(1));
+}
 
 /// Reattach to the console this process was launched from, so terminal output
 /// works in both CLI and GUI runs.
@@ -609,7 +646,27 @@ fn main() {
     {
         let gui_mode = std::env::args().len() == 1; // Just "arnis" with no args
         if gui_mode {
-            gui::run_gui();
+            #[cfg(target_os = "linux")]
+            let user_rendering_override = has_user_rendering_override();
+
+            if let Err(e) = gui::run_gui() {
+                #[cfg(target_os = "linux")]
+                {
+                    let already_retried = env::var_os(EGL_ZINK_RETRY_MARKER).is_some();
+                    if !already_retried && !user_rendering_override && is_egl_startup_failure(&e) {
+                        eprintln!(
+                            "{} Linux EGL initialization failed; retrying once with zink.",
+                            "Warning:".yellow().bold()
+                        );
+                        if let Err(retry_error) = retry_gui_with_zink() {
+                            eprintln!("{} {}", "Error:".red().bold(), retry_error);
+                        }
+                    }
+                }
+
+                eprintln!("{} {}", "Error:".red().bold(), e);
+                std::process::exit(1);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- handle GUI startup failures in Linux without panicking
- detect EGL initialization failures (including surfaceless/EGL_NOT_INITIALIZED cases)
- retry exactly once by relaunching with `MESA_LOADER_DRIVER_OVERRIDE=zink`
- skip fallback when users already provided rendering overrides (`MESA_LOADER_DRIVER_OVERRIDE`, `LIBGL_ALWAYS_SOFTWARE`, `GALLIUM_DRIVER`)
- guard retries with a marker env var to avoid loops

## Why
Multiple Linux reports (Wayland/Hyprland and Fedora variants) fail during WebKitGTK EGL initialization, but succeed when launched with `MESA_LOADER_DRIVER_OVERRIDE=zink`. This makes that workaround automatic only for affected startup failures while preserving existing behavior for everyone else.

## Related issues
- #799
- #833
- #1290
