### PR TITLE
Fix crash-prone random range and detail-tier overflow

### DIFF
--- a/src/element_processing/buildings.rs
+++ b/src/element_processing/buildings.rs
@@ -2017,7 +2017,7 @@ fn compute_detail_tier(
 ) -> DetailTier {
     let mut score: i32 = 0;
     score += (footprint as i32 / 40).min(25);
-    score += (building_height * 2).min(25);
+    score += building_height.saturating_mul(2).min(25);
     score += match category {
         BuildingCategory::Historic | BuildingCategory::Religious => 20,
         BuildingCategory::Commercial | BuildingCategory::Hotel | BuildingCategory::Office => 10,
@@ -11940,6 +11940,19 @@ mod style_tests {
         assert_eq!(
             compute_detail_tier(&notable, BuildingCategory::Historic, 600, 20, true),
             DetailTier::Landmark
+        );
+    }
+
+    #[test]
+    fn detail_tier_height_score_does_not_overflow() {
+        let way = ProcessedWay {
+            id: 1,
+            nodes: Vec::new(),
+            tags: std::collections::HashMap::new(),
+        };
+        assert_eq!(
+            compute_detail_tier(&way, BuildingCategory::House, 100, i32::MAX, false),
+            DetailTier::Standard
         );
     }
 

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -414,8 +414,12 @@ pub fn generate_landuse(
                         "clay" | "kaolinite" => CLAY,
                         _ => STONE,
                     };
-                    let random_choice: i32 =
-                        rng.random_range(0..100 + editor.get_absolute_y(x, 0, z)); // The deeper it is the more resources are there
+                    // The deeper it is the more resources there are. Clamp the span
+                    // to keep this valid even when the terrain floor goes below -100.
+                    let ore_roll_span = 100_i32
+                        .saturating_add(editor.get_absolute_y(x, 0, z))
+                        .max(1);
+                    let random_choice: i32 = rng.random_range(0..ore_roll_span);
                     if random_choice < 5 {
                         editor.set_block(ore_block, x, 0, z, Some(&[STONE]), None);
                     }
@@ -585,6 +589,45 @@ mod sealed_surface_tests {
         assert!(
             editor.check_for_block(20, 0, 20, Some(&[GRASS_BLOCK])),
             "the forest still paints the ground beside it"
+        );
+    }
+
+    #[test]
+    fn quarry_ore_roll_handles_deep_terrain_without_panicking() {
+        let xzbbox = XZBBox::rect_from_xz_lengths(60.0, 60.0).unwrap();
+        let mut editor = test_editor(&xzbbox);
+        editor.set_ground(Arc::new(crate::ground::Ground::new_flat(-250)));
+
+        let outlines = BridgeOutlineIndex::build(&[]);
+        let structures = BridgeStructureMap::build(&[], &editor, &outlines);
+        let surface = BridgeSurfaceMap::build(&[], &structures, 1.0);
+
+        let args = Args::parse_from(["arnis", "--bbox", "1,2,3,4", "--mode", "geo-only"]);
+        let way = rect_way(2, 5, 5, 54, 54, &[("landuse", "quarry"), ("resource", "coal")]);
+        let cache = FloodFillCache::new();
+        let footprints = BuildingFootprintBitmap::new_empty();
+        let roads = RoadMaskBitmap::new_empty();
+        generate_landuse(
+            &mut editor,
+            &way,
+            &args,
+            &cache,
+            &footprints,
+            &roads,
+            &surface,
+        );
+
+        let mut ore_cells = 0usize;
+        for x in 10..50 {
+            for z in 10..50 {
+                if editor.check_for_block(x, 0, z, Some(&[COAL_ORE])) {
+                    ore_cells += 1;
+                }
+            }
+        }
+        assert!(
+            ore_cells > 0,
+            "deep quarries should still generate ore cells (found {ore_cells})"
         );
     }
 }

--- a/src/element_processing/landuse.rs
+++ b/src/element_processing/landuse.rs
@@ -603,7 +603,14 @@ mod sealed_surface_tests {
         let surface = BridgeSurfaceMap::build(&[], &structures, 1.0);
 
         let args = Args::parse_from(["arnis", "--bbox", "1,2,3,4", "--mode", "geo-only"]);
-        let way = rect_way(2, 5, 5, 54, 54, &[("landuse", "quarry"), ("resource", "coal")]);
+        let way = rect_way(
+            2,
+            5,
+            5,
+            54,
+            54,
+            &[("landuse", "quarry"), ("resource", "coal")],
+        );
         let cache = FloodFillCache::new();
         let footprints = BuildingFootprintBitmap::new_empty();
         let roads = RoadMaskBitmap::new_empty();


### PR DESCRIPTION
## Summary
- guard quarry ore roll sampling against invalid/empty ranges on deep terrain by clamping the random span to at least 1
- harden building detail-tier height scoring with saturating multiplication to prevent integer overflow on extreme height values
- add focused regression tests for both crash paths

## Crash signatures addressed
- cannot sample empty range @ src/element_processing/landuse.rs:414:29
- attempt to multiply with overflow @ src/element_processing/buildings.rs:2009:14

## Validation
- cargo test --quiet quarry_ore_roll_handles_deep_terrain_without_panicking
- cargo test --quiet detail_tier_height_score_does_not_overflow