### PR TITLE
Remove magma blocks from water body floors

### DIFF
--- a/src/water_depth.rs
+++ b/src/water_depth.rs
@@ -2,8 +2,8 @@
 
 use crate::block_definitions::{
     Block, AIR, BLUE_FLOWER, CLAY, COARSE_DIRT, DEAD_BUSH, DIRT, FERN, GRASS, GRAVEL, KELP,
-    KELP_PLANT, LARGE_FERN_LOWER, LARGE_FERN_UPPER, MAGMA_BLOCK, OAK_LEAVES, RED_FLOWER, SAND,
-    SANDSTONE, SEAGRASS, SEA_PICKLE, SOUL_SAND, STONE, TALL_GRASS_BOTTOM, TALL_GRASS_TOP,
+    KELP_PLANT, LARGE_FERN_LOWER, LARGE_FERN_UPPER, OAK_LEAVES, RED_FLOWER, SAND, SANDSTONE,
+    SEAGRASS, SEA_PICKLE, SOUL_SAND, STONE, TALL_GRASS_BOTTOM, TALL_GRASS_TOP,
     TALL_SEAGRASS_BOTTOM, TALL_SEAGRASS_TOP, WATER, WHITE_FLOWER, YELLOW_FLOWER,
 };
 use crate::coordinate_system::cartesian::{XZBBox, XZPoint};
@@ -416,8 +416,6 @@ pub fn carve_water_column(
                 } else {
                     GRAVEL
                 }
-            } else if d >= 5 && vn(401, 503, 8) > 0.96 {
-                MAGMA_BLOCK
             } else if d >= 5 && vn(727, 911, 8) > 0.96 {
                 SOUL_SAND
             } else if vn(73, 109, 64) > 0.74 {


### PR DESCRIPTION
## Summary
Fixes #1212

Magma blocks were occasionally generated on the bottom of rivers/lakes/sea as one of the rare noise-driven bed tiers. This isn't realistic — real water bodies don't have magma on their floor. This PR removes that tier from `water_depth.rs`, leaving the rest of the floor variety (gravel, sand, clay, dirt, coarse dirt, soul sand) untouched.

## Changes
- Removed the `MAGMA_BLOCK` branch from the water bed material selection in `src/water_depth.rs`
- Removed the now-unused `MAGMA_BLOCK` import

## Testing
- `cargo check` — passes
- `cargo clippy` — clean
- `cargo fmt` — applied