### PR TITLE
Add Luanti save path GUI setting

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -153,6 +153,7 @@ pub fn run_gui() -> Result<(), String> {
             gui_create_world,
             gui_get_default_save_path,
             gui_get_default_bedrock_save_path,
+            gui_get_default_luanti_save_path,
             gui_set_save_path,
             gui_pick_save_directory,
             gui_start_generation,
@@ -251,6 +252,29 @@ fn resolve_bedrock_output_dir(configured: &str) -> PathBuf {
         );
     }
     crate::world_utils::get_bedrock_output_directory()
+}
+
+/// Returns the default directory for Luanti/Minetest worlds.
+#[tauri::command]
+fn gui_get_default_luanti_save_path() -> String {
+    crate::world_utils::get_luanti_worlds_directory()
+        .display()
+        .to_string()
+}
+
+/// Returns the configured Luanti worlds directory, or the default if it is unusable.
+fn resolve_luanti_output_dir(configured: &str) -> PathBuf {
+    let trimmed = configured.trim();
+    if !trimmed.is_empty() {
+        let configured_dir = PathBuf::from(trimmed);
+        if configured_dir.is_dir() {
+            return configured_dir;
+        }
+        eprintln!(
+            "Warning: Luanti save path '{trimmed}' is not a directory, using the default instead."
+        );
+    }
+    crate::world_utils::get_luanti_worlds_directory()
 }
 
 #[derive(serde::Serialize)]
@@ -998,6 +1022,7 @@ fn gui_start_generation(
     bbox_text: String,
     selected_world: String,
     bedrock_save_path: String,
+    luanti_save_path: String,
     world_scale: f64,
     ground_level: i32,
     terrain_enabled: bool,
@@ -1150,13 +1175,17 @@ fn gui_start_generation(
                 WorldFormat::BedrockMcWorld => resolve_bedrock_output_dir(&bedrock_save_path),
                 _ => PathBuf::new(),
             };
+            let luanti_output_dir = match world_format {
+                WorldFormat::LuantiWorld => resolve_luanti_output_dir(&luanti_save_path),
+                _ => PathBuf::new(),
+            };
 
             // Check available disk space before starting generation (minimum 3GB required)
             const MIN_DISK_SPACE_BYTES: u64 = 3 * 1024 * 1024 * 1024; // 3 GB
             let check_path = match world_format {
                 WorldFormat::JavaAnvil => world_path.clone(),
                 WorldFormat::BedrockMcWorld => bedrock_output_dir.clone(),
-                WorldFormat::LuantiWorld => crate::world_utils::get_luanti_worlds_directory(),
+                WorldFormat::LuantiWorld => luanti_output_dir.clone(),
             };
             // Probe the nearest existing ancestor: a missing or space-containing
             // path otherwise confuses the Windows volume lookup, which then reports
@@ -1239,7 +1268,7 @@ fn gui_start_generation(
                     (output_path, Some(lvl_name))
                 }
                 WorldFormat::LuantiWorld => {
-                    let worlds_dir = crate::world_utils::get_luanti_worlds_directory();
+                    let worlds_dir = luanti_output_dir.clone();
                     let _ = std::fs::create_dir_all(&worlds_dir);
                     let mut counter = 1;
                     let world_name = loop {

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -403,6 +403,20 @@
           </div>
         </div>
 
+        <!-- Luanti Save Path -->
+        <div class="settings-row">
+          <label for="luanti-save-path-input">
+            <span data-localize="luanti_save_path">Luanti Save Path</span>
+            <span class="tooltip-icon" data-tooltip="Directory where new Luanti/Minetest worlds are created">?</span>
+          </label>
+          <div class="settings-control save-path-control">
+            <input type="text" id="luanti-save-path-input" name="luanti-save-path-input" class="save-path-input" placeholder="Luanti worlds directory">
+            <button type="button" id="luanti-save-path-browse" class="save-path-browse" title="Browse...">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M10 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2z"/></svg>
+            </button>
+          </div>
+        </div>
+
         <!-- Language Selector -->
         <div class="settings-row">
           <label for="language-select">

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -139,6 +139,7 @@ async function applyLocalization(localization) {
     "span[data-localize='custom_map_source']": "custom_map_source",
     "span[data-localize='java_save_path']": "java_save_path",
     "span[data-localize='bedrock_save_path']": "bedrock_save_path",
+    "span[data-localize='luanti_save_path']": "luanti_save_path",
     "span[data-localize='rotation_angle']": "rotation_angle",
     "span[data-localize='canopy_height']": "canopy_height",
     "span[data-localize='max_tree_size']": "max_tree_size",
@@ -866,6 +867,7 @@ function resolveDefaultSavePath() {
 
   resolve('gui_get_default_save_path', 'savePath');
   resolve('gui_get_default_bedrock_save_path', 'bedrockSavePath');
+  resolve('gui_get_default_luanti_save_path', 'luantiSavePath');
 }
 
 function initSettings() {
@@ -1499,6 +1501,7 @@ function initTooltips() {
 /// Save path management, one path per world format
 let savePath = "";
 let bedrockSavePath = "";
+let luantiSavePath = "";
 
 const SAVE_PATHS = {
   java: {
@@ -1516,6 +1519,14 @@ const SAVE_PATHS = {
     browseId: 'bedrock-save-path-browse',
     get: () => bedrockSavePath,
     set: (value) => { bedrockSavePath = value; },
+  },
+  luanti: {
+    storageKey: 'arnis-luanti-save-path',
+    defaultCommand: 'gui_get_default_luanti_save_path',
+    inputId: 'luanti-save-path-input',
+    browseId: 'luanti-save-path-browse',
+    get: () => luantiSavePath,
+    set: (value) => { luantiSavePath = value; },
   },
 };
 
@@ -1999,6 +2010,7 @@ async function startGeneration() {
         bboxText: selectedBBox,
         selectedWorld: worldPath,
         bedrockSavePath: bedrockSavePath,
+        luantiSavePath: luantiSavePath,
         worldScale: scale,
         groundLevel: ground_level,
         terrainEnabled: terrain,

--- a/src/gui/js/settings-store.js
+++ b/src/gui/js/settings-store.js
@@ -1,6 +1,6 @@
 // Persistence, per-setting revert and global reset for the Settings modal.
 // Values live in one localStorage blob. The preferences that already had their
-// own keys (language, map theme, world format, Luanti, the two save paths,
+// own keys (language, map theme, world format, Luanti, the save paths,
 // telemetry) keep them and are only listed here for revert and reset.
 // Defaults come from the HTML attributes, which JS assignments never change,
 // so there is no ordering hazard with initSettings().
@@ -52,6 +52,7 @@ const SETTINGS = [
   // Application
   { id: 'save-path-input', kind: 'text', store: EXTERNAL, dynamicDefault: 'savePath' },
   { id: 'bedrock-save-path-input', kind: 'text', store: EXTERNAL, dynamicDefault: 'bedrockSavePath' },
+  { id: 'luanti-save-path-input', kind: 'text', store: EXTERNAL, dynamicDefault: 'luantiSavePath' },
   { id: 'language-select', kind: 'select', store: EXTERNAL, dynamicDefault: 'language' },
 
   // Consent record, not a preference. The user answered it on first run and the

--- a/src/gui/locales/ar.json
+++ b/src/gui/locales/ar.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "يتم إنشاء عالم Bedrock تلقائيًا",
   "java_save_path": "مسار حفظ Java",
   "bedrock_save_path": "مسار حفظ Bedrock",
+  "luanti_save_path": "مسار حفظ Luanti",
   "rotation_angle": "زاوية الدوران",
   "settings_section_generation": "التوليد",
   "settings_section_world": "العالم",

--- a/src/gui/locales/de.json
+++ b/src/gui/locales/de.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Bedrock-Welt wird automatisch generiert",
   "java_save_path": "Java-Speicherpfad",
   "bedrock_save_path": "Bedrock-Speicherpfad",
+  "luanti_save_path": "Luanti-Speicherpfad",
   "rotation_angle": "Rotationswinkel",
   "settings_section_generation": "Generierung",
   "settings_section_world": "Welt",

--- a/src/gui/locales/en-US.json
+++ b/src/gui/locales/en-US.json
@@ -69,6 +69,7 @@
   "bedrock_auto_generated": "Bedrock world is auto-generated",
   "java_save_path": "Java Save Path",
   "bedrock_save_path": "Bedrock Save Path",
+  "luanti_save_path": "Luanti Save Path",
   "rotation_angle": "Rotation Angle",
   "settings_section_generation": "Generation",
   "settings_section_world": "World",

--- a/src/gui/locales/es.json
+++ b/src/gui/locales/es.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "El mundo Bedrock se genera automáticamente",
   "java_save_path": "Ruta de guardado de Java",
   "bedrock_save_path": "Ruta de guardado de Bedrock",
+  "luanti_save_path": "Ruta de guardado de Luanti",
   "rotation_angle": "Ángulo de Rotación",
   "settings_section_generation": "Generación",
   "settings_section_world": "Mundo",

--- a/src/gui/locales/fi.json
+++ b/src/gui/locales/fi.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Bedrock-maailma luodaan automaattisesti",
   "java_save_path": "Javan tallennuspolku",
   "bedrock_save_path": "Bedrockin tallennuspolku",
+  "luanti_save_path": "Luanti-tallennuspolku",
   "rotation_angle": "Kiertokulma",
   "settings_section_generation": "Generointi",
   "settings_section_world": "Maailma",

--- a/src/gui/locales/fr-FR.json
+++ b/src/gui/locales/fr-FR.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Le monde Bedrock est généré automatiquement",
   "java_save_path": "Chemin de sauvegarde Java",
   "bedrock_save_path": "Chemin de sauvegarde Bedrock",
+  "luanti_save_path": "Chemin de sauvegarde Luanti",
   "rotation_angle": "Angle de Rotation",
   "settings_section_generation": "Génération",
   "settings_section_world": "Monde",

--- a/src/gui/locales/hu.json
+++ b/src/gui/locales/hu.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "A Bedrock világ automatikusan generálódik",
   "java_save_path": "Java mentési útvonal",
   "bedrock_save_path": "Bedrock mentési útvonal",
+  "luanti_save_path": "Luanti mentési útvonal",
   "rotation_angle": "Forgatási Szög",
   "settings_section_generation": "Generálás",
   "settings_section_world": "Világ",

--- a/src/gui/locales/ja.json
+++ b/src/gui/locales/ja.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Bedrock ワールドは自動生成されます",
   "java_save_path": "Java の保存先",
   "bedrock_save_path": "Bedrock の保存先",
+  "luanti_save_path": "Luanti の保存先",
   "rotation_angle": "回転角度",
   "settings_section_generation": "生成",
   "settings_section_world": "ワールド",

--- a/src/gui/locales/ka-GE.json
+++ b/src/gui/locales/ka-GE.json
@@ -69,6 +69,7 @@
   "bedrock_auto_generated": "Bedrock-ის სამყარო ავტომატურად იქმნება",
   "java_save_path": "Java-ს შენახვის გზა",
   "bedrock_save_path": "Bedrock-ის შენახვის გზა",
+  "luanti_save_path": "Luanti-ის შენახვის გზა",
   "rotation_angle": "ბრუნვის კუთხე",
   "settings_section_generation": "გენერაცია",
   "settings_section_world": "სამყარო",

--- a/src/gui/locales/ko.json
+++ b/src/gui/locales/ko.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Bedrock 월드는 자동 생성됩니다",
   "java_save_path": "Java 저장 경로",
   "bedrock_save_path": "Bedrock 저장 경로",
+  "luanti_save_path": "Luanti 저장 경로",
   "rotation_angle": "회전 각도",
   "settings_section_generation": "생성",
   "settings_section_world": "월드",

--- a/src/gui/locales/lt.json
+++ b/src/gui/locales/lt.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Bedrock pasaulis generuojamas automatiškai",
   "java_save_path": "Java išsaugojimo kelias",
   "bedrock_save_path": "Bedrock išsaugojimo kelias",
+  "luanti_save_path": "Luanti išsaugojimo kelias",
   "rotation_angle": "Pasukimo Kampas",
   "settings_section_generation": "Generavimas",
   "settings_section_world": "Pasaulis",

--- a/src/gui/locales/lv.json
+++ b/src/gui/locales/lv.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Bedrock pasaule tiek ģenerēta automātiski",
   "java_save_path": "Java saglabāšanas ceļš",
   "bedrock_save_path": "Bedrock saglabāšanas ceļš",
+  "luanti_save_path": "Luanti saglabāšanas ceļš",
   "rotation_angle": "Rotācijas Leņķis",
   "settings_section_generation": "Ģenerēšana",
   "settings_section_world": "Pasaule",

--- a/src/gui/locales/pl.json
+++ b/src/gui/locales/pl.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Świat Bedrock jest generowany automatycznie",
   "java_save_path": "Ścieżka zapisu Java",
   "bedrock_save_path": "Ścieżka zapisu Bedrock",
+  "luanti_save_path": "Ścieżka zapisu Luanti",
   "rotation_angle": "Kąt Obrotu",
   "settings_section_generation": "Generowanie",
   "settings_section_world": "Świat",

--- a/src/gui/locales/pt-BR.json
+++ b/src/gui/locales/pt-BR.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "O mundo de bedrock é gerado automaticamente",
   "java_save_path": "Caminho de salvamento do Java",
   "bedrock_save_path": "Caminho de salvamento do Bedrock",
+  "luanti_save_path": "Caminho de salvamento do Luanti",
   "rotation_angle": "Ângulo de Rotação",
   "settings_section_generation": "Geração",
   "settings_section_world": "Mundo",

--- a/src/gui/locales/ru.json
+++ b/src/gui/locales/ru.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Мир Bedrock генерируется автоматически",
   "java_save_path": "Путь сохранения Java",
   "bedrock_save_path": "Путь сохранения Bedrock",
+  "luanti_save_path": "Путь сохранения Luanti",
   "rotation_angle": "Угол Поворота",
   "settings_section_generation": "Генерация",
   "settings_section_world": "Мир",

--- a/src/gui/locales/sl.json
+++ b/src/gui/locales/sl.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Bedrock svet je samodejno ustvarjen",
   "java_save_path": "Pot shranjevanja Java",
   "bedrock_save_path": "Pot shranjevanja Bedrock",
+  "luanti_save_path": "Pot shranjevanja Luanti",
   "rotation_angle": "Kot zasuka",
   "settings_section_generation": "Generiranje",
   "settings_section_world": "Svet",

--- a/src/gui/locales/sv.json
+++ b/src/gui/locales/sv.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Bedrock-världen genereras automatiskt",
   "java_save_path": "Sökväg för Java",
   "bedrock_save_path": "Sökväg för Bedrock",
+  "luanti_save_path": "Sökväg för Luanti",
   "rotation_angle": "Rotationsvinkel",
   "settings_section_generation": "Generering",
   "settings_section_world": "Värld",

--- a/src/gui/locales/ua.json
+++ b/src/gui/locales/ua.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Bedrock світ генерується автоматично",
   "java_save_path": "Шлях збереження Java",
   "bedrock_save_path": "Шлях збереження Bedrock",
+  "luanti_save_path": "Шлях збереження Luanti",
   "rotation_angle": "Кут Обертання",
   "settings_section_generation": "Генерація",
   "settings_section_world": "Світ",

--- a/src/gui/locales/zh-CN.json
+++ b/src/gui/locales/zh-CN.json
@@ -62,6 +62,7 @@
   "bedrock_auto_generated": "Bedrock 世界自动生成",
   "java_save_path": "Java 存档路径",
   "bedrock_save_path": "Bedrock 存档路径",
+  "luanti_save_path": "Luanti 存档路径",
   "rotation_angle": "旋转角度",
   "settings_section_generation": "生成",
   "settings_section_world": "世界",


### PR DESCRIPTION
## Summary
Java and Bedrock world formats each had a configurable save-path setting in the GUI (with a browse button), but Luanti/Minetest worlds were always written to the OS-default Luanti worlds directory (`get_luanti_worlds_directory()`) with no way to override it. This adds a matching "Luanti Save Path" setting.

## Changes
- `src/gui.rs`: new `gui_get_default_luanti_save_path` Tauri command and `resolve_luanti_output_dir` helper (mirrors the existing Bedrock equivalents). `gui_start_generation` now accepts `luanti_save_path` and uses the resolved directory for both the disk-space check and world creation instead of always calling `get_luanti_worlds_directory()` directly.
- `src/gui/index.html`: new "Luanti Save Path" settings row (text input + browse button), consistent with the Java/Bedrock rows.
- `src/gui/js/main.js`: new `luantiSavePath` state, `SAVE_PATHS.luanti` entry, default-path resolution, localization wiring, and passes the path through to `gui_start_generation`.
- `src/gui/js/settings-store.js`: registers the new input for revert/reset support.
- `src/gui/locales/*.json`: added `luanti_save_path` translation key to all locales.

## Testing
- `cargo check` and `cargo clippy` pass with no new warnings.