### PR TITLE
Read Overture from its vector tiles, and cache what both transports fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,6 @@ GUI Build: ```cargo run --release```<br>
 | `geo-only` | OSM objects on flat ground |
 | `terrain-only` | Real elevation terrain, no objects at all (skips the OpenStreetMap query and the Overture fetch entirely, so `--overture` has no effect) |
 
-`--overture-source` selects how the Overture Maps buildings are read. Both transports carry the same release's data, so this only changes what the fetch costs:
-
-| Source | Result |
-| --- | --- |
-| `auto` (default) | The published vector tiles, falling back to the GeoParquet partitions if the tile archive cannot be read or the area is continental |
-| `tiles` | Vector tiles only, so a broken archive fails visibly instead of silently costing more |
-| `parquet` | GeoParquet partitions only |
-
-Everything either transport downloads is cached under `arnis-overture-cache` in the OS cache directory, keyed by the Overture release. Releases are immutable, so a cached read never needs revalidating; the GUI's "clear cache" button empties it along with the other caches.
-
 After your pull request is merged, I will take care of regularly creating update releases which will include your changes.
 
 If you are using Nix, you can run the program directly with `nix run github:louis-e/arnis -- --output-dir=YOUR_PATH/.minecraft/saves/worldname --bbox="min_lat,min_lng,max_lat,max_lng"`

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ GUI Build: ```cargo run --release```<br>
 | `geo-only` | OSM objects on flat ground |
 | `terrain-only` | Real elevation terrain, no objects at all (skips the OpenStreetMap query and the Overture fetch entirely, so `--overture` has no effect) |
 
+`--overture-source` selects how the Overture Maps buildings are read. Both transports carry the same release's data, so this only changes what the fetch costs:
+
+| Source | Result |
+| --- | --- |
+| `auto` (default) | The published vector tiles, falling back to the GeoParquet partitions if the tile archive cannot be read or the area is continental |
+| `tiles` | Vector tiles only, so a broken archive fails visibly instead of silently costing more |
+| `parquet` | GeoParquet partitions only |
+
+Everything either transport downloads is cached under `arnis-overture-cache` in the OS cache directory, keyed by the Overture release. Releases are immutable, so a cached read never needs revalidating; the GUI's "clear cache" button empties it along with the other caches.
+
 After your pull request is merged, I will take care of regularly creating update releases which will include your changes.
 
 If you are using Nix, you can run the program directly with `nix run github:louis-e/arnis -- --output-dir=YOUR_PATH/.minecraft/saves/worldname --bbox="min_lat,min_lng,max_lat,max_lng"`

--- a/src/args.rs
+++ b/src/args.rs
@@ -98,6 +98,13 @@ pub struct Args {
     #[arg(long = "overture", default_value_t = true, action = ArgAction::Set, num_args = 0..=1, default_missing_value = "true")]
     pub overture: bool,
 
+    /// Which Overture transport to read. Both carry the same buildings.
+    /// auto: vector tiles, falling back to the Parquet partitions (default)
+    /// tiles: vector tiles only, so a fallback cannot hide a broken archive
+    /// parquet: the GeoParquet partitions only
+    #[arg(long = "overture-source", value_enum, default_value_t = OvertureSource::Auto)]
+    pub overture_source: OvertureSource,
+
     /// Disable both external 3D models (3DMR + Wikimedia) and bundled schematic
     /// props (cars, boats, cranes, ...) with a single toggle.
     #[arg(long = "no-3d", default_value_t = true, action = ArgAction::SetFalse)]
@@ -169,6 +176,26 @@ pub struct Args {
     /// building signage: shop name plates, house numbers and crossing signs.
     #[arg(long, value_enum, default_value_t = SignageLevel::Basic)]
     pub signage: SignageLevel,
+}
+
+/// Which transport to read Overture Maps buildings through.
+///
+/// Both carry the same release's data; they differ in cost. The tile archive is
+/// one range request per z14 tile and is cached per release, so a city is about
+/// 1.3 MB and a repeat run is free. The Parquet partitions need a ~233 KB
+/// catalogue and a ~1.3 MB footer per partition before any building is read, but
+/// they win on continental areas, where whole row groups beat one request per
+/// square kilometre.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default, clap::ValueEnum)]
+pub enum OvertureSource {
+    /// Tiles where they are cheaper and available, Parquet otherwise.
+    #[default]
+    Auto,
+    /// Vector tiles only. Fails rather than falling back, so a broken archive is
+    /// visible instead of merely slow.
+    Tiles,
+    /// GeoParquet partitions only.
+    Parquet,
 }
 
 /// How much image signage to place.

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1363,9 +1363,11 @@ fn gui_start_generation(
                 max_tree_size: crate::trees::tree_library::TreeSize::from_str_lossy(&max_tree_size),
                 canopy_height: canopy_height_enabled,
                 overture: overture_enabled,
-                // Which transport carries the buildings is a fetch detail with
-                // no effect on the world, so the GUI leaves it on auto rather
-                // than spending a setting on it.
+                // Auto picks whichever transport is cheaper for the area. The
+                // two are not bit-identical - tiles quantise coordinates to a
+                // 0.4 m lattice and keep the largest ring of a multipolygon the
+                // Parquet reader drops entirely - but both differences are far
+                // below a block, so the choice is not worth a GUI setting.
                 overture_source: crate::args::OvertureSource::Auto,
                 use_3d: use_3d_enabled,
                 debug: false,

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -808,6 +808,7 @@ fn gui_clear_tile_caches() -> Result<String, String> {
     let combined = clear_all_cached_tiles()
         .combined(clear_land_cover_cache())
         .combined(crate::canopy::clear_canopy_cache())
+        .combined(crate::overture::clear_overture_cache())
         .combined(clear_model_caches());
     let megabytes = combined.bytes_freed as f64 / (1024.0 * 1024.0);
 
@@ -1362,6 +1363,10 @@ fn gui_start_generation(
                 max_tree_size: crate::trees::tree_library::TreeSize::from_str_lossy(&max_tree_size),
                 canopy_height: canopy_height_enabled,
                 overture: overture_enabled,
+                // Which transport carries the buildings is a fetch detail with
+                // no effect on the world, so the GUI leaves it on auto rather
+                // than spending a setting on it.
+                overture_source: crate::args::OvertureSource::Auto,
                 use_3d: use_3d_enabled,
                 debug: false,
                 timeout: Some(std::time::Duration::from_secs(40)),
@@ -1445,7 +1450,12 @@ fn gui_start_generation(
             let (fetch_result, overture_data, ground) = std::thread::scope(|s| {
                 let overture_handle = s.spawn(|| {
                     if args.overture {
-                        overture::fetch_overture_buildings(&bbox, args.scale, args.debug)
+                        overture::fetch_overture_buildings(
+                            &bbox,
+                            args.scale,
+                            args.overture_source,
+                            args.debug,
+                        )
                     } else {
                         overture::OvertureData::default()
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,7 +379,12 @@ fn run_cli() {
         let overture_handle = s.spawn(|| {
             let t = std::time::Instant::now();
             let data = if args.overture && !skip_objects {
-                overture::fetch_overture_buildings(&effective_bbox, args.scale, args.debug)
+                overture::fetch_overture_buildings(
+                    &effective_bbox,
+                    args.scale,
+                    args.overture_source,
+                    args.debug,
+                )
             } else {
                 overture::OvertureData::default()
             };

--- a/src/overture/cache.rs
+++ b/src/overture/cache.rs
@@ -1,0 +1,224 @@
+//! On-disk cache for Overture Maps data.
+//!
+//! Overture publishes immutable, dated releases (`2026-08-19.0`) and keeps only
+//! the newest two online under a 60-day retention rule. Two consequences shape
+//! this module:
+//!
+//! * **Everything is keyed by release**, so a cached byte range can never go
+//!   stale. A release name identifies fixed content; there is no TTL to get
+//!   wrong, and no revalidation request to pay for. The only thing that ages is
+//!   *which* release is newest, which release discovery answers on every run.
+//! * **The release that last worked is remembered**, because the compile-time
+//!   fallback is a date and dates rot. When discovery fails on a machine whose
+//!   last successful release has since been retired, we would otherwise fall
+//!   back to a constant that expired even earlier.
+//!
+//! Writes are atomic (temp file + rename) so a killed run, a full disk or two
+//! concurrent Arnis processes can never leave a truncated file that a later run
+//! reads back as valid data.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::elevation::cache::CacheClearStats;
+
+/// Cache root under the OS cache directory, alongside `arnis-tile-cache` and
+/// `arnis-landcover-cache`.
+const OVERTURE_CACHE_DIR: &str = "arnis-overture-cache";
+
+/// File holding the last release that actually served data on this machine.
+const LAST_GOOD_RELEASE_FILE: &str = "last_good_release";
+
+/// Cache root. Falls back to a relative directory when the OS has no cache dir,
+/// matching every other Arnis cache.
+pub fn cache_root() -> PathBuf {
+    match dirs::cache_dir() {
+        Some(dir) => dir.join(OVERTURE_CACHE_DIR),
+        None => PathBuf::from(format!("./{OVERTURE_CACHE_DIR}")),
+    }
+}
+
+/// Clear every cached Overture artefact. Entry point for the GUI cache-clean
+/// command, which calls one of these per cache root.
+pub fn clear_overture_cache() -> CacheClearStats {
+    crate::elevation::cache::clear_cache_dir(&cache_root())
+}
+
+/// A release name is `YYYY-MM-DD.N`. Validated before it is ever used as a path
+/// segment, so a hostile or corrupt bucket listing cannot escape the cache root.
+pub fn is_valid_release(release: &str) -> bool {
+    let Some((date, revision)) = release.split_once('.') else {
+        return false;
+    };
+    if revision.is_empty() || !revision.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    let parts: Vec<&str> = date.split('-').collect();
+    matches!(parts.as_slice(), [y, m, d]
+        if y.len() == 4 && m.len() == 2 && d.len() == 2
+            && [y, m, d].iter().all(|p| p.bytes().all(|b| b.is_ascii_digit())))
+}
+
+/// Directory holding one release's cached artefacts. `None` for a name that is
+/// not a well-formed release, which keeps path traversal impossible by
+/// construction rather than by escaping.
+pub fn release_dir(release: &str) -> Option<PathBuf> {
+    is_valid_release(release).then(|| cache_root().join(release))
+}
+
+/// Read a cached file, or `None` if it is absent or unreadable. A read error is
+/// never fatal: the caller refetches.
+pub fn read(path: &Path) -> Option<Vec<u8>> {
+    std::fs::read(path).ok()
+}
+
+/// Write `bytes` to `path` atomically.
+///
+/// The temp file carries the process id so two Arnis processes caching the same
+/// tile cannot write through each other's partial file; the rename then makes
+/// whichever finishes last the visible one, and both hold identical bytes.
+/// Every failure is silent by design - the cache is an optimisation, and a
+/// read-only or full disk must not fail a generation.
+pub fn write_atomic(path: &Path, bytes: &[u8]) {
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let tmp = parent.join(format!(
+        ".{}.{}.tmp",
+        path.file_name().and_then(|n| n.to_str()).unwrap_or("cache"),
+        std::process::id()
+    ));
+    let written = std::fs::File::create(&tmp).and_then(|mut f| {
+        f.write_all(bytes)?;
+        // The rename below only orders the directory entry, not the file's own
+        // data, so without this a crash can leave a correctly named file whose
+        // contents are still in the page cache.
+        f.sync_all()
+    });
+    if written.is_err() || std::fs::rename(&tmp, path).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
+/// The release that last served data on this machine, if it is still a
+/// well-formed name.
+pub fn last_good_release() -> Option<String> {
+    let raw = std::fs::read_to_string(cache_root().join(LAST_GOOD_RELEASE_FILE)).ok()?;
+    let release = raw.trim().to_string();
+    is_valid_release(&release).then_some(release)
+}
+
+/// Remember `release` as the one that last worked. Skipped when it is already
+/// recorded, so a normal run does no write at all.
+pub fn set_last_good_release(release: &str) {
+    if !is_valid_release(release) || last_good_release().as_deref() == Some(release) {
+        return;
+    }
+    write_atomic(
+        &cache_root().join(LAST_GOOD_RELEASE_FILE),
+        release.as_bytes(),
+    );
+}
+
+/// Delete cached release directories older than `keep`.
+///
+/// Overture retires a release after 60 days, so without this the cache grows a
+/// new directory every month and never loses one. Only names that parse as
+/// releases are considered, and only ones that sort strictly older than the
+/// release actually in use - so a run that pinned an older release cannot
+/// delete the newer data another run is still using.
+pub fn prune_releases_older_than(keep: &str) {
+    if !is_valid_release(keep) {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(cache_root()) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if !is_valid_release(&name)
+            || super::release_sort_key(&name) >= super::release_sort_key(keep)
+        {
+            continue;
+        }
+        if entry.file_type().is_ok_and(|t| t.is_dir()) {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_names_are_validated_before_becoming_path_segments() {
+        assert!(is_valid_release("2026-08-19.0"));
+        assert!(is_valid_release("2026-08-19.12"));
+
+        // Anything that could escape the cache root, or is simply malformed.
+        for bad in [
+            "../etc",
+            "2026-08-19",
+            "2026-8-19.0",
+            "2026-08-19.",
+            "2026-08-19.x",
+            "..",
+            "",
+            "release/2026-08-19.0",
+            "2026-08-19.0/..",
+        ] {
+            assert!(!is_valid_release(bad), "{bad} must be rejected");
+            assert!(release_dir(bad).is_none(), "{bad} must have no cache dir");
+        }
+    }
+
+    #[test]
+    fn a_write_that_fails_leaves_no_file_behind() {
+        let dir = tempfile::tempdir().unwrap();
+        // A path whose parent is an existing *file* cannot be created.
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, b"x").unwrap();
+        write_atomic(&blocker.join("nested").join("f.bin"), b"data");
+
+        // The blocker is untouched and no temp file was left in the directory.
+        assert_eq!(std::fs::read(&blocker).unwrap(), b"x");
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp file left behind");
+    }
+
+    #[test]
+    fn an_atomic_write_round_trips_and_overwrites() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sub").join("file.bin");
+
+        write_atomic(&path, b"first");
+        assert_eq!(read(&path).unwrap(), b"first");
+
+        write_atomic(&path, b"second");
+        assert_eq!(read(&path).unwrap(), b"second");
+
+        // No temp files survive a successful write.
+        let leftovers: Vec<_> = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with('.'))
+            .collect();
+        assert!(leftovers.is_empty());
+    }
+
+    #[test]
+    fn read_of_a_missing_file_is_none_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read(&dir.path().join("absent")).is_none());
+    }
+}

--- a/src/overture/cache.rs
+++ b/src/overture/cache.rs
@@ -19,6 +19,7 @@
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::elevation::cache::CacheClearStats;
 
@@ -74,12 +75,21 @@ pub fn read(path: &Path) -> Option<Vec<u8>> {
 
 /// Write `bytes` to `path` atomically.
 ///
-/// The temp file carries the process id so two Arnis processes caching the same
-/// tile cannot write through each other's partial file; the rename then makes
-/// whichever finishes last the visible one, and both hold identical bytes.
-/// Every failure is silent by design - the cache is an optimisation, and a
+/// The temp name carries the process id and a per-write counter, so no two
+/// writers ever share one. Both halves are needed: the pid separates processes,
+/// and the counter separates writers inside a process, which happens whenever
+/// the 3D preview and a generation open the same release at once. Sharing a
+/// temp path would let one writer truncate a file another is still writing and
+/// then publish it.
+///
+/// The rename makes whichever finishes last visible, and since both writers
+/// hold identical bytes for a given path, either is correct.
+///
+/// Every failure is silent by design. The cache is an optimisation, and a
 /// read-only or full disk must not fail a generation.
 pub fn write_atomic(path: &Path, bytes: &[u8]) {
+    static WRITE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
     let Some(parent) = path.parent() else {
         return;
     };
@@ -87,9 +97,10 @@ pub fn write_atomic(path: &Path, bytes: &[u8]) {
         return;
     }
     let tmp = parent.join(format!(
-        ".{}.{}.tmp",
+        ".{}.{}.{}.tmp",
         path.file_name().and_then(|n| n.to_str()).unwrap_or("cache"),
-        std::process::id()
+        std::process::id(),
+        WRITE_SEQUENCE.fetch_add(1, Ordering::Relaxed)
     ));
     let written = std::fs::File::create(&tmp).and_then(|mut f| {
         f.write_all(bytes)?;
@@ -214,6 +225,35 @@ mod tests {
             .filter(|e| e.file_name().to_string_lossy().starts_with('.'))
             .collect();
         assert!(leftovers.is_empty());
+    }
+
+    #[test]
+    fn concurrent_writers_to_one_path_never_publish_a_mixed_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("contended.bin");
+
+        // Same length, different bytes, so a torn write is visible as a mix.
+        let a = vec![b'a'; 512 * 1024];
+        let b = vec![b'b'; 512 * 1024];
+
+        std::thread::scope(|scope| {
+            for payload in [&a, &b] {
+                for _ in 0..8 {
+                    scope.spawn(|| write_atomic(&path, payload));
+                }
+            }
+        });
+
+        let got = read(&path).expect("one writer must have published");
+        assert!(got == a || got == b, "published a torn or mixed file");
+
+        // Every writer cleaned up after itself.
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files left behind");
     }
 
     #[test]

--- a/src/overture/mod.rs
+++ b/src/overture/mod.rs
@@ -94,8 +94,15 @@ const OVERTURE_RELEASE_LIST_URL: &str =
 /// on a machine that has fetched before. Bump it when cutting a release.
 const OVERTURE_STAC_RELEASE_FALLBACK: &str = "2026-08-19.0";
 
-/// How many releases to request before giving up, so a broken host cannot stall the fetch.
-const OVERTURE_MAX_RELEASE_ATTEMPTS: usize = 3;
+/// How many releases to request before giving up, so a broken host cannot stall
+/// the fetch. Spent on at most two discovered releases plus the two fallbacks
+/// below, deduplicated - and since only two releases are ever online, the
+/// fallbacks usually collapse into the discovered ones and cost nothing.
+const OVERTURE_MAX_RELEASE_ATTEMPTS: usize = 4;
+
+/// Slots [`OVERTURE_MAX_RELEASE_ATTEMPTS`] reserves for the two fallbacks: the
+/// release that last worked on this machine, and the bundled constant.
+const RELEASE_FALLBACK_SLOTS: usize = 2;
 
 /// High bit marker for Overture IDs to avoid collision with OSM IDs.
 /// OSM IDs are sequential positive u64 (currently up to ~12 billion, well under 2^34).
@@ -1018,26 +1025,39 @@ fn release_candidates(client: &Client, debug: bool) -> Vec<String> {
         }
     };
 
-    // Reserve the last attempts for the fallbacks so they stay reachable on a
-    // long listing.
+    let candidates = build_release_candidates(discovered, cache::last_good_release());
+    if debug {
+        println!("Overture releases to try: {}", candidates.join(", "));
+    }
+    candidates
+}
+
+/// Order the releases to try, bounded by [`OVERTURE_MAX_RELEASE_ATTEMPTS`].
+///
+/// Split out from the network call so the bound itself is testable: the whole
+/// point of the constant is that a host answering slowly cannot stall a fetch
+/// indefinitely, and that guarantee is easy to lose when fallbacks are appended
+/// after a `take`.
+fn build_release_candidates(discovered: Vec<String>, last_good: Option<String>) -> Vec<String> {
+    // The two fallbacks get reserved slots so a long listing cannot push them
+    // out, and so appending them cannot push the total past the bound.
+    let discovered_slots = OVERTURE_MAX_RELEASE_ATTEMPTS.saturating_sub(RELEASE_FALLBACK_SLOTS);
     let mut candidates: Vec<String> = discovered
         .into_iter()
         .filter(|r| cache::is_valid_release(r))
-        .take(OVERTURE_MAX_RELEASE_ATTEMPTS.saturating_sub(1))
+        .take(discovered_slots)
         .collect();
 
-    for fallback in cache::last_good_release()
+    for fallback in last_good
         .into_iter()
         .chain(std::iter::once(OVERTURE_STAC_RELEASE_FALLBACK.to_string()))
     {
-        if !candidates.contains(&fallback) {
+        if cache::is_valid_release(&fallback) && !candidates.contains(&fallback) {
             candidates.push(fallback);
         }
     }
 
-    if debug {
-        println!("Overture releases to try: {}", candidates.join(", "));
-    }
+    debug_assert!(candidates.len() <= OVERTURE_MAX_RELEASE_ATTEMPTS);
     candidates
 }
 
@@ -2314,7 +2334,11 @@ fn fetch_range_with_attempts(
     if length == 0 {
         return Err("fetch_range called with length 0".into());
     }
-    let end = start + length - 1;
+    // Row-group offsets and lengths come from the partition footer, which is
+    // network data. Wrapping would turn a bad range into a plausible small one.
+    let end = start
+        .checked_add(length - 1)
+        .ok_or_else(|| format!("range {start}+{length} overflows the partition"))?;
     let mut last_error = String::new();
 
     for attempt in 0..max_attempts.max(1) {
@@ -2717,12 +2741,64 @@ mod tests {
 
     #[test]
     fn release_candidates_end_with_the_remembered_and_bundled_fallbacks() {
-        // Discovery is the first answer, but the list must always end somewhere
-        // usable: a machine offline at the bucket still has to try something.
-        assert!(cache::is_valid_release(OVERTURE_STAC_RELEASE_FALLBACK));
+        let discovered = |names: &[&str]| names.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+
+        // Discovery answers first, then the remembered release, then the
+        // bundled constant: a machine offline at the bucket still has something
+        // to try, and it is a release that actually worked here.
+        let candidates = build_release_candidates(
+            discovered(&["2026-09-16.0", "2026-09-01.0"]),
+            Some("2026-05-01.0".to_string()),
+        );
+        assert_eq!(
+            candidates,
+            vec![
+                "2026-09-16.0",
+                "2026-09-01.0",
+                "2026-05-01.0",
+                OVERTURE_STAC_RELEASE_FALLBACK
+            ]
+        );
+
+        // Discovery failing leaves exactly the two fallbacks.
+        assert_eq!(
+            build_release_candidates(Vec::new(), Some("2026-05-01.0".to_string())),
+            vec!["2026-05-01.0", OVERTURE_STAC_RELEASE_FALLBACK]
+        );
+        assert_eq!(
+            build_release_candidates(Vec::new(), None),
+            vec![OVERTURE_STAC_RELEASE_FALLBACK]
+        );
+
+        // A fallback already discovered is not tried twice. In practice this is
+        // the normal case, since only two releases are ever online.
+        assert_eq!(
+            build_release_candidates(
+                discovered(&[OVERTURE_STAC_RELEASE_FALLBACK]),
+                Some(OVERTURE_STAC_RELEASE_FALLBACK.to_string()),
+            ),
+            vec![OVERTURE_STAC_RELEASE_FALLBACK]
+        );
+
+        // The bound holds however long the listing is. Losing this is how a
+        // slow host turns one fetch into an unbounded wait.
+        let many = discovered(&[
+            "2026-09-16.0",
+            "2026-09-01.0",
+            "2026-08-19.0",
+            "2026-07-22.0",
+            "2026-06-17.0",
+        ]);
+        let candidates = build_release_candidates(many, Some("2026-05-01.0".to_string()));
+        assert_eq!(candidates.len(), OVERTURE_MAX_RELEASE_ATTEMPTS);
+
         // Malformed names from a bucket listing never reach a URL or a path.
-        assert!(!cache::is_valid_release("release/2026-08-19.0"));
-        assert!(!cache::is_valid_release("latest"));
+        assert!(cache::is_valid_release(OVERTURE_STAC_RELEASE_FALLBACK));
+        let filtered = build_release_candidates(
+            discovered(&["release/2026-08-19.0", "latest", "../x"]),
+            None,
+        );
+        assert_eq!(filtered, vec![OVERTURE_STAC_RELEASE_FALLBACK]);
     }
 
     #[test]

--- a/src/overture/mod.rs
+++ b/src/overture/mod.rs
@@ -11,9 +11,59 @@
 //! `building:levels` on OSM buildings that carry neither tag. That enrichment
 //! is strictly additive - an existing OSM tag is never overwritten.
 //!
-//! Data is read from GeoParquet files hosted on Azure Blob Storage using
-//! HTTP Range requests (same pattern as land_cover.rs COG reading).
+//! Two transports carry the same data, both over HTTP range requests:
+//!
+//! * **Tiles** ([`tiles`]) read the release's PMTiles archive, fetching only the
+//!   z14 tiles the bounding box covers. Cheapest for anything up to a large
+//!   metropolitan area, and cached on disk.
+//! * **Parquet** read the release's GeoParquet partitions, pulling a catalogue,
+//!   a footer per partition and then the matching row groups. Cheaper once an
+//!   area is continental, and the fallback whenever the archive cannot be read.
+//!
+//! Both are keyed by an Overture release. Releases are immutable and only the
+//! newest two stay online under a 60-day retention rule, so everything either
+//! transport downloads is cached under the release it came from (see [`cache`])
+//! and never needs revalidating.
 
+mod cache;
+mod mvt;
+mod pmtiles;
+mod tiles;
+
+pub use cache::clear_overture_cache;
+
+/// What a fetch actually cost, so the two transports can be compared on
+/// measurement rather than on the docstrings above.
+mod stats {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NETWORK_BYTES: AtomicU64 = AtomicU64::new(0);
+    static CACHED_BYTES: AtomicU64 = AtomicU64::new(0);
+    static REQUESTS: AtomicU64 = AtomicU64::new(0);
+
+    pub(super) fn record_network(bytes: u64) {
+        NETWORK_BYTES.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    pub(super) fn record_cached(bytes: u64) {
+        CACHED_BYTES.fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    pub(super) fn record_request() {
+        REQUESTS.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// `(network bytes, cached bytes, http requests)` since process start.
+    pub(super) fn snapshot() -> (u64, u64, u64) {
+        (
+            NETWORK_BYTES.load(Ordering::Relaxed),
+            CACHED_BYTES.load(Ordering::Relaxed),
+            REQUESTS.load(Ordering::Relaxed),
+        )
+    }
+}
+
+use crate::args::OvertureSource;
 use crate::clipping::clip_way_to_bbox;
 use crate::coordinate_system::geographic::{LLBBox, LLPoint};
 use crate::coordinate_system::transformation::CoordTransformer;
@@ -37,8 +87,12 @@ const OVERTURE_STAC_ROOT: &str = "https://stac.overturemaps.org";
 const OVERTURE_RELEASE_LIST_URL: &str =
     "https://overturemaps-us-west-2.s3.amazonaws.com/?list-type=2&prefix=release/&delimiter=/";
 
-/// Used when release discovery fails; bump occasionally to a recent release.
-const OVERTURE_STAC_RELEASE_FALLBACK: &str = "2026-07-22.0";
+/// Last resort when release discovery fails and this machine has never
+/// succeeded before. Overture retires a release 60 days after publishing it, so
+/// this constant rots: it is tried *after* the release that last worked here
+/// (see [`cache::last_good_release`]) precisely so a stale value costs nothing
+/// on a machine that has fetched before. Bump it when cutting a release.
+const OVERTURE_STAC_RELEASE_FALLBACK: &str = "2026-08-19.0";
 
 /// How many releases to request before giving up, so a broken host cannot stall the fetch.
 const OVERTURE_MAX_RELEASE_ATTEMPTS: usize = 3;
@@ -95,6 +149,21 @@ pub struct OsmRef {
     /// "way" or "relation" - matches `ProcessedElement::kind()`.
     kind: &'static str,
     id: u64,
+}
+
+impl OsmRef {
+    #[cfg(test)]
+    fn way(id: u64) -> Self {
+        Self { kind: "way", id }
+    }
+
+    #[cfg(test)]
+    fn relation(id: u64) -> Self {
+        Self {
+            kind: "relation",
+            id,
+        }
+    }
 }
 
 /// Attributes Overture holds for an OSM building that OSM itself does not.
@@ -335,6 +404,82 @@ pub(crate) struct OvertureBuilding {
     facade_material: Option<&'static str>,
 }
 
+// ─── Shared attribute interning ──────────────────────────────────────────
+//
+// Overture's schema is the same whether a row arrives as a Parquet record or as
+// a vector-tile attribute, so both providers intern through these tables. A
+// value outside the enum is dropped rather than carried as a heap string, and
+// keeping one definition is what stops the two paths drifting into rendering
+// the same building differently.
+
+/// Roof shape, mapped to its OSM spelling.
+///
+/// Both spellings of the three renamed values are accepted: the GeoParquet
+/// schema and the tile build do not always agree on `gable`/`gabled`.
+fn intern_roof_shape(value: &str) -> Option<&'static str> {
+    Some(match value {
+        "gabled" | "gable" => "gabled",
+        "hipped" | "hip" => "hipped",
+        "flat" => "flat",
+        "pyramidal" => "pyramidal",
+        "dome" | "onion" => "dome",
+        "skillion" | "shed" => "skillion",
+        "gambrel" => "gambrel",
+        "mansard" => "mansard",
+        "round" => "round",
+        "half_hipped" => "half_hipped",
+        "saltbox" => "saltbox",
+        "sawtooth" => "sawtooth",
+        "spherical" => "spherical",
+        _ => return None,
+    })
+}
+
+fn intern_roof_material(value: &str) -> Option<&'static str> {
+    Some(match value {
+        "concrete" => "concrete",
+        "copper" => "copper",
+        "eternit" => "eternit",
+        "glass" => "glass",
+        "grass" => "grass",
+        "gravel" => "gravel",
+        "metal" => "metal",
+        "plastic" => "plastic",
+        "roof_tiles" => "roof_tiles",
+        "slate" => "slate",
+        "solar_panels" => "solar_panels",
+        "thatch" => "thatch",
+        "tar_paper" => "tar_paper",
+        "wood" => "wood",
+        _ => return None,
+    })
+}
+
+fn intern_roof_orientation(value: &str) -> Option<&'static str> {
+    Some(match value {
+        "along" => "along",
+        "across" => "across",
+        _ => return None,
+    })
+}
+
+fn intern_facade_material(value: &str) -> Option<&'static str> {
+    Some(match value {
+        "brick" => "brick",
+        "cement_block" => "cement_block",
+        "clay" => "clay",
+        "concrete" => "concrete",
+        "glass" => "glass",
+        "metal" => "metal",
+        "plaster" => "plaster",
+        "plastic" => "plastic",
+        "stone" => "stone",
+        "timber_framing" => "timber_framing",
+        "wood" => "wood",
+        _ => return None,
+    })
+}
+
 // ─── Public API ──────────────────────────────────────────────────────────
 
 /// What a generation-path Overture fetch produces.
@@ -355,8 +500,13 @@ pub struct OvertureData {
 /// Buildings whose primary source is "OpenStreetMap" are excluded from
 /// `elements` to avoid duplicates with the existing OSM data pipeline; their
 /// conflated heights survive in `hints`.
-pub fn fetch_overture_buildings(bbox: &LLBBox, scale: f64, debug: bool) -> OvertureData {
-    match fetch_overture_buildings_inner(bbox, scale, debug) {
+pub fn fetch_overture_buildings(
+    bbox: &LLBBox,
+    scale: f64,
+    source: OvertureSource,
+    debug: bool,
+) -> OvertureData {
+    match fetch_overture_buildings_inner(bbox, scale, source, debug) {
         Ok(data) => data,
         Err(e) => {
             eprintln!(
@@ -497,6 +647,130 @@ fn overture_building_budget(bbox: &LLBBox) -> usize {
 pub(crate) fn collect_overture_buildings(
     client: &Client,
     bbox: &LLBBox,
+    source: OvertureSource,
+    include_osm_sourced: bool,
+    max_buildings: usize,
+    report_gaps: bool,
+    debug: bool,
+) -> Result<OvertureCollection, Box<dyn std::error::Error>> {
+    let started = std::time::Instant::now();
+    let before = stats::snapshot();
+    let result = collect_by_transport(
+        client,
+        bbox,
+        source,
+        include_osm_sourced,
+        max_buildings,
+        report_gaps,
+        debug,
+    );
+    if debug {
+        let after = stats::snapshot();
+        println!(
+            "Overture fetch: {:.2} MB over the network, {:.2} MB from cache, \
+             {} request(s), {:.1}s",
+            (after.0 - before.0) as f64 / 1_048_576.0,
+            (after.1 - before.1) as f64 / 1_048_576.0,
+            after.2 - before.2,
+            started.elapsed().as_secs_f64(),
+        );
+    }
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_by_transport(
+    client: &Client,
+    bbox: &LLBBox,
+    source: OvertureSource,
+    include_osm_sourced: bool,
+    max_buildings: usize,
+    report_gaps: bool,
+    debug: bool,
+) -> Result<OvertureCollection, Box<dyn std::error::Error>> {
+    let candidates = release_candidates(client, debug);
+
+    // Tiles first, unless the caller pinned Parquet or the area is large enough
+    // that whole row groups beat one request per square kilometre.
+    let try_tiles = source != OvertureSource::Parquet && tiles::covers_area(bbox);
+    if source == OvertureSource::Tiles && !tiles::covers_area(bbox) {
+        return Err(format!(
+            "--overture-source tiles was requested, but this area needs more than the \
+             {} tiles that path is cheaper for. Use auto or parquet.",
+            tiles::MAX_TILES
+        )
+        .into());
+    }
+
+    let mut tile_errors: Vec<String> = Vec::new();
+    if try_tiles {
+        for release in &candidates {
+            match tiles::collect_from_tiles(
+                client,
+                bbox,
+                release,
+                include_osm_sourced,
+                max_buildings,
+                report_gaps,
+                debug,
+            ) {
+                Ok(collection) => {
+                    if debug {
+                        println!("Using Overture release {release} (vector tiles)");
+                    }
+                    accept_release(release);
+                    return Ok(collection);
+                }
+                Err(e) => {
+                    if debug {
+                        println!("Overture tiles unavailable for release {release}: {e}");
+                    }
+                    tile_errors.push(format!("{release}: {e}"));
+                }
+            }
+        }
+        if source == OvertureSource::Tiles {
+            return Err(format!(
+                "no Overture tile archive could be read ({})",
+                tile_errors.join("; ")
+            )
+            .into());
+        }
+        // Auto: the archive is the faster path, not the only one. Said once,
+        // because a silent switch hides a bucket that has stopped answering -
+        // but only where the caller wants coverage warnings, since the 3D
+        // preview re-fetches on every pan and would repeat this endlessly.
+        if report_gaps {
+            eprintln!(
+                "{} Overture vector tiles unavailable ({}); falling back to the Parquet \
+                 partitions, which is slower but carries the same data.",
+                "Warning:".yellow().bold(),
+                tile_errors
+                    .first()
+                    .map(String::as_str)
+                    .unwrap_or("no releases to try")
+            );
+        }
+    }
+
+    collect_from_parquet(
+        client,
+        bbox,
+        &candidates,
+        include_osm_sourced,
+        max_buildings,
+        report_gaps,
+        debug,
+    )
+}
+
+/// The GeoParquet transport: a catalogue, then a footer and the matching row
+/// groups per overlapping partition.
+#[allow(clippy::too_many_arguments)]
+fn collect_from_parquet(
+    client: &Client,
+    bbox: &LLBBox,
+    candidates: &[String],
     include_osm_sourced: bool,
     max_buildings: usize,
     report_gaps: bool,
@@ -504,7 +778,33 @@ pub(crate) fn collect_overture_buildings(
 ) -> Result<OvertureCollection, Box<dyn std::error::Error>> {
     // List partition files whose geographic bounds overlap our bbox
     // (single ~230 KB STAC download instead of 512 HTTP requests)
-    let partition_urls = list_partition_files(client, bbox, debug)?;
+    let mut last_error: Box<dyn std::error::Error> =
+        "no Overture release candidates".to_string().into();
+    let mut resolved: Option<(&str, Vec<String>)> = None;
+    for release in candidates {
+        match list_partition_files(client, bbox, release, debug) {
+            Ok(urls) => {
+                if debug {
+                    println!("Using Overture release {release} (Parquet partitions)");
+                }
+                accept_release(release);
+                resolved = Some((release, urls));
+                break;
+            }
+            Err(e) => {
+                if debug {
+                    println!("Overture release {release} unavailable: {e}");
+                }
+                last_error = e;
+            }
+        }
+    }
+    // An empty list from a release that answered means the bbox covers no
+    // partitions - open ocean, say. Every release failing is a different thing
+    // entirely, and must not be reported as "no buildings here".
+    let Some((release, partition_urls)) = resolved else {
+        return Err(last_error);
+    };
     if partition_urls.is_empty() {
         if debug {
             println!("No Overture partitions overlap the bbox");
@@ -543,7 +843,7 @@ pub(crate) fn collect_overture_buildings(
             );
         }
 
-        match process_partition_file(client, url, bbox, debug) {
+        match process_partition_file(client, url, release, bbox, debug) {
             Ok((buildings, failed_row_groups)) => {
                 lost_row_groups += failed_row_groups;
                 for building in buildings {
@@ -607,6 +907,7 @@ pub(crate) fn collect_overture_buildings(
 fn fetch_overture_buildings_inner(
     bbox: &LLBBox,
     scale: f64,
+    source: OvertureSource,
     debug: bool,
 ) -> Result<OvertureData, Box<dyn std::error::Error>> {
     let client = overture_client()?;
@@ -617,7 +918,7 @@ fn fetch_overture_buildings_inner(
     let OvertureCollection {
         buildings: all_buildings,
         hints,
-    } = collect_overture_buildings(&client, bbox, false, budget, true, debug)?;
+    } = collect_overture_buildings(&client, bbox, source, false, budget, true, debug)?;
 
     if debug {
         println!(
@@ -689,69 +990,101 @@ fn parse_release_listing(body: &str) -> Result<Vec<String>, Box<dyn std::error::
 
 /// Release names currently published in the bucket, newest first.
 fn discover_releases(client: &Client) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    stats::record_request();
     let body = client
         .get(OVERTURE_RELEASE_LIST_URL)
         .send()?
         .error_for_status()?
         .text()?;
+    stats::record_network(body.len() as u64);
     parse_release_listing(&body)
 }
 
-/// Downloads the STAC index from the newest release that serves one, oldest tried last.
-fn fetch_stac_catalog(
-    client: &Client,
-    debug: bool,
-) -> Result<reqwest::blocking::Response, Box<dyn std::error::Error>> {
-    let releases = match discover_releases(client) {
+/// Releases to try, in order, newest first.
+///
+/// Discovery answers what is published right now. Behind it sit two fallbacks
+/// that matter only when discovery fails: the release that last actually served
+/// data on this machine, and finally the compile-time constant. That ordering is
+/// the point - the constant is a date, dates rot, and a machine that has fetched
+/// before already knows a better answer than a constant baked in months ago.
+fn release_candidates(client: &Client, debug: bool) -> Vec<String> {
+    let discovered = match discover_releases(client) {
         Ok(releases) => releases,
         Err(e) => {
             if debug {
-                println!("Overture release discovery failed ({e}), using bundled release");
+                println!("Overture release discovery failed ({e}), using remembered release");
             }
             Vec::new()
         }
     };
 
-    // Reserve the last attempt for the fallback so it stays reachable on a long listing.
-    let mut candidates: Vec<String> = releases
+    // Reserve the last attempts for the fallbacks so they stay reachable on a
+    // long listing.
+    let mut candidates: Vec<String> = discovered
         .into_iter()
+        .filter(|r| cache::is_valid_release(r))
         .take(OVERTURE_MAX_RELEASE_ATTEMPTS.saturating_sub(1))
         .collect();
-    if !candidates
-        .iter()
-        .any(|r| r == OVERTURE_STAC_RELEASE_FALLBACK)
+
+    for fallback in cache::last_good_release()
+        .into_iter()
+        .chain(std::iter::once(OVERTURE_STAC_RELEASE_FALLBACK.to_string()))
     {
-        candidates.push(OVERTURE_STAC_RELEASE_FALLBACK.to_string());
+        if !candidates.contains(&fallback) {
+            candidates.push(fallback);
+        }
     }
 
     if debug {
         println!("Overture releases to try: {}", candidates.join(", "));
     }
+    candidates
+}
 
-    let mut last_error = String::from("no Overture release candidates");
-    for release in &candidates {
-        let url = format!("{OVERTURE_STAC_ROOT}/{release}/collections.parquet");
-        match client.get(&url).send() {
-            Ok(response) if response.status().is_success() => {
-                if debug {
-                    println!("Using Overture release {release}");
-                }
-                return Ok(response);
-            }
-            Ok(response) => {
-                last_error = format!(
-                    "STAC catalog download failed with status {} (url: {url})",
-                    response.status()
-                );
-            }
-            Err(e) => last_error = format!("STAC catalog request failed: {e} (url: {url})"),
-        }
+/// Record `release` as usable and drop cached data from older ones.
+fn accept_release(release: &str) {
+    cache::set_last_good_release(release);
+    cache::prune_releases_older_than(release);
+}
+
+/// The STAC index for one release, from disk if it has been read before.
+///
+/// A release is immutable, so a cached index for it can never be stale and is
+/// returned without so much as a revalidation request. That matters because the
+/// index is ~233 KB and every Parquet fetch begins by reading all of it.
+fn stac_index_for(
+    client: &Client,
+    release: &str,
+    debug: bool,
+) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
+    let path = cache::release_dir(release).map(|d| d.join("stac_index.parquet"));
+    if let Some(cached) = path.as_ref().and_then(|p| cache::read(p)) {
+        stats::record_cached(cached.len() as u64);
         if debug {
-            println!("Overture release {release} unavailable: {last_error}");
+            println!(
+                "Overture release {release}: STAC index served from cache ({} KB)",
+                cached.len() / 1024
+            );
         }
+        return Ok(bytes::Bytes::from(cached));
     }
 
-    Err(last_error.into())
+    let url = format!("{OVERTURE_STAC_ROOT}/{release}/collections.parquet");
+    stats::record_request();
+    let response = client.get(&url).send()?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "STAC catalog download failed with status {} (url: {url})",
+            response.status()
+        )
+        .into());
+    }
+    let body = response.bytes()?;
+    stats::record_network(body.len() as u64);
+    if let Some(path) = &path {
+        cache::write_atomic(path, &body);
+    }
+    Ok(body)
 }
 
 /// List partition file URLs that overlap the target bbox.
@@ -763,11 +1096,10 @@ fn fetch_stac_catalog(
 fn list_partition_files(
     client: &Client,
     bbox: &LLBBox,
+    release: &str,
     debug: bool,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
-    // Resolve the current release dynamically; old releases are retired and 404.
-    let stac_bytes = fetch_stac_catalog(client, debug)?.bytes()?;
-    let reader = SerializedFileReader::new(stac_bytes)?;
+    let reader = SerializedFileReader::new(stac_index_for(client, release, debug)?)?;
 
     let target_min_lng = bbox.min().lng();
     let target_max_lng = bbox.max().lng();
@@ -894,21 +1226,15 @@ fn list_partition_files(
 fn process_partition_file(
     client: &Client,
     url: &str,
+    release: &str,
     bbox: &LLBBox,
     debug: bool,
 ) -> Result<(Vec<OvertureBuilding>, usize), Box<dyn std::error::Error>> {
-    // Step 1: Get file size via HEAD request
-    let head_resp = client.head(url).send()?;
-    if !head_resp.status().is_success() {
-        return Err(format!("HEAD request failed: {}", head_resp.status()).into());
-    }
+    let partition_cache = partition_cache_dir(release, url);
 
-    let file_size: u64 = head_resp
-        .headers()
-        .get("content-length")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse().ok())
-        .ok_or("Missing Content-Length header")?;
+    // Step 1: file size. Cached with the rest of the partition, because a
+    // release is immutable and so is the size of a file inside it.
+    let file_size: u64 = partition_size_cached(client, url, partition_cache.as_deref())?;
 
     if file_size < 12 {
         return Err("File too small to be valid Parquet".into());
@@ -917,7 +1243,7 @@ fn process_partition_file(
     // Step 2: Read the Parquet footer.
     // Parquet files end with: [footer bytes] [4-byte footer length (LE)] [4-byte magic "PAR1"]
     // First, read the last 8 bytes to get the footer length.
-    let tail = fetch_range(client, url, file_size - 8, 8)?;
+    let tail = fetch_partition_range(client, url, partition_cache.as_deref(), file_size - 8, 8)?;
     if tail.len() < 8 {
         return Err(format!(
             "Truncated Parquet tail: expected 8 bytes, got {}",
@@ -936,7 +1262,13 @@ fn process_partition_file(
 
     // Read the footer bytes
     let footer_start = file_size - 8 - footer_len;
-    let footer_bytes = fetch_range(client, url, footer_start, footer_len)?;
+    let footer_bytes = fetch_partition_range(
+        client,
+        url,
+        partition_cache.as_deref(),
+        footer_start,
+        footer_len,
+    )?;
 
     // Parse the footer using the parquet crate
     let metadata = parquet::file::metadata::ParquetMetaDataReader::decode_metadata(&footer_bytes)?;
@@ -979,7 +1311,14 @@ fn process_partition_file(
         } else {
             OVERTURE_RANGE_ATTEMPTS
         };
-        match fetch_range_with_attempts(client, url, rg_offset, rg_len, attempts) {
+        match fetch_partition_range_with_attempts(
+            client,
+            url,
+            partition_cache.as_deref(),
+            rg_offset,
+            rg_len,
+            attempts,
+        ) {
             Ok(rg_data) => {
                 downloaded_bytes += rg_len;
                 downloaded.insert(rg_idx);
@@ -1293,54 +1632,17 @@ fn parse_overture_row(
             }
             "roof_shape" => {
                 if let parquet::record::Field::Str(s) = field {
-                    // Closed enum, mapped to its OSM spelling here so the row carries
-                    // no heap string. A value outside the enum is dropped.
-                    roof_shape = match s.as_str() {
-                        "gabled" | "gable" => Some("gabled"),
-                        "hipped" | "hip" => Some("hipped"),
-                        "flat" => Some("flat"),
-                        "pyramidal" => Some("pyramidal"),
-                        "dome" | "onion" => Some("dome"),
-                        "skillion" | "shed" => Some("skillion"),
-                        "gambrel" => Some("gambrel"),
-                        "mansard" => Some("mansard"),
-                        "round" => Some("round"),
-                        "half_hipped" => Some("half_hipped"),
-                        "saltbox" => Some("saltbox"),
-                        "sawtooth" => Some("sawtooth"),
-                        "spherical" => Some("spherical"),
-                        _ => None,
-                    };
+                    roof_shape = intern_roof_shape(s);
                 }
             }
             "roof_material" => {
                 if let parquet::record::Field::Str(s) = field {
-                    roof_material = match s.as_str() {
-                        "concrete" => Some("concrete"),
-                        "copper" => Some("copper"),
-                        "eternit" => Some("eternit"),
-                        "glass" => Some("glass"),
-                        "grass" => Some("grass"),
-                        "gravel" => Some("gravel"),
-                        "metal" => Some("metal"),
-                        "plastic" => Some("plastic"),
-                        "roof_tiles" => Some("roof_tiles"),
-                        "slate" => Some("slate"),
-                        "solar_panels" => Some("solar_panels"),
-                        "thatch" => Some("thatch"),
-                        "tar_paper" => Some("tar_paper"),
-                        "wood" => Some("wood"),
-                        _ => None,
-                    };
+                    roof_material = intern_roof_material(s);
                 }
             }
             "roof_orientation" => {
                 if let parquet::record::Field::Str(s) = field {
-                    roof_orientation = match s.as_str() {
-                        "along" => Some("along"),
-                        "across" => Some("across"),
-                        _ => None,
-                    };
+                    roof_orientation = intern_roof_orientation(s);
                 }
             }
             "facade_color" => {
@@ -1362,21 +1664,7 @@ fn parse_overture_row(
             }
             "facade_material" => {
                 if let parquet::record::Field::Str(s) = field {
-                    // Interned, so the row allocates nothing and unknown values drop.
-                    facade_material = match s.as_str() {
-                        "brick" => Some("brick"),
-                        "cement_block" => Some("cement_block"),
-                        "clay" => Some("clay"),
-                        "concrete" => Some("concrete"),
-                        "glass" => Some("glass"),
-                        "metal" => Some("metal"),
-                        "plaster" => Some("plaster"),
-                        "plastic" => Some("plastic"),
-                        "stone" => Some("stone"),
-                        "timber_framing" => Some("timber_framing"),
-                        "wood" => Some("wood"),
-                        _ => None,
-                    };
+                    facade_material = intern_facade_material(s);
                 }
             }
             "bbox" => {
@@ -1912,14 +2200,107 @@ fn row_group_byte_range(metadata: &ParquetMetaData, rg_idx: usize) -> (u64, u64)
     (min_offset, max_end.saturating_sub(min_offset))
 }
 
-/// Fetch a byte range from a URL via HTTP Range request, retrying transient failures.
-fn fetch_range(
+// ─── Partition byte cache ────────────────────────────────────────────────
+//
+// A release is immutable, so every byte range read out of one of its partitions
+// is too. Row-group ranges are a function of the file rather than of the request,
+// so two runs over the same area - and usually two runs over the same city - ask
+// for exactly the same ranges. Without this the Parquet transport re-downloads
+// its ~1.3 MB footer and every matching row group on every single run.
+
+/// Cache directory for one partition file, or `None` when either the release or
+/// the file name is not something we will build a path from.
+fn partition_cache_dir(release: &str, url: &str) -> Option<std::path::PathBuf> {
+    let name = url.rsplit('/').next().filter(|segment| {
+        !segment.is_empty()
+            && segment.len() <= 128
+            && segment
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b"-_.".contains(&b))
+            && !segment.starts_with('.')
+    })?;
+    cache::release_dir(release).map(|d| d.join("parquet").join(name))
+}
+
+/// Size of a partition file, from cache when it has been read before.
+fn partition_size_cached(
     client: &Client,
     url: &str,
+    cache_dir: Option<&std::path::Path>,
+) -> Result<u64, Box<dyn std::error::Error>> {
+    let path = cache_dir.map(|d| d.join("size"));
+    if let Some(size) = path
+        .as_ref()
+        .and_then(|p| cache::read(p))
+        .and_then(|raw| String::from_utf8(raw).ok())
+        .and_then(|text| text.trim().parse::<u64>().ok())
+        .filter(|size| *size >= 12)
+    {
+        return Ok(size);
+    }
+
+    stats::record_request();
+    let head_resp = client.head(url).send()?;
+    if !head_resp.status().is_success() {
+        return Err(format!("HEAD request failed: {}", head_resp.status()).into());
+    }
+    let file_size: u64 = head_resp
+        .headers()
+        .get("content-length")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse().ok())
+        .ok_or("Missing Content-Length header")?;
+    if file_size < 12 {
+        return Err("File too small to be valid Parquet".into());
+    }
+    if let Some(path) = &path {
+        cache::write_atomic(path, file_size.to_string().as_bytes());
+    }
+    Ok(file_size)
+}
+
+/// Fetch a byte range of a partition, reading from and populating the cache.
+fn fetch_partition_range(
+    client: &Client,
+    url: &str,
+    cache_dir: Option<&std::path::Path>,
     start: u64,
     length: u64,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    fetch_range_with_attempts(client, url, start, length, OVERTURE_RANGE_ATTEMPTS)
+    fetch_partition_range_with_attempts(
+        client,
+        url,
+        cache_dir,
+        start,
+        length,
+        OVERTURE_RANGE_ATTEMPTS,
+    )
+}
+
+fn fetch_partition_range_with_attempts(
+    client: &Client,
+    url: &str,
+    cache_dir: Option<&std::path::Path>,
+    start: u64,
+    length: u64,
+    max_attempts: u32,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let path = cache_dir.map(|d| d.join(format!("{start}_{length}.bin")));
+    if let Some(path) = &path {
+        if let Some(bytes) = cache::read(path) {
+            // A short file is a write that did not finish; refetching costs one
+            // request, trusting it would corrupt a row group.
+            if bytes.len() as u64 == length {
+                stats::record_cached(length);
+                return Ok(bytes);
+            }
+        }
+    }
+    let bytes = fetch_range_with_attempts(client, url, start, length, max_attempts)?;
+    if let Some(path) = &path {
+        cache::write_atomic(path, &bytes);
+    }
+    Ok(bytes)
 }
 
 /// As [`fetch_range`], with the retry budget chosen by the caller.
@@ -1940,6 +2321,7 @@ fn fetch_range_with_attempts(
         if attempt > 0 {
             std::thread::sleep(Duration::from_millis(500 << (attempt - 1)));
         }
+        stats::record_request();
         let response = match client
             .get(url)
             .header("Range", format!("bytes={start}-{end}"))
@@ -1963,7 +2345,10 @@ fn fetch_range_with_attempts(
         }
 
         match response.bytes() {
-            Ok(body) => return Ok(body.to_vec()),
+            Ok(body) => {
+                stats::record_network(body.len() as u64);
+                return Ok(body.to_vec());
+            }
             Err(e) => last_error = format!("range body from {url} could not be read: {e}"),
         }
     }
@@ -2281,6 +2666,63 @@ mod tests {
             releases,
             vec!["2026-07-22.10", "2026-07-22.9", "2026-06-17.0"]
         );
+    }
+
+    #[test]
+    fn the_bundled_fallback_release_is_a_release_name() {
+        // It is used as a path segment for the cache and interpolated into a
+        // URL, so a typo here must fail the build, not a user's fetch.
+        assert!(cache::is_valid_release(OVERTURE_STAC_RELEASE_FALLBACK));
+    }
+
+    #[test]
+    fn partition_bytes_are_cached_under_their_release_and_file() {
+        let dir = partition_cache_dir(
+            "2026-08-19.0",
+            "https://overturemaps-us-west-2.s3.amazonaws.com/release/2026-08-19.0/\
+             theme=buildings/type=building/part-00042-abc-c000.zstd.parquet",
+        )
+        .expect("a normal partition URL is cacheable");
+        assert!(dir.ends_with("2026-08-19.0/parquet/part-00042-abc-c000.zstd.parquet"));
+
+        // Only the last URL segment is used, so `..` earlier in a path is
+        // discarded rather than traversed. What must be refused is a *segment*
+        // that would escape the directory or collide with our own bookkeeping.
+        for url in [
+            "https://host/a/..",
+            "https://host/a/.",
+            "https://host/a/",
+            "https://host/a/.hidden",
+            "https://host/a/name%2Fwith%2Fescapes",
+            "https://host/a/name with spaces",
+        ] {
+            assert!(
+                partition_cache_dir("2026-08-19.0", url).is_none(),
+                "{url} must not become a cache path"
+            );
+        }
+        // Whatever survives is a single harmless segment inside the release dir.
+        let odd = partition_cache_dir("2026-08-19.0", "https://host/release/../../etc/passwd")
+            .expect("a plain trailing name is usable");
+        assert_eq!(
+            odd,
+            cache::release_dir("2026-08-19.0")
+                .unwrap()
+                .join("parquet")
+                .join("passwd")
+        );
+
+        assert!(partition_cache_dir("../evil", "https://host/a/part-0.parquet").is_none());
+    }
+
+    #[test]
+    fn release_candidates_end_with_the_remembered_and_bundled_fallbacks() {
+        // Discovery is the first answer, but the list must always end somewhere
+        // usable: a machine offline at the bucket still has to try something.
+        assert!(cache::is_valid_release(OVERTURE_STAC_RELEASE_FALLBACK));
+        // Malformed names from a bucket listing never reach a URL or a path.
+        assert!(!cache::is_valid_release("release/2026-08-19.0"));
+        assert!(!cache::is_valid_release("latest"));
     }
 
     #[test]

--- a/src/overture/mvt.rs
+++ b/src/overture/mvt.rs
@@ -1,0 +1,644 @@
+//! Minimal Mapbox Vector Tile decoder.
+//!
+//! Only what Overture's building tiles need: layers, their key/value tables,
+//! and polygon rings. Points and linestrings are decoded to rings too, but the
+//! caller filters on `geom_type`.
+//!
+//! This parses bytes straight off the network, so every read is bounds-checked
+//! and every count that comes out of the input is bounded by the input that is
+//! actually left. A malformed tile returns an error or a short feature list; it
+//! never panics and never allocates on a length the file merely claims.
+
+/// Protobuf wire types we accept. Groups (3 and 4) are deprecated and rejected.
+const WIRE_VARINT: u8 = 0;
+const WIRE_64BIT: u8 = 1;
+const WIRE_LEN: u8 = 2;
+const WIRE_32BIT: u8 = 5;
+
+/// MVT geometry type for a polygon (`vector_tile.proto`, `GeomType.POLYGON`).
+pub const GEOM_POLYGON: u32 = 3;
+
+/// Default tile extent when a layer omits it, per the MVT specification.
+const DEFAULT_EXTENT: u32 = 4096;
+
+/// A tile is one protobuf message; anything larger than this is not a tile we
+/// asked for. Overture's densest z14 building tiles decompress to ~1.6 MB.
+const MAX_TILE_BYTES: usize = 64 * 1024 * 1024;
+
+pub type Result<T> = std::result::Result<T, String>;
+
+/// One value from a layer's value table.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Str(String),
+    F64(f64),
+    I64(i64),
+    U64(u64),
+    Bool(bool),
+}
+
+impl Value {
+    /// The value as a string, for attributes Overture encodes as text.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Value::Str(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// The value as a number, accepting every numeric encoding a writer may
+    /// have chosen. Overture's tiles store `num_floors` as an integer and
+    /// `height` as a float, but nothing in the format guarantees that, and a
+    /// re-encode with different types must not silently drop heights.
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            Value::F64(v) => Some(*v),
+            Value::I64(v) => Some(*v as f64),
+            Value::U64(v) => Some(*v as f64),
+            // A height written as the string "12.5" is still a height.
+            Value::Str(s) => s.trim().parse().ok(),
+            Value::Bool(_) => None,
+        }
+    }
+}
+
+/// A decoded polygon ring in tile-local integer coordinates.
+#[derive(Debug, Clone)]
+pub struct Ring {
+    pub points: Vec<(i32, i32)>,
+    /// True for an exterior ring. Per the MVT specification exterior rings wind
+    /// clockwise on screen, which in the tile's y-down coordinate system is a
+    /// positive shoelace sum.
+    pub exterior: bool,
+}
+
+/// One feature. Attributes stay as indices into the layer's tables so a tile
+/// with thousands of features allocates no string per attribute.
+#[derive(Debug, Clone)]
+pub struct Feature {
+    pub geom_type: u32,
+    /// Flat `(key_index, value_index)` pairs, as the format stores them.
+    pub tags: Vec<u32>,
+    pub rings: Vec<Ring>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Layer {
+    pub name: String,
+    pub extent: u32,
+    pub keys: Vec<String>,
+    pub values: Vec<Value>,
+    pub features: Vec<Feature>,
+}
+
+impl Layer {
+    /// Look up one attribute of a feature by key name.
+    pub fn attr(&self, feature: &Feature, key: &str) -> Option<&Value> {
+        // Tags are (key, value) pairs; an odd trailing entry is malformed and
+        // simply has no pair to read.
+        for pair in feature.tags.chunks_exact(2) {
+            let (k, v) = (pair[0] as usize, pair[1] as usize);
+            if self.keys.get(k).is_some_and(|name| name == key) {
+                return self.values.get(v);
+            }
+        }
+        None
+    }
+
+    /// The attribute as a string, for the common case.
+    pub fn attr_str(&self, feature: &Feature, key: &str) -> Option<&str> {
+        self.attr(feature, key).and_then(Value::as_str)
+    }
+
+    /// The attribute as a number, for the common case.
+    pub fn attr_f64(&self, feature: &Feature, key: &str) -> Option<f64> {
+        self.attr(feature, key).and_then(Value::as_f64)
+    }
+}
+
+// ─── Protobuf wire reader ────────────────────────────────────────────────
+
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn done(&self) -> bool {
+        self.pos >= self.buf.len()
+    }
+
+    fn remaining(&self) -> usize {
+        self.buf.len().saturating_sub(self.pos)
+    }
+
+    fn varint(&mut self) -> Result<u64> {
+        let mut value: u64 = 0;
+        let mut shift = 0u32;
+        loop {
+            let byte = *self
+                .buf
+                .get(self.pos)
+                .ok_or("truncated varint at end of buffer")?;
+            self.pos += 1;
+            value |= u64::from(byte & 0x7f) << shift;
+            if byte & 0x80 == 0 {
+                return Ok(value);
+            }
+            shift += 7;
+            // A protobuf varint is at most 10 bytes; past that the input is
+            // malformed and continuing would shift out of range.
+            if shift >= 64 {
+                return Err("varint longer than 64 bits".into());
+            }
+        }
+    }
+
+    fn bytes(&mut self, len: usize) -> Result<&'a [u8]> {
+        if len > self.remaining() {
+            return Err(format!(
+                "length-delimited field claims {len} bytes, {} remain",
+                self.remaining()
+            ));
+        }
+        let out = &self.buf[self.pos..self.pos + len];
+        self.pos += len;
+        Ok(out)
+    }
+
+    /// Next `(field_number, wire_type)`, or `None` at end of buffer.
+    fn key(&mut self) -> Result<Option<(u32, u8)>> {
+        if self.done() {
+            return Ok(None);
+        }
+        let key = self.varint()?;
+        let field = u32::try_from(key >> 3).map_err(|_| "field number out of range")?;
+        Ok(Some((field, (key & 7) as u8)))
+    }
+
+    /// Consume the value for a field we do not care about.
+    fn skip(&mut self, wire: u8) -> Result<()> {
+        match wire {
+            WIRE_VARINT => {
+                self.varint()?;
+            }
+            WIRE_64BIT => {
+                self.bytes(8)?;
+            }
+            WIRE_LEN => {
+                let len = usize::try_from(self.varint()?).map_err(|_| "field length overflow")?;
+                self.bytes(len)?;
+            }
+            WIRE_32BIT => {
+                self.bytes(4)?;
+            }
+            other => return Err(format!("unsupported protobuf wire type {other}")),
+        }
+        Ok(())
+    }
+
+    /// A length-delimited submessage.
+    fn message(&mut self) -> Result<Reader<'a>> {
+        let len = usize::try_from(self.varint()?).map_err(|_| "message length overflow")?;
+        Ok(Reader::new(self.bytes(len)?))
+    }
+
+    fn string(&mut self) -> Result<String> {
+        let len = usize::try_from(self.varint()?).map_err(|_| "string length overflow")?;
+        let raw = self.bytes(len)?;
+        // Overture writes UTF-8; a broken byte in a name must cost that name,
+        // not the tile.
+        Ok(String::from_utf8_lossy(raw).into_owned())
+    }
+
+    /// A packed repeated `uint32`. Also accepts the unpacked encoding, which
+    /// the specification still permits.
+    fn packed_u32(&mut self, wire: u8, out: &mut Vec<u32>) -> Result<()> {
+        match wire {
+            WIRE_VARINT => {
+                out.push(u32::try_from(self.varint()?).map_err(|_| "u32 out of range")?);
+            }
+            WIRE_LEN => {
+                let mut inner = self.message()?;
+                // One varint is at least one byte, so the byte length is a hard
+                // upper bound on the element count and reserving it is safe.
+                out.reserve(inner.remaining());
+                while !inner.done() {
+                    out.push(u32::try_from(inner.varint()?).map_err(|_| "u32 out of range")?);
+                }
+            }
+            other => return Err(format!("packed u32 field has wire type {other}")),
+        }
+        Ok(())
+    }
+}
+
+fn zigzag(value: u32) -> i32 {
+    ((value >> 1) as i32) ^ -((value & 1) as i32)
+}
+
+// ─── Message decoding ────────────────────────────────────────────────────
+
+/// Decode a tile into its layers.
+pub fn decode_tile(buf: &[u8]) -> Result<Vec<Layer>> {
+    if buf.len() > MAX_TILE_BYTES {
+        return Err(format!("tile is {} bytes, refusing to decode", buf.len()));
+    }
+    let mut reader = Reader::new(buf);
+    let mut layers = Vec::new();
+    while let Some((field, wire)) = reader.key()? {
+        match (field, wire) {
+            // Tile.layers
+            (3, WIRE_LEN) => layers.push(decode_layer(&mut reader.message()?)?),
+            _ => reader.skip(wire)?,
+        }
+    }
+    Ok(layers)
+}
+
+fn decode_layer(reader: &mut Reader<'_>) -> Result<Layer> {
+    let mut name = String::new();
+    let mut extent = DEFAULT_EXTENT;
+    let mut keys: Vec<String> = Vec::new();
+    let mut values: Vec<Value> = Vec::new();
+    // Features are decoded after the whole layer, because a writer is free to
+    // emit them before the extent that their geometry is expressed in.
+    let mut feature_bodies: Vec<&[u8]> = Vec::new();
+
+    while let Some((field, wire)) = reader.key()? {
+        match (field, wire) {
+            (1, WIRE_LEN) => name = reader.string()?,
+            (2, WIRE_LEN) => {
+                let len = usize::try_from(reader.varint()?).map_err(|_| "feature length")?;
+                feature_bodies.push(reader.bytes(len)?);
+            }
+            (3, WIRE_LEN) => keys.push(reader.string()?),
+            (4, WIRE_LEN) => values.push(decode_value(&mut reader.message()?)?),
+            (5, WIRE_VARINT) => {
+                let raw = reader.varint()?;
+                // Extent divides every coordinate; zero would make the tile
+                // transform undefined, so keep the specified default instead.
+                extent = u32::try_from(raw).unwrap_or(DEFAULT_EXTENT).max(1);
+            }
+            _ => reader.skip(wire)?,
+        }
+    }
+
+    let mut features = Vec::with_capacity(feature_bodies.len());
+    for body in feature_bodies {
+        // One unreadable feature costs that feature, not the layer: a tile with
+        // thousands of buildings should not be lost to one bad geometry.
+        if let Ok(feature) = decode_feature(&mut Reader::new(body)) {
+            features.push(feature);
+        }
+    }
+
+    Ok(Layer {
+        name,
+        extent,
+        keys,
+        values,
+        features,
+    })
+}
+
+fn decode_value(reader: &mut Reader<'_>) -> Result<Value> {
+    let mut value = Value::Bool(false);
+    while let Some((field, wire)) = reader.key()? {
+        match (field, wire) {
+            (1, WIRE_LEN) => value = Value::Str(reader.string()?),
+            (2, WIRE_32BIT) => {
+                let b = reader.bytes(4)?;
+                value = Value::F64(f32::from_le_bytes([b[0], b[1], b[2], b[3]]) as f64);
+            }
+            (3, WIRE_64BIT) => {
+                let b = reader.bytes(8)?;
+                let mut arr = [0u8; 8];
+                arr.copy_from_slice(b);
+                value = Value::F64(f64::from_le_bytes(arr));
+            }
+            (4, WIRE_VARINT) => value = Value::I64(reader.varint()? as i64),
+            (5, WIRE_VARINT) => value = Value::U64(reader.varint()?),
+            (6, WIRE_VARINT) => {
+                let raw = reader.varint()?;
+                value = Value::I64(((raw >> 1) as i64) ^ -((raw & 1) as i64));
+            }
+            (7, WIRE_VARINT) => value = Value::Bool(reader.varint()? != 0),
+            _ => reader.skip(wire)?,
+        }
+    }
+    Ok(value)
+}
+
+fn decode_feature(reader: &mut Reader<'_>) -> Result<Feature> {
+    let mut geom_type = 0u32;
+    let mut tags: Vec<u32> = Vec::new();
+    let mut geometry: Vec<u32> = Vec::new();
+
+    while let Some((field, wire)) = reader.key()? {
+        match field {
+            // Feature.id - not used; Overture's own `id` attribute is the GERS id.
+            1 => reader.skip(wire)?,
+            2 => reader.packed_u32(wire, &mut tags)?,
+            3 if wire == WIRE_VARINT => {
+                geom_type = u32::try_from(reader.varint()?).unwrap_or(0);
+            }
+            4 => reader.packed_u32(wire, &mut geometry)?,
+            _ => reader.skip(wire)?,
+        }
+    }
+
+    Ok(Feature {
+        geom_type,
+        tags,
+        rings: decode_geometry(&geometry),
+    })
+}
+
+/// Decode MVT command/parameter integers into rings.
+///
+/// Commands are `(id & 0x7) | (count << 3)`; `MoveTo` (1) and `LineTo` (2) each
+/// take two zigzag parameters per repetition, `ClosePath` (7) takes none.
+/// Coordinates are cursor deltas, so a truncated stream simply ends the ring
+/// rather than corrupting the ones already read.
+fn decode_geometry(geometry: &[u32]) -> Vec<Ring> {
+    let mut rings: Vec<Ring> = Vec::new();
+    let mut current: Vec<(i32, i32)> = Vec::new();
+    let (mut x, mut y) = (0i32, 0i32);
+    let mut i = 0usize;
+
+    let flush = |points: &mut Vec<(i32, i32)>, rings: &mut Vec<Ring>| {
+        // Two points cannot bound an area; a degenerate ring is dropped rather
+        // than passed on as a zero-area polygon.
+        if points.len() >= 3 {
+            let ring = std::mem::take(points);
+            let exterior = shoelace2(&ring) > 0;
+            rings.push(Ring {
+                points: ring,
+                exterior,
+            });
+        } else {
+            points.clear();
+        }
+    };
+
+    while i < geometry.len() {
+        let command = geometry[i];
+        i += 1;
+        let id = command & 0x7;
+        let count = (command >> 3) as usize;
+
+        match id {
+            // MoveTo: starts a new ring at an absolute (delta-accumulated) point.
+            1 => {
+                for _ in 0..count {
+                    let Some(&dx) = geometry.get(i) else { break };
+                    let Some(&dy) = geometry.get(i + 1) else {
+                        break;
+                    };
+                    i += 2;
+                    x = x.wrapping_add(zigzag(dx));
+                    y = y.wrapping_add(zigzag(dy));
+                    flush(&mut current, &mut rings);
+                    current.push((x, y));
+                }
+            }
+            // LineTo: extends the current ring.
+            2 => {
+                current.reserve(count.min(geometry.len().saturating_sub(i) / 2));
+                for _ in 0..count {
+                    let Some(&dx) = geometry.get(i) else { break };
+                    let Some(&dy) = geometry.get(i + 1) else {
+                        break;
+                    };
+                    i += 2;
+                    x = x.wrapping_add(zigzag(dx));
+                    y = y.wrapping_add(zigzag(dy));
+                    current.push((x, y));
+                }
+            }
+            // ClosePath: the ring is implicitly closed, so nothing is appended.
+            7 => flush(&mut current, &mut rings),
+            // An unknown command id means the rest of the stream cannot be
+            // located; keep what has been read.
+            _ => break,
+        }
+    }
+    flush(&mut current, &mut rings);
+    rings
+}
+
+/// Twice the signed area of a ring. Positive means clockwise on screen in the
+/// tile's y-down coordinate system, which the MVT specification defines as an
+/// exterior ring. `i64` because coordinates can reach the buffer bounds and the
+/// products would overflow `i32`.
+fn shoelace2(points: &[(i32, i32)]) -> i64 {
+    let mut sum: i64 = 0;
+    for idx in 0..points.len() {
+        let (x1, y1) = points[idx];
+        let (x2, y2) = points[(idx + 1) % points.len()];
+        sum += i64::from(x1) * i64::from(y2) - i64::from(x2) * i64::from(y1);
+    }
+    sum
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a protobuf varint.
+    fn varint(mut v: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        loop {
+            let byte = (v & 0x7f) as u8;
+            v >>= 7;
+            if v == 0 {
+                out.push(byte);
+                return out;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+
+    fn key(field: u32, wire: u8) -> Vec<u8> {
+        varint((u64::from(field) << 3) | u64::from(wire))
+    }
+
+    fn len_field(field: u32, body: &[u8]) -> Vec<u8> {
+        let mut out = key(field, WIRE_LEN);
+        out.extend(varint(body.len() as u64));
+        out.extend_from_slice(body);
+        out
+    }
+
+    fn zz(v: i32) -> u32 {
+        ((v << 1) ^ (v >> 31)) as u32
+    }
+
+    fn packed(values: &[u32]) -> Vec<u8> {
+        let mut body = Vec::new();
+        for v in values {
+            body.extend(varint(u64::from(*v)));
+        }
+        body
+    }
+
+    /// One square building, clockwise on screen, with a string and a number.
+    fn sample_tile() -> Vec<u8> {
+        let geometry = packed(&[
+            (1 << 3) | 1, // MoveTo, 1
+            zz(10),
+            zz(10),
+            (3 << 3) | 2, // LineTo, 3
+            zz(20),
+            zz(0),
+            zz(0),
+            zz(20),
+            zz(-20),
+            zz(0),
+            7 | (1 << 3), // ClosePath
+        ]);
+
+        let mut feature = Vec::new();
+        feature.extend(len_field(2, &packed(&[0, 0, 1, 1]))); // tags
+        feature.extend(key(3, WIRE_VARINT));
+        feature.extend(varint(u64::from(GEOM_POLYGON)));
+        feature.extend(len_field(4, &geometry));
+
+        let mut string_value = Vec::new();
+        string_value.extend(len_field(1, b"OpenStreetMap"));
+        let mut double_value = Vec::new();
+        double_value.extend(key(3, WIRE_64BIT));
+        double_value.extend_from_slice(&12.5f64.to_le_bytes());
+
+        let mut layer = Vec::new();
+        layer.extend(len_field(1, b"building"));
+        layer.extend(len_field(2, &feature));
+        layer.extend(len_field(3, b"@geometry_source"));
+        layer.extend(len_field(3, b"height"));
+        layer.extend(len_field(4, &string_value));
+        layer.extend(len_field(4, &double_value));
+        layer.extend(key(5, WIRE_VARINT));
+        layer.extend(varint(4096));
+
+        len_field(3, &layer)
+    }
+
+    #[test]
+    fn decodes_a_layer_with_attributes_and_one_exterior_ring() {
+        let layers = decode_tile(&sample_tile()).unwrap();
+        assert_eq!(layers.len(), 1);
+        let layer = &layers[0];
+        assert_eq!(layer.name, "building");
+        assert_eq!(layer.extent, 4096);
+        assert_eq!(layer.features.len(), 1);
+
+        let feature = &layer.features[0];
+        assert_eq!(feature.geom_type, GEOM_POLYGON);
+        assert_eq!(
+            layer.attr_str(feature, "@geometry_source"),
+            Some("OpenStreetMap")
+        );
+        assert_eq!(layer.attr_f64(feature, "height"), Some(12.5));
+        assert_eq!(layer.attr(feature, "absent"), None);
+
+        assert_eq!(feature.rings.len(), 1);
+        let ring = &feature.rings[0];
+        assert!(ring.exterior, "clockwise-on-screen ring must be exterior");
+        assert_eq!(
+            ring.points,
+            vec![(10, 10), (30, 10), (30, 30), (10, 30)],
+            "cursor deltas must accumulate"
+        );
+    }
+
+    #[test]
+    fn a_counter_clockwise_ring_is_a_hole() {
+        // Same square, wound the other way.
+        let ring = vec![(10, 10), (10, 30), (30, 30), (30, 10)];
+        assert!(shoelace2(&ring) < 0);
+        let rings = decode_geometry(&[
+            (1 << 3) | 1,
+            zz(10),
+            zz(10),
+            (3 << 3) | 2,
+            zz(0),
+            zz(20),
+            zz(20),
+            zz(0),
+            zz(0),
+            zz(-20),
+            7 | (1 << 3),
+        ]);
+        assert_eq!(rings.len(), 1);
+        assert!(!rings[0].exterior);
+    }
+
+    #[test]
+    fn a_multipolygon_yields_one_exterior_ring_per_part() {
+        // Two separate squares in one feature.
+        let mut cmds = vec![(1 << 3) | 1, zz(0), zz(0), (3 << 3) | 2];
+        cmds.extend([zz(10), zz(0), zz(0), zz(10), zz(-10), zz(0)]);
+        cmds.push(7 | (1 << 3));
+        cmds.extend([(1 << 3) | 1, zz(50), zz(0), (3 << 3) | 2]);
+        cmds.extend([zz(10), zz(0), zz(0), zz(10), zz(-10), zz(0)]);
+        cmds.push(7 | (1 << 3));
+
+        let rings = decode_geometry(&cmds);
+        assert_eq!(rings.len(), 2);
+        assert!(rings.iter().all(|r| r.exterior));
+    }
+
+    #[test]
+    fn truncated_and_malformed_input_is_rejected_without_panicking() {
+        let tile = sample_tile();
+        // Every prefix of a valid tile must either decode or error, never panic.
+        for cut in 0..tile.len() {
+            let _ = decode_tile(&tile[..cut]);
+        }
+        // A varint that never terminates.
+        assert!(decode_tile(&[0x1a, 0x02, 0xff, 0xff]).is_err());
+        // A length-delimited field claiming more bytes than exist.
+        assert!(decode_tile(&[0x1a, 0x7f, 0x00]).is_err());
+        // Deprecated group wire types are refused rather than mis-parsed.
+        assert!(decode_tile(&[0x1b]).is_err());
+    }
+
+    #[test]
+    fn a_geometry_that_runs_short_keeps_the_points_it_had() {
+        // LineTo claims three points but only supplies one.
+        let rings = decode_geometry(&[
+            (1 << 3) | 1,
+            zz(0),
+            zz(0),
+            (3 << 3) | 2,
+            zz(10),
+            zz(0),
+            zz(0),
+            zz(10),
+        ]);
+        assert_eq!(rings.len(), 1);
+        assert_eq!(rings[0].points, vec![(0, 0), (10, 0), (10, 10)]);
+    }
+
+    #[test]
+    fn degenerate_rings_are_dropped() {
+        // Two points cannot bound an area.
+        let rings = decode_geometry(&[(1 << 3) | 1, zz(0), zz(0), (1 << 3) | 2, zz(5), zz(5)]);
+        assert!(rings.is_empty());
+    }
+
+    #[test]
+    fn numbers_are_read_from_every_encoding_a_writer_may_use() {
+        assert_eq!(Value::F64(3.5).as_f64(), Some(3.5));
+        assert_eq!(Value::I64(7).as_f64(), Some(7.0));
+        assert_eq!(Value::U64(9).as_f64(), Some(9.0));
+        assert_eq!(Value::Str("12.5".into()).as_f64(), Some(12.5));
+        assert_eq!(Value::Str("tall".into()).as_f64(), None);
+        assert_eq!(Value::Bool(true).as_f64(), None);
+    }
+}

--- a/src/overture/mvt.rs
+++ b/src/overture/mvt.rs
@@ -237,10 +237,9 @@ impl<'a> Reader<'a> {
             }
             WIRE_LEN => {
                 let mut inner = self.message()?;
-                // Deliberately no `reserve` here. The byte length bounds the
-                // element count, but each element is four bytes, so reserving
-                // from it would allocate four times a field size that the tile
-                // itself chooses. Amortised growth costs less than trusting it.
+                // No `reserve` here. The byte length bounds the element
+                // count, but each element is four bytes, so reserving from it
+                // would allocate four times a length the tile chooses.
                 while !inner.done() {
                     out.push(u32::try_from(inner.varint()?).map_err(|_| "u32 out of range")?);
                 }
@@ -451,10 +450,9 @@ fn decode_geometry(geometry: &[u32]) -> Vec<Ring> {
 /// exterior ring.
 ///
 /// `i128`, not `i64`. Coordinates accumulate from cursor deltas and can reach
-/// any `i32`, so one term is up to 2^62 and just three of them overflow an
-/// `i64` accumulator - which this crate builds with `overflow-checks = true`,
-/// so it would panic in release on a malformed tile rather than merely give a
-/// wrong sign. This function is on the no-panic path for network data.
+/// any `i32`, so one term is up to 2^62 and three of them overflow an `i64`
+/// accumulator. This crate builds with `overflow-checks = true`, so that would
+/// panic in a release build on a malformed tile.
 fn shoelace2(points: &[(i32, i32)]) -> i128 {
     let mut sum: i128 = 0;
     for idx in 0..points.len() {

--- a/src/overture/mvt.rs
+++ b/src/overture/mvt.rs
@@ -66,10 +66,23 @@ impl Value {
 #[derive(Debug, Clone)]
 pub struct Ring {
     pub points: Vec<(i32, i32)>,
-    /// True for an exterior ring. Per the MVT specification exterior rings wind
-    /// clockwise on screen, which in the tile's y-down coordinate system is a
-    /// positive shoelace sum.
-    pub exterior: bool,
+    /// Twice the ring's signed area, kept because callers need it both to tell
+    /// an exterior ring from a hole and to pick the largest part of a
+    /// multipolygon - and recomputing it per ring is pure waste.
+    pub area2: i128,
+}
+
+impl Ring {
+    /// Per the MVT specification exterior rings wind clockwise on screen, which
+    /// in the tile's y-down coordinate system is a positive shoelace sum.
+    pub fn exterior(&self) -> bool {
+        self.area2 > 0
+    }
+
+    /// Twice the ring's unsigned area, for comparing parts of one polygon.
+    pub fn area2_abs(&self) -> i128 {
+        self.area2.unsigned_abs() as i128
+    }
 }
 
 /// One feature. Attributes stay as indices into the layer's tables so a tile
@@ -377,10 +390,10 @@ fn decode_geometry(geometry: &[u32]) -> Vec<Ring> {
         // than passed on as a zero-area polygon.
         if points.len() >= 3 {
             let ring = std::mem::take(points);
-            let exterior = shoelace2(&ring) > 0;
+            let area2 = shoelace2(&ring);
             rings.push(Ring {
                 points: ring,
-                exterior,
+                area2,
             });
         } else {
             points.clear();
@@ -435,14 +448,19 @@ fn decode_geometry(geometry: &[u32]) -> Vec<Ring> {
 
 /// Twice the signed area of a ring. Positive means clockwise on screen in the
 /// tile's y-down coordinate system, which the MVT specification defines as an
-/// exterior ring. `i64` because coordinates can reach the buffer bounds and the
-/// products would overflow `i32`.
-fn shoelace2(points: &[(i32, i32)]) -> i64 {
-    let mut sum: i64 = 0;
+/// exterior ring.
+///
+/// `i128`, not `i64`. Coordinates accumulate from cursor deltas and can reach
+/// any `i32`, so one term is up to 2^62 and just three of them overflow an
+/// `i64` accumulator - which this crate builds with `overflow-checks = true`,
+/// so it would panic in release on a malformed tile rather than merely give a
+/// wrong sign. This function is on the no-panic path for network data.
+fn shoelace2(points: &[(i32, i32)]) -> i128 {
+    let mut sum: i128 = 0;
     for idx in 0..points.len() {
         let (x1, y1) = points[idx];
         let (x2, y2) = points[(idx + 1) % points.len()];
-        sum += i64::from(x1) * i64::from(y2) - i64::from(x2) * i64::from(y1);
+        sum += i128::from(x1) * i128::from(y2) - i128::from(x2) * i128::from(y1);
     }
     sum
 }
@@ -549,7 +567,7 @@ mod tests {
 
         assert_eq!(feature.rings.len(), 1);
         let ring = &feature.rings[0];
-        assert!(ring.exterior, "clockwise-on-screen ring must be exterior");
+        assert!(ring.exterior(), "clockwise-on-screen ring must be exterior");
         assert_eq!(
             ring.points,
             vec![(10, 10), (30, 10), (30, 30), (10, 30)],
@@ -576,7 +594,7 @@ mod tests {
             7 | (1 << 3),
         ]);
         assert_eq!(rings.len(), 1);
-        assert!(!rings[0].exterior);
+        assert!(!rings[0].exterior());
     }
 
     #[test]
@@ -591,7 +609,7 @@ mod tests {
 
         let rings = decode_geometry(&cmds);
         assert_eq!(rings.len(), 2);
-        assert!(rings.iter().all(|r| r.exterior));
+        assert!(rings.iter().all(|r| r.exterior()));
     }
 
     #[test]
@@ -624,6 +642,66 @@ mod tests {
         ]);
         assert_eq!(rings.len(), 1);
         assert_eq!(rings[0].points, vec![(0, 0), (10, 0), (10, 10)]);
+    }
+
+    #[test]
+    fn an_extreme_ring_computes_its_area_without_overflowing() {
+        // Coordinates accumulate from cursor deltas and can reach any i32. With
+        // an i64 accumulator three of these terms overflow, and this crate
+        // builds with overflow-checks on, so that would panic in release.
+        let extreme = vec![
+            (i32::MIN, i32::MIN),
+            (i32::MAX, i32::MIN),
+            (i32::MAX, i32::MAX),
+            (i32::MIN, i32::MAX),
+        ];
+        let area2 = shoelace2(&extreme);
+        assert!(area2.unsigned_abs() > u64::MAX as u128, "area needs i128");
+
+        // And the same through the public decoder, which is the contract that
+        // matters: malformed input must not panic.
+        let rings = decode_geometry(&[
+            (1 << 3) | 1,
+            zz(i32::MIN),
+            zz(i32::MIN),
+            (3 << 3) | 2,
+            zz(i32::MAX),
+            zz(0),
+            zz(0),
+            zz(i32::MAX),
+            zz(i32::MIN),
+            zz(0),
+            7 | (1 << 3),
+        ]);
+        assert_eq!(rings.len(), 1);
+    }
+
+    #[test]
+    fn the_largest_part_of_a_multipolygon_is_the_one_with_the_most_area() {
+        // A big plain square and a small many-sided one. Picking by vertex
+        // count would choose the outbuilding over the building.
+        let mut cmds = vec![(1 << 3) | 1, zz(0), zz(0), (3 << 3) | 2];
+        cmds.extend([zz(1000), zz(0), zz(0), zz(1000), zz(-1000), zz(0)]);
+        cmds.push(7 | (1 << 3));
+        cmds.extend([(1 << 3) | 1, zz(2000), zz(0), (7 << 3) | 2]);
+        for step in [
+            (10, 0),
+            (10, 0),
+            (0, 10),
+            (0, 10),
+            (-10, 0),
+            (-10, 0),
+            (0, -10),
+        ] {
+            cmds.extend([zz(step.0), zz(step.1)]);
+        }
+        cmds.push(7 | (1 << 3));
+
+        let rings = decode_geometry(&cmds);
+        assert_eq!(rings.len(), 2);
+        assert!(rings[1].points.len() > rings[0].points.len(), "setup");
+        let largest = rings.iter().max_by_key(|r| r.area2_abs()).unwrap();
+        assert_eq!(largest.points.len(), rings[0].points.len());
     }
 
     #[test]

--- a/src/overture/mvt.rs
+++ b/src/overture/mvt.rs
@@ -96,8 +96,8 @@ impl Layer {
     pub fn attr(&self, feature: &Feature, key: &str) -> Option<&Value> {
         // Tags are (key, value) pairs; an odd trailing entry is malformed and
         // simply has no pair to read.
-        for pair in feature.tags.chunks_exact(2) {
-            let (k, v) = (pair[0] as usize, pair[1] as usize);
+        for &[key_index, value_index] in feature.tags.as_chunks::<2>().0 {
+            let (k, v) = (key_index as usize, value_index as usize);
             if self.keys.get(k).is_some_and(|name| name == key) {
                 return self.values.get(v);
             }
@@ -224,9 +224,10 @@ impl<'a> Reader<'a> {
             }
             WIRE_LEN => {
                 let mut inner = self.message()?;
-                // One varint is at least one byte, so the byte length is a hard
-                // upper bound on the element count and reserving it is safe.
-                out.reserve(inner.remaining());
+                // Deliberately no `reserve` here. The byte length bounds the
+                // element count, but each element is four bytes, so reserving
+                // from it would allocate four times a field size that the tile
+                // itself chooses. Amortised growth costs less than trusting it.
                 while !inner.done() {
                     out.push(u32::try_from(inner.varint()?).map_err(|_| "u32 out of range")?);
                 }

--- a/src/overture/pmtiles.rs
+++ b/src/overture/pmtiles.rs
@@ -1,0 +1,743 @@
+//! PMTiles v3 archive reader, over HTTP range requests and a disk cache.
+//!
+//! Overture publishes its themes as single planet-scale PMTiles archives in the
+//! `overturemaps-extras` bucket (`tiles/<release>/buildings.pmtiles`, ~180 GB).
+//! The format is a header, a root directory, optional leaf directories and the
+//! tile data, all addressable by byte range - so reading one city means reading
+//! a header, one directory page and a handful of tiles, never the archive.
+//!
+//! Only what Arnis needs is implemented: directory lookup and tile retrieval.
+//! Writing, clustering guarantees and the deduplication that `run_length`
+//! expresses are read, not produced.
+//!
+//! Specification: <https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md>
+
+use reqwest::blocking::Client;
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::PathBuf;
+
+use super::cache;
+use super::stats;
+
+/// Fixed size of a v3 header, in bytes.
+const HEADER_LEN: usize = 127;
+
+/// First read of a new archive. Large enough that the header and the whole root
+/// directory almost always arrive together (Overture's is ~14 KB), so opening an
+/// archive costs one request rather than two.
+const HEADER_PROBE_LEN: u64 = 16 * 1024;
+
+/// A directory that claims more than this is not one we can use, and reserving
+/// for it would be a denial of service on a corrupt or hostile archive.
+const MAX_DIRECTORY_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Guards against a directory whose entry count is inconsistent with its bytes.
+const MAX_DIRECTORY_ENTRIES: u64 = 8 * 1024 * 1024;
+
+/// Leaf descents before a lookup gives up. The format allows nesting; two levels
+/// is all any published archive uses, and a cycle must not hang generation.
+const MAX_LEAF_DEPTH: usize = 4;
+
+/// Compression identifiers from the specification.
+const COMPRESSION_NONE: u8 = 1;
+const COMPRESSION_GZIP: u8 = 2;
+const COMPRESSION_BROTLI: u8 = 3;
+const COMPRESSION_ZSTD: u8 = 4;
+
+/// Tile type identifier for Mapbox Vector Tiles.
+const TILE_TYPE_MVT: u8 = 1;
+
+pub type Result<T> = std::result::Result<T, String>;
+
+/// The parts of a v3 header this reader uses.
+#[derive(Debug, Clone, Copy)]
+pub struct Header {
+    root_offset: u64,
+    root_length: u64,
+    leaf_offset: u64,
+    tile_data_offset: u64,
+    internal_compression: u8,
+    tile_compression: u8,
+    pub min_zoom: u8,
+    pub max_zoom: u8,
+}
+
+/// One directory entry. `run_length == 0` marks a pointer to a leaf directory
+/// rather than to tile data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Entry {
+    tile_id: u64,
+    run_length: u32,
+    length: u32,
+    offset: u64,
+}
+
+/// Where a tile's bytes live in the archive, and how long they are.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TileLocation {
+    pub offset: u64,
+    pub length: u32,
+}
+
+fn parse_u64(buf: &[u8], at: usize) -> u64 {
+    let mut arr = [0u8; 8];
+    arr.copy_from_slice(&buf[at..at + 8]);
+    u64::from_le_bytes(arr)
+}
+
+impl Header {
+    fn parse(buf: &[u8]) -> Result<Header> {
+        if buf.len() < HEADER_LEN {
+            return Err(format!(
+                "PMTiles header is {} bytes, expected {HEADER_LEN}",
+                buf.len()
+            ));
+        }
+        if &buf[0..7] != b"PMTiles" {
+            return Err("not a PMTiles archive (bad magic)".into());
+        }
+        if buf[7] != 3 {
+            return Err(format!("PMTiles version {} is not supported", buf[7]));
+        }
+        let header = Header {
+            root_offset: parse_u64(buf, 8),
+            root_length: parse_u64(buf, 16),
+            leaf_offset: parse_u64(buf, 40),
+            tile_data_offset: parse_u64(buf, 56),
+            internal_compression: buf[97],
+            tile_compression: buf[98],
+            min_zoom: buf[100],
+            max_zoom: buf[101],
+        };
+        if buf[99] != TILE_TYPE_MVT {
+            return Err(format!(
+                "archive holds tile type {}, expected Mapbox Vector Tiles",
+                buf[99]
+            ));
+        }
+        if header.root_length == 0 || header.root_length > MAX_DIRECTORY_BYTES {
+            return Err(format!(
+                "root directory length {} is out of range",
+                header.root_length
+            ));
+        }
+        Ok(header)
+    }
+}
+
+/// Undo the archive's declared compression.
+fn decompress(kind: u8, data: Vec<u8>) -> Result<Vec<u8>> {
+    match kind {
+        COMPRESSION_NONE => Ok(data),
+        COMPRESSION_GZIP => {
+            let mut out = Vec::new();
+            flate2::read::GzDecoder::new(data.as_slice())
+                .read_to_end(&mut out)
+                .map_err(|e| format!("gzip decode failed: {e}"))?;
+            Ok(out)
+        }
+        COMPRESSION_ZSTD => {
+            zstd::decode_all(data.as_slice()).map_err(|e| format!("zstd decode failed: {e}"))
+        }
+        COMPRESSION_BROTLI => Err("archive uses brotli, which Arnis does not link".into()),
+        other => Err(format!("unknown PMTiles compression {other}")),
+    }
+}
+
+// ─── Directory decoding ──────────────────────────────────────────────────
+
+struct Varints<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl Varints<'_> {
+    fn next(&mut self) -> Result<u64> {
+        let mut value = 0u64;
+        let mut shift = 0u32;
+        loop {
+            let byte = *self.buf.get(self.pos).ok_or("directory ended mid-varint")?;
+            self.pos += 1;
+            value |= u64::from(byte & 0x7f) << shift;
+            if byte & 0x80 == 0 {
+                return Ok(value);
+            }
+            shift += 7;
+            if shift >= 64 {
+                return Err("directory varint longer than 64 bits".into());
+            }
+        }
+    }
+}
+
+/// Decode a directory: a count, then four parallel arrays.
+///
+/// `offset` is delta-encoded against the previous entry: a stored zero means
+/// "immediately after the previous entry", and any other value is the real
+/// offset plus one.
+fn decode_directory(buf: &[u8]) -> Result<Vec<Entry>> {
+    let mut reader = Varints { buf, pos: 0 };
+    let count = reader.next()?;
+    if count > MAX_DIRECTORY_ENTRIES || count > buf.len() as u64 {
+        return Err(format!("directory claims {count} entries"));
+    }
+    let count = count as usize;
+    let mut entries = vec![
+        Entry {
+            tile_id: 0,
+            run_length: 0,
+            length: 0,
+            offset: 0,
+        };
+        count
+    ];
+
+    let mut tile_id = 0u64;
+    for entry in entries.iter_mut() {
+        tile_id = tile_id
+            .checked_add(reader.next()?)
+            .ok_or("tile id overflowed")?;
+        entry.tile_id = tile_id;
+    }
+    for entry in entries.iter_mut() {
+        entry.run_length = u32::try_from(reader.next()?).map_err(|_| "run length out of range")?;
+    }
+    for entry in entries.iter_mut() {
+        entry.length = u32::try_from(reader.next()?).map_err(|_| "entry length out of range")?;
+    }
+    for index in 0..count {
+        let raw = reader.next()?;
+        entries[index].offset = if raw == 0 {
+            let previous = index
+                .checked_sub(1)
+                .ok_or("first directory entry uses the contiguous-offset marker")?;
+            entries[previous]
+                .offset
+                .checked_add(u64::from(entries[previous].length))
+                .ok_or("entry offset overflowed")?
+        } else {
+            raw - 1
+        };
+    }
+    Ok(entries)
+}
+
+/// The entry covering `tile_id`, or `None` when the archive has no such tile.
+///
+/// Entries are sorted by tile id, so this is a binary search for the last entry
+/// that starts at or before the target; a run then has to actually reach it.
+fn find_entry(entries: &[Entry], tile_id: u64) -> Option<Entry> {
+    let index = entries
+        .partition_point(|e| e.tile_id <= tile_id)
+        .checked_sub(1)?;
+    let entry = entries[index];
+    if entry.run_length == 0 {
+        // A leaf pointer covers everything from here to the next entry.
+        return Some(entry);
+    }
+    (tile_id < entry.tile_id.saturating_add(u64::from(entry.run_length))).then_some(entry)
+}
+
+// ─── Tile addressing ─────────────────────────────────────────────────────
+
+/// PMTiles orders tiles along a Hilbert curve, zoom level by zoom level, so a
+/// tile's id is the count of every tile in lower zooms plus its position on the
+/// curve at its own zoom. Neighbouring tiles then land close together in the
+/// archive, which is what makes a city a handful of contiguous reads.
+pub fn zxy_to_tile_id(z: u8, x: u32, y: u32) -> Result<u64> {
+    if z > 31 {
+        return Err(format!("zoom {z} is out of range"));
+    }
+    let n = 1u64 << z;
+    if u64::from(x) >= n || u64::from(y) >= n {
+        return Err(format!("tile {z}/{x}/{y} is outside the zoom level"));
+    }
+
+    // Tiles in every zoom below this one: (4^z - 1) / 3.
+    let mut id = ((1u64 << (2 * u32::from(z))) - 1) / 3;
+
+    let (mut tx, mut ty) = (u64::from(x), u64::from(y));
+    let mut side = n >> 1;
+    while side > 0 {
+        let rx = u64::from(tx & side != 0);
+        let ry = u64::from(ty & side != 0);
+        id += side * side * ((3 * rx) ^ ry);
+        // Rotate the quadrant so the curve stays continuous.
+        if ry == 0 {
+            if rx == 1 {
+                tx = side.wrapping_sub(1).wrapping_sub(tx);
+                ty = side.wrapping_sub(1).wrapping_sub(ty);
+            }
+            std::mem::swap(&mut tx, &mut ty);
+        }
+        side >>= 1;
+    }
+    Ok(id)
+}
+
+/// Web-Mercator tile containing a coordinate at the given zoom.
+pub fn lonlat_to_tile(lon: f64, lat: f64, z: u8) -> (u32, u32) {
+    let n = f64::from(1u32 << z);
+    let x = ((lon + 180.0) / 360.0 * n).floor();
+    // Clamped to the Mercator limit so a pole never produces an infinity.
+    let lat = lat.clamp(-85.051_128_78, 85.051_128_78).to_radians();
+    let y = ((1.0 - (lat.tan() + 1.0 / lat.cos()).ln() / std::f64::consts::PI) / 2.0 * n).floor();
+    let last = (1u32 << z) - 1;
+    ((x.max(0.0) as u32).min(last), (y.max(0.0) as u32).min(last))
+}
+
+/// Longitude of a tile-local x coordinate, where `fraction` is `local_x / extent`.
+pub fn tile_x_to_lon(z: u8, tile_x: u32, fraction: f64) -> f64 {
+    let n = f64::from(1u32 << z);
+    (f64::from(tile_x) + fraction) / n * 360.0 - 180.0
+}
+
+/// Latitude of a tile-local y coordinate, where `fraction` is `local_y / extent`.
+pub fn tile_y_to_lat(z: u8, tile_y: u32, fraction: f64) -> f64 {
+    let n = f64::from(1u32 << z);
+    let t = std::f64::consts::PI * (1.0 - 2.0 * (f64::from(tile_y) + fraction) / n);
+    t.sinh().atan().to_degrees()
+}
+
+// ─── Archive ─────────────────────────────────────────────────────────────
+
+/// An opened archive: the header, the root directory, and whichever leaf
+/// directories have been read so far.
+pub struct Archive {
+    url: String,
+    header: Header,
+    root: Vec<Entry>,
+    leaves: HashMap<(u64, u32), Vec<Entry>>,
+    cache_dir: Option<PathBuf>,
+}
+
+impl Archive {
+    /// Open the archive at `url`, caching the header and root directory under
+    /// `cache_dir`.
+    ///
+    /// The first read covers the header and, in practice, the whole root
+    /// directory. Only an archive with an unusually large root costs a second
+    /// request, and only on the run that first opens it.
+    pub fn open(client: &Client, url: &str, cache_dir: Option<PathBuf>) -> Result<Archive> {
+        let header_path = cache_dir.as_ref().map(|d| d.join("header.bin"));
+        let root_path = cache_dir.as_ref().map(|d| d.join("root.bin"));
+
+        let cached = header_path
+            .as_ref()
+            .and_then(|p| cache::read(p))
+            .zip(root_path.as_ref().and_then(|p| cache::read(p)));
+
+        let (header_bytes, root_bytes) = match cached {
+            Some((header_bytes, root_bytes)) => {
+                stats::record_cached((header_bytes.len() + root_bytes.len()) as u64);
+                (header_bytes, root_bytes)
+            }
+            None => {
+                let probe = fetch_range(client, url, 0, HEADER_PROBE_LEN)?;
+                let header = Header::parse(&probe)?;
+                let root_end = header
+                    .root_offset
+                    .checked_add(header.root_length)
+                    .ok_or("root directory range overflows")?;
+
+                let root_bytes = if root_end <= probe.len() as u64 {
+                    probe[header.root_offset as usize..root_end as usize].to_vec()
+                } else {
+                    fetch_range(client, url, header.root_offset, header.root_length)?
+                };
+                let header_bytes = probe[..HEADER_LEN].to_vec();
+
+                if let (Some(hp), Some(rp)) = (&header_path, &root_path) {
+                    cache::write_atomic(hp, &header_bytes);
+                    cache::write_atomic(rp, &root_bytes);
+                }
+                (header_bytes, root_bytes)
+            }
+        };
+
+        let header = Header::parse(&header_bytes)?;
+        let root = decode_directory(&decompress(header.internal_compression, root_bytes)?)?;
+        Ok(Archive {
+            url: url.to_string(),
+            header,
+            root,
+            leaves: HashMap::new(),
+            cache_dir,
+        })
+    }
+
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+
+    /// Resolve a tile to its byte range, descending through leaf directories.
+    ///
+    /// Takes `&mut self` because a leaf directory read is memoised here: a city
+    /// is a few dozen tiles behind one or two leaves, so resolving them all up
+    /// front costs one or two requests and lets the tile bodies be fetched in
+    /// parallel afterwards.
+    pub fn locate(
+        &mut self,
+        client: &Client,
+        z: u8,
+        x: u32,
+        y: u32,
+    ) -> Result<Option<TileLocation>> {
+        let tile_id = zxy_to_tile_id(z, x, y)?;
+        let mut entries: &[Entry] = &self.root;
+        // Owned storage for a leaf that was just read, so the borrow above can
+        // be rebound to it.
+        for _ in 0..MAX_LEAF_DEPTH {
+            let Some(entry) = find_entry(entries, tile_id) else {
+                return Ok(None);
+            };
+            if entry.run_length > 0 {
+                let offset = self
+                    .header
+                    .tile_data_offset
+                    .checked_add(entry.offset)
+                    .ok_or("tile offset overflows")?;
+                return Ok(Some(TileLocation {
+                    offset,
+                    length: entry.length,
+                }));
+            }
+            // A leaf pointer with no length would loop forever on itself.
+            if entry.length == 0 {
+                return Ok(None);
+            }
+            let key = (entry.offset, entry.length);
+            if !self.leaves.contains_key(&key) {
+                let absolute = self
+                    .header
+                    .leaf_offset
+                    .checked_add(entry.offset)
+                    .ok_or("leaf offset overflows")?;
+                let raw = self.read_cached(
+                    client,
+                    absolute,
+                    u64::from(entry.length),
+                    self.cache_dir.as_ref().map(|d| {
+                        d.join("leaf")
+                            .join(format!("{}_{}.bin", entry.offset, entry.length))
+                    }),
+                )?;
+                let decoded =
+                    decode_directory(&decompress(self.header.internal_compression, raw)?)?;
+                self.leaves.insert(key, decoded);
+            }
+            entries = &self.leaves[&key];
+        }
+        Err("PMTiles directory nesting is deeper than this reader follows".into())
+    }
+
+    /// Fetch and decompress one tile's bytes.
+    ///
+    /// Takes `&self`, so tiles resolved by [`Archive::locate`] can be fetched
+    /// from several threads at once.
+    pub fn tile(
+        &self,
+        client: &Client,
+        z: u8,
+        x: u32,
+        y: u32,
+        location: TileLocation,
+    ) -> Result<Vec<u8>> {
+        if location.length == 0 {
+            return Ok(Vec::new());
+        }
+        let path = self.cache_dir.as_ref().map(|d| {
+            d.join("t")
+                .join(z.to_string())
+                .join(x.to_string())
+                .join(format!("{y}.bin"))
+        });
+        let raw = self.read_cached(client, location.offset, u64::from(location.length), path)?;
+        decompress(self.header.tile_compression, raw)
+    }
+
+    /// Read a byte range, preferring the cache and populating it on a miss.
+    ///
+    /// A cached file whose length disagrees with the range is treated as a miss
+    /// rather than trusted, so a truncated write from an older build can only
+    /// cost one refetch.
+    fn read_cached(
+        &self,
+        client: &Client,
+        offset: u64,
+        length: u64,
+        path: Option<PathBuf>,
+    ) -> Result<Vec<u8>> {
+        if let Some(path) = &path {
+            if let Some(bytes) = cache::read(path) {
+                if bytes.len() as u64 == length {
+                    stats::record_cached(length);
+                    return Ok(bytes);
+                }
+            }
+        }
+        let bytes = fetch_range(client, &self.url, offset, length)?;
+        if let Some(path) = &path {
+            cache::write_atomic(path, &bytes);
+        }
+        Ok(bytes)
+    }
+}
+
+/// Attempts per range read. A dropped tile takes a square kilometre of
+/// buildings with it, so a transient failure must not settle it.
+const RANGE_ATTEMPTS: u32 = 3;
+
+/// Fetch `[offset, offset + length)` over HTTP, retrying transient failures.
+fn fetch_range(client: &Client, url: &str, offset: u64, length: u64) -> Result<Vec<u8>> {
+    if length == 0 {
+        return Ok(Vec::new());
+    }
+    let end = offset + length - 1;
+    let mut last_error = String::new();
+
+    for attempt in 0..RANGE_ATTEMPTS {
+        if attempt > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(500 << (attempt - 1)));
+        }
+        stats::record_request();
+        let response = match client
+            .get(url)
+            .header("Range", format!("bytes={offset}-{end}"))
+            .send()
+        {
+            Ok(response) => response,
+            Err(e) => {
+                last_error = format!("range request to {url} failed: {e}");
+                continue;
+            }
+        };
+
+        let status = response.status();
+        // A 200 means the server ignored the range and is about to send the
+        // whole archive. Refusing is the only safe answer at 180 GB.
+        if status.as_u16() != 206 {
+            last_error = format!("HTTP {status} fetching range from {url} (expected 206)");
+            if !(status.is_server_error() || status.as_u16() == 429) {
+                break;
+            }
+            continue;
+        }
+
+        match response.bytes() {
+            Ok(body) => {
+                stats::record_network(body.len() as u64);
+                return Ok(body.to_vec());
+            }
+            Err(e) => last_error = format!("range body from {url} could not be read: {e}"),
+        }
+    }
+    Err(last_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn varint(mut v: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        loop {
+            let byte = (v & 0x7f) as u8;
+            v >>= 7;
+            if v == 0 {
+                out.push(byte);
+                return out;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+
+    fn serialize_directory(entries: &[Entry]) -> Vec<u8> {
+        let mut out = varint(entries.len() as u64);
+        let mut last = 0u64;
+        for e in entries {
+            out.extend(varint(e.tile_id - last));
+            last = e.tile_id;
+        }
+        for e in entries {
+            out.extend(varint(u64::from(e.run_length)));
+        }
+        for e in entries {
+            out.extend(varint(u64::from(e.length)));
+        }
+        for (i, e) in entries.iter().enumerate() {
+            let contiguous =
+                i > 0 && e.offset == entries[i - 1].offset + u64::from(entries[i - 1].length);
+            out.extend(varint(if contiguous { 0 } else { e.offset + 1 }));
+        }
+        out
+    }
+
+    fn entry(tile_id: u64, run_length: u32, length: u32, offset: u64) -> Entry {
+        Entry {
+            tile_id,
+            run_length,
+            length,
+            offset,
+        }
+    }
+
+    #[test]
+    fn tile_ids_match_the_specifications_examples() {
+        // The curve starts at the single zoom-0 tile and covers each zoom in turn.
+        assert_eq!(zxy_to_tile_id(0, 0, 0).unwrap(), 0);
+        assert_eq!(zxy_to_tile_id(1, 0, 0).unwrap(), 1);
+        assert_eq!(zxy_to_tile_id(1, 0, 1).unwrap(), 2);
+        assert_eq!(zxy_to_tile_id(1, 1, 1).unwrap(), 3);
+        assert_eq!(zxy_to_tile_id(1, 1, 0).unwrap(), 4);
+        assert_eq!(zxy_to_tile_id(2, 0, 0).unwrap(), 5);
+
+        // Every tile of a zoom level maps to a distinct id in that level's block.
+        let mut seen = std::collections::HashSet::new();
+        for x in 0..8 {
+            for y in 0..8 {
+                let id = zxy_to_tile_id(3, x, y).unwrap();
+                assert!((21..85).contains(&id), "z3 id {id} outside its block");
+                assert!(seen.insert(id), "duplicate id {id}");
+            }
+        }
+        assert_eq!(seen.len(), 64);
+
+        assert!(zxy_to_tile_id(1, 2, 0).is_err(), "x outside the zoom level");
+        assert!(zxy_to_tile_id(32, 0, 0).is_err(), "zoom out of range");
+    }
+
+    #[test]
+    fn the_munich_tile_id_matches_the_live_archive() {
+        // Verified against Overture's published buildings.pmtiles: the z14 tile
+        // covering Munich's Altstadt resolves to this id in the real root
+        // directory. Pins both the tile lookup and the Hilbert numbering.
+        let (x, y) = lonlat_to_tile(11.575, 48.137, 14);
+        assert_eq!((x, y), (8718, 5685));
+        assert_eq!(zxy_to_tile_id(14, x, y).unwrap(), 317_195_426);
+    }
+
+    #[test]
+    fn tile_coordinates_round_trip_through_the_projection() {
+        for (lon, lat) in [
+            (11.575, 48.137),
+            (-73.984, 40.754),
+            (0.0, 0.0),
+            (139.7, 35.68),
+        ] {
+            let z = 14;
+            let (x, y) = lonlat_to_tile(lon, lat, z);
+            // The point must fall inside the tile it was assigned to.
+            let west = tile_x_to_lon(z, x, 0.0);
+            let east = tile_x_to_lon(z, x, 1.0);
+            let north = tile_y_to_lat(z, y, 0.0);
+            let south = tile_y_to_lat(z, y, 1.0);
+            assert!(west <= lon && lon < east, "{lon} outside [{west}, {east})");
+            assert!(
+                south <= lat && lat <= north,
+                "{lat} outside [{south}, {north}]"
+            );
+        }
+    }
+
+    #[test]
+    fn poles_and_antimeridian_stay_inside_the_grid() {
+        let last = (1u32 << 14) - 1;
+        assert_eq!(lonlat_to_tile(180.0, 0.0, 14).0, last);
+        assert_eq!(lonlat_to_tile(-180.0, 0.0, 14).0, 0);
+        assert_eq!(lonlat_to_tile(0.0, 90.0, 14).1, 0);
+        assert_eq!(lonlat_to_tile(0.0, -90.0, 14).1, last);
+    }
+
+    #[test]
+    fn directory_round_trips_including_contiguous_offsets() {
+        let entries = vec![
+            entry(0, 1, 100, 0),
+            // Contiguous with the previous entry, so its offset is stored as 0.
+            entry(5, 1, 250, 100),
+            entry(9, 0, 64, 4096),
+            entry(20, 3, 10, 9000),
+        ];
+        let decoded = decode_directory(&serialize_directory(&entries)).unwrap();
+        assert_eq!(decoded, entries);
+    }
+
+    #[test]
+    fn lookup_honours_runs_and_leaf_pointers() {
+        let entries = vec![
+            entry(10, 3, 5, 0),
+            entry(20, 0, 64, 128),
+            entry(40, 1, 5, 0),
+        ];
+
+        // Inside the run.
+        assert_eq!(find_entry(&entries, 10), Some(entries[0]));
+        assert_eq!(find_entry(&entries, 12), Some(entries[0]));
+        // Past the run's end but before the next entry: the archive has no tile.
+        assert_eq!(find_entry(&entries, 13), None);
+        // Below the first entry.
+        assert_eq!(find_entry(&entries, 9), None);
+        // A leaf pointer covers everything up to the next entry.
+        assert_eq!(find_entry(&entries, 20), Some(entries[1]));
+        assert_eq!(find_entry(&entries, 39), Some(entries[1]));
+        assert_eq!(find_entry(&entries, 40), Some(entries[2]));
+        assert_eq!(find_entry(&entries, 41), None);
+    }
+
+    #[test]
+    fn a_malformed_directory_is_rejected_without_panicking() {
+        // Entry count far past what the bytes could hold.
+        assert!(decode_directory(&varint(u64::MAX)).is_err());
+        // Truncated arrays.
+        let good = serialize_directory(&[entry(1, 1, 2, 3), entry(9, 1, 2, 40)]);
+        for cut in 0..good.len() {
+            let _ = decode_directory(&good[..cut]);
+        }
+        // A first entry using the contiguous marker has nothing to be contiguous with.
+        let mut broken = varint(1);
+        broken.extend(varint(0)); // tile id
+        broken.extend(varint(1)); // run length
+        broken.extend(varint(1)); // length
+        broken.extend(varint(0)); // offset marker
+        assert!(decode_directory(&broken).is_err());
+    }
+
+    #[test]
+    fn a_header_is_validated_before_any_range_is_derived_from_it() {
+        let mut buf = vec![0u8; HEADER_LEN];
+        buf[0..7].copy_from_slice(b"PMTiles");
+        buf[7] = 3;
+        buf[99] = TILE_TYPE_MVT;
+        buf[16..24].copy_from_slice(&1024u64.to_le_bytes()); // root length
+        assert!(Header::parse(&buf).is_ok());
+
+        let mut bad_magic = buf.clone();
+        bad_magic[0] = b'X';
+        assert!(Header::parse(&bad_magic).is_err());
+
+        let mut bad_version = buf.clone();
+        bad_version[7] = 2;
+        assert!(Header::parse(&bad_version).is_err());
+
+        let mut bad_type = buf.clone();
+        bad_type[99] = 2; // PNG
+        assert!(Header::parse(&bad_type).is_err());
+
+        let mut huge_root = buf.clone();
+        huge_root[16..24].copy_from_slice(&u64::MAX.to_le_bytes());
+        assert!(Header::parse(&huge_root).is_err());
+
+        assert!(Header::parse(&buf[..HEADER_LEN - 1]).is_err());
+    }
+
+    #[test]
+    fn brotli_is_refused_rather_than_silently_producing_nothing() {
+        assert!(decompress(COMPRESSION_BROTLI, vec![1, 2, 3]).is_err());
+        assert!(decompress(99, vec![1, 2, 3]).is_err());
+        assert_eq!(
+            decompress(COMPRESSION_NONE, vec![1, 2, 3]).unwrap(),
+            vec![1, 2, 3]
+        );
+    }
+}

--- a/src/overture/pmtiles.rs
+++ b/src/overture/pmtiles.rs
@@ -131,20 +131,53 @@ impl Header {
     }
 }
 
-/// Undo the archive's declared compression.
-fn decompress(kind: u8, data: Vec<u8>) -> Result<Vec<u8>> {
+/// Undo the archive's declared compression, refusing output past `max_output`.
+///
+/// The caps elsewhere in this file bound what is *fetched*, which says nothing
+/// about what it expands to: a few hundred kilobytes of gzip can decode to
+/// gigabytes. These bytes come off the network, so the decoders are read
+/// through `take` and the result is rejected the moment it exceeds the limit,
+/// rather than after a decoder has already allocated it.
+fn decompress(kind: u8, data: Vec<u8>, max_output: u64) -> Result<Vec<u8>> {
+    /// Reads at most `max_output` bytes, then reports the overrun rather than
+    /// returning a truncated buffer that would parse as valid-but-wrong.
+    fn read_bounded(mut reader: impl Read, max_output: u64, what: &str) -> Result<Vec<u8>> {
+        let mut out = Vec::new();
+        // One byte past the cap, so hitting it is distinguishable from a
+        // stream that happens to be exactly the maximum size.
+        reader
+            .by_ref()
+            .take(max_output.saturating_add(1))
+            .read_to_end(&mut out)
+            .map_err(|e| format!("{what} decode failed: {e}"))?;
+        if out.len() as u64 > max_output {
+            return Err(format!(
+                "{what} stream expands past the {max_output} byte limit"
+            ));
+        }
+        Ok(out)
+    }
+
     match kind {
-        COMPRESSION_NONE => Ok(data),
-        COMPRESSION_GZIP => {
-            let mut out = Vec::new();
-            flate2::read::GzDecoder::new(data.as_slice())
-                .read_to_end(&mut out)
-                .map_err(|e| format!("gzip decode failed: {e}"))?;
-            Ok(out)
+        COMPRESSION_NONE => {
+            if data.len() as u64 > max_output {
+                return Err(format!(
+                    "uncompressed block is {} bytes, past the {max_output} byte limit",
+                    data.len()
+                ));
+            }
+            Ok(data)
         }
-        COMPRESSION_ZSTD => {
-            zstd::decode_all(data.as_slice()).map_err(|e| format!("zstd decode failed: {e}"))
-        }
+        COMPRESSION_GZIP => read_bounded(
+            flate2::read::GzDecoder::new(data.as_slice()),
+            max_output,
+            "gzip",
+        ),
+        COMPRESSION_ZSTD => read_bounded(
+            zstd::Decoder::new(data.as_slice()).map_err(|e| format!("zstd decode failed: {e}"))?,
+            max_output,
+            "zstd",
+        ),
         COMPRESSION_BROTLI => Err("archive uses brotli, which Arnis does not link".into()),
         other => Err(format!("unknown PMTiles compression {other}")),
     }
@@ -362,7 +395,11 @@ impl Archive {
         };
 
         let header = Header::parse(&header_bytes)?;
-        let root = decode_directory(&decompress(header.internal_compression, root_bytes)?)?;
+        let root = decode_directory(&decompress(
+            header.internal_compression,
+            root_bytes,
+            MAX_DIRECTORY_BYTES,
+        )?)?;
         Ok(Archive {
             url: url.to_string(),
             header,
@@ -436,8 +473,11 @@ impl Archive {
                             .join(format!("{}_{}.bin", entry.offset, entry.length))
                     }),
                 )?;
-                let decoded =
-                    decode_directory(&decompress(self.header.internal_compression, raw)?)?;
+                let decoded = decode_directory(&decompress(
+                    self.header.internal_compression,
+                    raw,
+                    MAX_DIRECTORY_BYTES,
+                )?)?;
                 self.leaves.insert(key, decoded);
             }
             entries = &self.leaves[&key];
@@ -475,7 +515,7 @@ impl Archive {
                 .join(format!("{y}.bin"))
         });
         let raw = self.read_cached(client, location.offset, u64::from(location.length), path)?;
-        decompress(self.header.tile_compression, raw)
+        decompress(self.header.tile_compression, raw, MAX_TILE_BYTES)
     }
 
     /// Read a byte range, preferring the cache and populating it on a miss.
@@ -759,11 +799,29 @@ mod tests {
 
     #[test]
     fn brotli_is_refused_rather_than_silently_producing_nothing() {
-        assert!(decompress(COMPRESSION_BROTLI, vec![1, 2, 3]).is_err());
-        assert!(decompress(99, vec![1, 2, 3]).is_err());
+        assert!(decompress(COMPRESSION_BROTLI, vec![1, 2, 3], 1024).is_err());
+        assert!(decompress(99, vec![1, 2, 3], 1024).is_err());
         assert_eq!(
-            decompress(COMPRESSION_NONE, vec![1, 2, 3]).unwrap(),
+            decompress(COMPRESSION_NONE, vec![1, 2, 3], 1024).unwrap(),
             vec![1, 2, 3]
+        );
+
+        // A stream that expands past its cap is refused, not truncated: a
+        // short buffer would decode as a valid-looking, wrong directory.
+        let bomb = {
+            use std::io::Write;
+            let mut encoder =
+                flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
+            encoder.write_all(&vec![0u8; 512 * 1024]).unwrap();
+            encoder.finish().unwrap()
+        };
+        assert!(bomb.len() < 4096, "the test bomb must be small compressed");
+        assert!(decompress(COMPRESSION_GZIP, bomb.clone(), 4096).is_err());
+        assert_eq!(
+            decompress(COMPRESSION_GZIP, bomb, 1024 * 1024)
+                .unwrap()
+                .len(),
+            512 * 1024
         );
     }
 }

--- a/src/overture/pmtiles.rs
+++ b/src/overture/pmtiles.rs
@@ -133,18 +133,17 @@ impl Header {
 
 /// Undo the archive's declared compression, refusing output past `max_output`.
 ///
-/// The caps elsewhere in this file bound what is *fetched*, which says nothing
-/// about what it expands to: a few hundred kilobytes of gzip can decode to
-/// gigabytes. These bytes come off the network, so the decoders are read
-/// through `take` and the result is rejected the moment it exceeds the limit,
-/// rather than after a decoder has already allocated it.
+/// The other caps in this file bound the compressed size only. A few hundred
+/// kilobytes of gzip can decode to gigabytes, and these bytes come off the
+/// network, so both decoders read through `take` and the result is rejected
+/// once it passes the limit.
 fn decompress(kind: u8, data: Vec<u8>, max_output: u64) -> Result<Vec<u8>> {
     /// Reads at most `max_output` bytes, then reports the overrun rather than
     /// returning a truncated buffer that would parse as valid-but-wrong.
     fn read_bounded(mut reader: impl Read, max_output: u64, what: &str) -> Result<Vec<u8>> {
         let mut out = Vec::new();
-        // One byte past the cap, so hitting it is distinguishable from a
-        // stream that happens to be exactly the maximum size.
+        // One byte past the cap, so a stream sitting right on the limit is
+        // still told apart from one that overruns it.
         reader
             .by_ref()
             .take(max_output.saturating_add(1))
@@ -281,8 +280,8 @@ fn find_entry(entries: &[Entry], tile_id: u64) -> Option<Entry> {
 
 /// PMTiles orders tiles along a Hilbert curve, zoom level by zoom level, so a
 /// tile's id is the count of every tile in lower zooms plus its position on the
-/// curve at its own zoom. Neighbouring tiles then land close together in the
-/// archive, which is what makes a city a handful of contiguous reads.
+/// curve at its own zoom. Neighbouring tiles land close together in the
+/// archive, so a city reads as a handful of nearby ranges.
 pub fn zxy_to_tile_id(z: u8, x: u32, y: u32) -> Result<u64> {
     if z > 31 {
         return Err(format!("zoom {z} is out of range"));

--- a/src/overture/pmtiles.rs
+++ b/src/overture/pmtiles.rs
@@ -35,6 +35,11 @@ const MAX_DIRECTORY_BYTES: u64 = 64 * 1024 * 1024;
 /// Guards against a directory whose entry count is inconsistent with its bytes.
 const MAX_DIRECTORY_ENTRIES: u64 = 8 * 1024 * 1024;
 
+/// Largest tile body this reader will fetch. Overture's densest z14 building
+/// tile is ~410 KB compressed; the entry length is a u32, so without a cap the
+/// archive could ask us to download 4 GB for one tile.
+const MAX_TILE_BYTES: u64 = 64 * 1024 * 1024;
+
 /// Leaf descents before a lookup gives up. The format allows nesting; two levels
 /// is all any published archive uses, and a cycle must not hang generation.
 const MAX_LEAF_DEPTH: usize = 4;
@@ -407,6 +412,14 @@ impl Archive {
             if entry.length == 0 {
                 return Ok(None);
             }
+            // `length` is a u32, so the file may ask for up to 4 GB. Refuse
+            // before the request rather than after the download.
+            if u64::from(entry.length) > MAX_DIRECTORY_BYTES {
+                return Err(format!(
+                    "leaf directory claims {} bytes, past the {MAX_DIRECTORY_BYTES} cap",
+                    entry.length
+                ));
+            }
             let key = (entry.offset, entry.length);
             if !self.leaves.contains_key(&key) {
                 let absolute = self
@@ -446,6 +459,14 @@ impl Archive {
     ) -> Result<Vec<u8>> {
         if location.length == 0 {
             return Ok(Vec::new());
+        }
+        // Same reasoning as the leaf cap: a tile length is a u32 the archive
+        // chooses, and no vector tile is hundreds of megabytes.
+        if u64::from(location.length) > MAX_TILE_BYTES {
+            return Err(format!(
+                "tile {z}/{x}/{y} claims {} bytes, past the {MAX_TILE_BYTES} cap",
+                location.length
+            ));
         }
         let path = self.cache_dir.as_ref().map(|d| {
             d.join("t")
@@ -494,7 +515,12 @@ fn fetch_range(client: &Client, url: &str, offset: u64, length: u64) -> Result<V
     if length == 0 {
         return Ok(Vec::new());
     }
-    let end = offset + length - 1;
+    // Offsets and lengths come out of the archive's own header and directories.
+    // An overflow here would wrap the range into a small one and quietly return
+    // the wrong bytes, so it is an error rather than a saturation.
+    let end = offset
+        .checked_add(length - 1)
+        .ok_or_else(|| format!("range {offset}+{length} overflows the archive"))?;
     let mut last_error = String::new();
 
     for attempt in 0..RANGE_ATTEMPTS {

--- a/src/overture/pmtiles.rs
+++ b/src/overture/pmtiles.rs
@@ -35,6 +35,14 @@ const MAX_DIRECTORY_BYTES: u64 = 64 * 1024 * 1024;
 /// Guards against a directory whose entry count is inconsistent with its bytes.
 const MAX_DIRECTORY_ENTRIES: u64 = 8 * 1024 * 1024;
 
+/// Smallest number of bytes one directory entry can occupy: four varints of one
+/// byte each.
+const BYTES_PER_ENTRY_MIN: usize = 4;
+
+/// Entries reserved up front. Past this the vector grows as entries are read,
+/// so a directory cannot make us allocate for a count it never delivers.
+const ENTRY_PREALLOC: usize = 4096;
+
 /// Largest tile body this reader will fetch. Overture's densest z14 building
 /// tile is ~410 KB compressed; the entry length is a u32, so without a cap the
 /// archive could ask us to download 4 GB for one tile.
@@ -190,6 +198,10 @@ struct Varints<'a> {
 }
 
 impl Varints<'_> {
+    fn remaining(&self) -> usize {
+        self.buf.len().saturating_sub(self.pos)
+    }
+
     fn next(&mut self) -> Result<u64> {
         let mut value = 0u64;
         let mut shift = 0u32;
@@ -216,26 +228,34 @@ impl Varints<'_> {
 fn decode_directory(buf: &[u8]) -> Result<Vec<Entry>> {
     let mut reader = Varints { buf, pos: 0 };
     let count = reader.next()?;
-    if count > MAX_DIRECTORY_ENTRIES || count > buf.len() as u64 {
-        return Err(format!("directory claims {count} entries"));
+
+    // Each entry contributes four varints and a varint is at least one byte, so
+    // the bytes left are a hard ceiling on how many entries can really follow.
+    // Without this a 64 MB directory could claim 64 million of them.
+    let possible = (reader.remaining() / BYTES_PER_ENTRY_MIN) as u64;
+    if count > MAX_DIRECTORY_ENTRIES || count > possible {
+        return Err(format!(
+            "directory claims {count} entries, but {} bytes can hold at most {possible}",
+            reader.remaining()
+        ));
     }
     let count = count as usize;
-    let mut entries = vec![
-        Entry {
-            tile_id: 0,
-            run_length: 0,
-            length: 0,
-            offset: 0,
-        };
-        count
-    ];
 
+    // Grown as the tile ids are actually read rather than allocated from the
+    // count. A truncated directory then fails on a varint, having reserved only
+    // what its bytes justified.
+    let mut entries: Vec<Entry> = Vec::with_capacity(count.min(ENTRY_PREALLOC));
     let mut tile_id = 0u64;
-    for entry in entries.iter_mut() {
+    for _ in 0..count {
         tile_id = tile_id
             .checked_add(reader.next()?)
             .ok_or("tile id overflowed")?;
-        entry.tile_id = tile_id;
+        entries.push(Entry {
+            tile_id,
+            run_length: 0,
+            length: 0,
+            offset: 0,
+        });
     }
     for entry in entries.iter_mut() {
         entry.run_length = u32::try_from(reader.next()?).map_err(|_| "run length out of range")?;
@@ -748,6 +768,31 @@ mod tests {
         assert_eq!(find_entry(&entries, 39), Some(entries[1]));
         assert_eq!(find_entry(&entries, 40), Some(entries[2]));
         assert_eq!(find_entry(&entries, 41), None);
+    }
+
+    #[test]
+    fn a_directory_cannot_allocate_for_entries_it_does_not_hold() {
+        // A count is four varints per entry at minimum, so a handful of bytes
+        // cannot hold a million entries. Rejected on the arithmetic, before any
+        // vector is sized from the claim.
+        let mut lying = varint(1_000_000);
+        lying.extend([0u8; 16]);
+        let err = decode_directory(&lying).unwrap_err();
+        assert!(err.contains("can hold at most"), "{err}");
+
+        // The largest count these bytes could justify is accepted as far as the
+        // arithmetic goes, and then fails on the reads rather than on a guess.
+        let bytes = vec![0u8; 64];
+        let mut honest = varint((bytes.len() / BYTES_PER_ENTRY_MIN) as u64);
+        honest.extend(&bytes);
+        assert!(decode_directory(&honest).is_err());
+
+        // And a directory that really does deliver its entries still decodes,
+        // including one longer than the pre-allocation.
+        let many: Vec<Entry> = (0..ENTRY_PREALLOC + 100)
+            .map(|i| entry(i as u64 * 2, 1, 8, i as u64 * 8))
+            .collect();
+        assert_eq!(decode_directory(&serialize_directory(&many)).unwrap(), many);
     }
 
     #[test]

--- a/src/overture/tiles.rs
+++ b/src/overture/tiles.rs
@@ -53,10 +53,10 @@ const TILES_THEME: &str = "buildings";
 
 /// Layer inside the archive.
 ///
-/// The archive also carries a `building_part` layer, which the Parquet path has
-/// no equivalent for. Reading it would add footprints that the other provider
-/// cannot produce, so it is deliberately left alone: swapping the transport must
-/// not change what a world contains.
+/// The archive also carries a `building_part` layer that the Parquet path has
+/// no equivalent for. Reading it would add footprints the other transport
+/// cannot produce, so it is left alone. Changing transport should not change
+/// what a world contains.
 const BUILDING_LAYER: &str = "building";
 
 /// Zoom to read. The archive's maximum, and therefore its full resolution;
@@ -73,10 +73,10 @@ pub(super) const MAX_TILES: usize = 4096;
 /// cheaper transport. Checked before any release is tried, so a continental
 /// request goes straight to Parquet instead of failing once per release.
 ///
-/// Counts arithmetically rather than by building the list: at zoom 14 a
-/// world-sized bounding box is 268 million tiles, and materialising the
-/// coordinates just to reject them would exhaust memory on the very request
-/// this check exists to route away.
+/// Counts arithmetically rather than by building the list. At zoom 14 a
+/// world-sized bounding box is 268 million tiles, so allocating the
+/// coordinates to reject them would run out of memory on exactly the request
+/// this check is meant to route elsewhere.
 pub(super) fn covers_area(bbox: &LLBBox) -> bool {
     tile_count(bbox) <= MAX_TILES as u64
 }
@@ -103,12 +103,11 @@ const FETCH_THREADS_MAX: usize = 8;
 
 /// Threads for the tile fetch pool.
 ///
-/// The work is latency-bound, so concurrency past the core count would still
-/// pay - but Arnis allocates through mimalloc, which gives every thread its own
-/// heap and segments, and decoding a tile allocates hard. On a four-core CI
-/// runner a fixed eight threads therefore cost more in resident allocator
-/// arenas than the extra overlap saves on a fetch that is a handful of tiles.
-/// Scaling with the machine keeps the overlap where there are cores to hold it.
+/// The work is latency-bound, so more threads than cores would still help the
+/// fetch. But Arnis allocates through mimalloc, which gives each thread its own
+/// heap, and tile decoding allocates heavily. On a four-core runner eight fixed
+/// threads cost more in resident allocator arenas than the extra overlap saves.
+/// Scaling with the machine keeps the overlap where there are cores for it.
 fn fetch_thread_count() -> usize {
     std::thread::available_parallelism()
         .map(std::num::NonZeroUsize::get)
@@ -182,10 +181,10 @@ struct TileBuilding {
     /// Twice the footprint's unsigned area, in square degrees.
     ///
     /// Used to pick the intact copy when a building appears in several tiles.
-    /// Vertex count cannot do that job: clipping against a tile boundary *adds*
+    /// Vertex count does not work here: clipping against a tile boundary adds
     /// intersection vertices, and a clipped rectangle keeps the same four
-    /// corners as a whole one. Clipping can only ever remove area, so the
-    /// largest copy is the one that was carried whole.
+    /// corners as a whole one. Clipping only ever removes area, so the largest
+    /// copy is the whole one.
     area2: f64,
 }
 
@@ -246,10 +245,9 @@ fn feature_to_building(
     }
     let gers_id = layer.attr_str(feature, "id")?.to_string();
 
-    // Largest exterior ring by area; holes are dropped, as they are on the
-    // Parquet path. By area rather than by vertex count, because a small,
-    // finely mapped outbuilding routinely carries more vertices than the main
-    // footprint it sits beside.
+    // Largest exterior ring by area; holes are dropped, as on the Parquet path.
+    // By area, not vertex count: a small, finely mapped outbuilding often has
+    // more vertices than the main footprint next to it.
     let ring = feature
         .rings
         .iter()
@@ -420,7 +418,7 @@ pub fn collect_from_tiles(
                     }
                     let layers = mvt::decode_tile(&raw)?;
                     // The decoded layers own their bytes, so the compressed
-                    // tile is dead weight from here on - and eight of these
+                    // tile is dead weight from here on. Up to eight of these
                     // are in flight at once.
                     drop(raw);
                     let mut harvest = TileHarvest::default();
@@ -433,13 +431,12 @@ pub fn collect_from_tiles(
                                 continue;
                             }
                             if candidate.building.is_osm_sourced {
-                                // An OSM-sourced row is a duplicate footprint
-                                // that still carries conflated Microsoft / Esri
-                                // / 3DEP values. Unless the caller wants the
-                                // geometry too, only those values are kept -
-                                // in a European city they are 99% of the rows,
-                                // so carrying their rings would dominate memory
-                                // for data that is then thrown away.
+                                // An OSM-sourced row duplicates a footprint we
+                                // already have, but carries conflated Microsoft
+                                // / Esri / 3DEP values. Keep only those unless
+                                // the caller asked for the geometry: in a
+                                // European city these are 99% of the rows, and
+                                // their rings would be discarded anyway.
                                 if let Some(key) = candidate.building.osm_ref {
                                     harvest.hints.push((
                                         key,
@@ -495,9 +492,9 @@ pub fn collect_from_tiles(
         }
     }
 
-    // Every tile failing is a broken archive, not an empty area. Returning an
-    // empty collection here would look like success, mark the release good, and
-    // rob `auto` of the Parquet fallback it promises.
+    // Every tile failing means a broken archive, not an empty area. Returning
+    // an empty collection would look like success, mark the release good, and
+    // skip the Parquet fallback that `auto` is supposed to provide.
     if attempted > 0 && lost_tiles == attempted {
         return Err(format!(
             "all {lost_tiles} Overture tile(s) holding data could not be read"
@@ -511,10 +508,9 @@ pub fn collect_from_tiles(
         );
     }
 
-    // A HashMap iterates in an order the standard library deliberately
-    // randomises per process, and the budget below truncates. Sorting by the
-    // GERS id makes which buildings survive a property of the data rather than
-    // of this run, so two runs of one bbox produce the same world.
+    // HashMap iteration order is randomised per process and the budget below
+    // truncates, so without a sort the surviving buildings would differ between
+    // two runs of the same bbox. Sort by GERS id to keep the world stable.
     let mut collected: Vec<TileBuilding> = best.into_values().collect();
     collected.sort_unstable_by(|a, b| a.gers_id.cmp(&b.gers_id));
     capped |= collected.len() > max_buildings;

--- a/src/overture/tiles.rs
+++ b/src/overture/tiles.rs
@@ -72,8 +72,28 @@ pub(super) const MAX_TILES: usize = 4096;
 /// Whether this bounding box is small enough for the tile path to be the
 /// cheaper transport. Checked before any release is tried, so a continental
 /// request goes straight to Parquet instead of failing once per release.
+///
+/// Counts arithmetically rather than by building the list: at zoom 14 a
+/// world-sized bounding box is 268 million tiles, and materialising the
+/// coordinates just to reject them would exhaust memory on the very request
+/// this check exists to route away.
 pub(super) fn covers_area(bbox: &LLBBox) -> bool {
-    tiles_for_bbox(bbox).len() <= MAX_TILES
+    tile_count(bbox) <= MAX_TILES as u64
+}
+
+/// Inclusive `(min_x, max_x, min_y, max_y)` tile range covering the bbox.
+///
+/// Tile y grows southward while latitude grows northward, so the corners come
+/// from opposite edges.
+fn tile_range(bbox: &LLBBox) -> (u32, u32, u32, u32) {
+    let (min_x, min_y) = pmtiles::lonlat_to_tile(bbox.min().lng(), bbox.max().lat(), QUERY_ZOOM);
+    let (max_x, max_y) = pmtiles::lonlat_to_tile(bbox.max().lng(), bbox.min().lat(), QUERY_ZOOM);
+    (min_x, max_x, min_y, max_y)
+}
+
+fn tile_count(bbox: &LLBBox) -> u64 {
+    let (min_x, max_x, min_y, max_y) = tile_range(bbox);
+    u64::from(max_x - min_x + 1) * u64::from(max_y - min_y + 1)
 }
 
 /// Concurrent range requests. Enough to keep the link busy, few enough that a
@@ -112,10 +132,10 @@ fn archive_cache_dir(release: &str) -> Option<std::path::PathBuf> {
     cache::release_dir(release).map(|d| d.join("tiles").join(TILES_THEME))
 }
 
-/// Every z14 tile the bounding box touches.
+/// Every z14 tile the bounding box touches. Call [`covers_area`] first: this
+/// allocates one entry per tile.
 fn tiles_for_bbox(bbox: &LLBBox) -> Vec<(u32, u32)> {
-    let (min_x, min_y) = pmtiles::lonlat_to_tile(bbox.min().lng(), bbox.max().lat(), QUERY_ZOOM);
-    let (max_x, max_y) = pmtiles::lonlat_to_tile(bbox.max().lng(), bbox.min().lat(), QUERY_ZOOM);
+    let (min_x, max_x, min_y, max_y) = tile_range(bbox);
     let mut tiles = Vec::new();
     for x in min_x..=max_x {
         for y in min_y..=max_y {
@@ -144,10 +164,29 @@ struct TileBuilding {
     /// GERS id, which is stable across tiles and is what deduplication keys on.
     gers_id: String,
     building: OvertureBuilding,
-    /// Vertices in the ring before it was converted. A polygon clipped by a tile
-    /// boundary keeps fewer of them than the same polygon carried whole inside a
-    /// neighbouring tile's buffer, so this picks the intact copy.
-    vertex_count: usize,
+    /// Twice the footprint's unsigned area, in square degrees.
+    ///
+    /// Used to pick the intact copy when a building appears in several tiles.
+    /// Vertex count cannot do that job: clipping against a tile boundary *adds*
+    /// intersection vertices, and a clipped rectangle keeps the same four
+    /// corners as a whole one. Clipping can only ever remove area, so the
+    /// largest copy is the one that was carried whole.
+    area2: f64,
+}
+
+/// Twice the unsigned area of a ring in (longitude, latitude) degrees.
+///
+/// Only ever compared against another copy of the same building, a few hundred
+/// metres away at most, so treating degrees as planar is exact enough for the
+/// comparison and avoids a projection.
+fn ring_area2(ring: &[(f64, f64)]) -> f64 {
+    let mut sum = 0.0;
+    for index in 0..ring.len() {
+        let (x1, y1) = ring[index];
+        let (x2, y2) = ring[(index + 1) % ring.len()];
+        sum += x1 * y2 - x2 * y1;
+    }
+    sum.abs()
 }
 
 /// Pull the OSM back-reference out of the tiles' `sources` attribute.
@@ -192,12 +231,15 @@ fn feature_to_building(
     }
     let gers_id = layer.attr_str(feature, "id")?.to_string();
 
-    // Largest exterior ring; holes are dropped, as they are on the Parquet path.
+    // Largest exterior ring by area; holes are dropped, as they are on the
+    // Parquet path. By area rather than by vertex count, because a small,
+    // finely mapped outbuilding routinely carries more vertices than the main
+    // footprint it sits beside.
     let ring = feature
         .rings
         .iter()
-        .filter(|r| r.exterior && r.points.len() >= 3)
-        .max_by_key(|r| r.points.len())?;
+        .filter(|r| r.exterior() && r.points.len() >= 3)
+        .max_by_key(|r| r.area2_abs())?;
 
     let extent = f64::from(layer.extent);
     let exterior_ring: Vec<(f64, f64)> = ring
@@ -224,7 +266,7 @@ fn feature_to_building(
         || sources.is_some_and(|s| s.contains("OpenStreetMap"));
 
     Some(TileBuilding {
-        vertex_count: ring.points.len(),
+        area2: ring_area2(&exterior_ring),
         gers_id: gers_id.clone(),
         building: OvertureBuilding {
             id: gers_id,
@@ -293,14 +335,14 @@ pub fn collect_from_tiles(
     report_gaps: bool,
     debug: bool,
 ) -> Result<OvertureCollection> {
-    let tiles = tiles_for_bbox(bbox);
-    if tiles.len() > MAX_TILES {
+    let wanted = tile_count(bbox);
+    if wanted > MAX_TILES as u64 {
         return Err(format!(
-            "area needs {} tiles at zoom {QUERY_ZOOM}, past the {MAX_TILES} this path is \
-             cheaper for",
-            tiles.len()
+            "area needs {wanted} tiles at zoom {QUERY_ZOOM}, past the {MAX_TILES} this path \
+             is cheaper for"
         ));
     }
+    let tiles = tiles_for_bbox(bbox);
     if tiles.is_empty() {
         return Ok(OvertureCollection::default());
     }
@@ -339,9 +381,10 @@ pub fn collect_from_tiles(
     let archive = &archive;
 
     // Deduplicate across tile buffers. The same building appears in every tile
-    // whose buffer reaches it, sometimes clipped; the copy with the most
-    // vertices is the one that was carried whole.
+    // whose buffer reaches it, sometimes clipped; the largest copy is the one
+    // that was carried whole.
     let mut best: HashMap<String, TileBuilding> = HashMap::new();
+    let mut attempted = 0usize;
     let mut hints = super::OvertureHints::default();
     let mut lost_tiles = 0usize;
     let mut capped = false;
@@ -351,6 +394,7 @@ pub fn collect_from_tiles(
     // the whole area's footprints in memory before the cap was ever consulted,
     // which for a dense metropolitan bbox is millions of polygons.
     for batch in located.chunks(TILE_BATCH) {
+        attempted += batch.len();
         let results: Vec<std::result::Result<TileHarvest, String>> = pool.install(|| {
             batch
                 .par_iter()
@@ -360,6 +404,10 @@ pub fn collect_from_tiles(
                         return Ok(TileHarvest::default());
                     }
                     let layers = mvt::decode_tile(&raw)?;
+                    // The decoded layers own their bytes, so the compressed
+                    // tile is dead weight from here on - and eight of these
+                    // are in flight at once.
+                    drop(raw);
                     let mut harvest = TileHarvest::default();
                     for layer in layers.iter().filter(|l| l.name == BUILDING_LAYER) {
                         for feature in &layer.features {
@@ -407,7 +455,7 @@ pub fn collect_from_tiles(
                     for candidate in harvest.buildings {
                         match best.entry(candidate.gers_id.clone()) {
                             std::collections::hash_map::Entry::Occupied(mut slot) => {
-                                if candidate.vertex_count > slot.get().vertex_count {
+                                if candidate.area2 > slot.get().area2 {
                                     slot.insert(candidate);
                                 }
                             }
@@ -432,6 +480,14 @@ pub fn collect_from_tiles(
         }
     }
 
+    // Every tile failing is a broken archive, not an empty area. Returning an
+    // empty collection here would look like success, mark the release good, and
+    // rob `auto` of the Parquet fallback it promises.
+    if attempted > 0 && lost_tiles == attempted {
+        return Err(format!(
+            "all {lost_tiles} Overture tile(s) holding data could not be read"
+        ));
+    }
     if report_gaps && lost_tiles > 0 {
         eprintln!(
             "{} Overture Maps data incomplete: {lost_tiles} tile(s) could not be read. \
@@ -566,7 +622,42 @@ mod tests {
     #[test]
     fn a_continental_bbox_is_handed_back_to_the_parquet_path() {
         // Far more than MAX_TILES at zoom 14.
-        assert!(tiles_for_bbox(&bbox(42.0, -5.0, 51.0, 8.0)).len() > MAX_TILES);
+        assert!(!covers_area(&bbox(42.0, -5.0, 51.0, 8.0)));
+        assert!(covers_area(&bbox(
+            48.125768, 11.552296, 48.148565, 11.593838
+        )));
+    }
+
+    #[test]
+    fn a_world_sized_bbox_is_rejected_without_listing_its_tiles() {
+        // Hundreds of millions of tiles at zoom 14. Counting has to be
+        // arithmetic: building the coordinate list would need gigabytes just to
+        // decide not to use it.
+        let world = bbox(-85.0, -180.0, 85.0, 180.0);
+        let (min_x, max_x, min_y, max_y) = tile_range(&world);
+        assert_eq!((min_x, max_x), (0, 16383), "full longitude span");
+        assert_eq!(
+            tile_count(&world),
+            u64::from(max_y - min_y + 1) * 16384,
+            "count is the rectangle, computed not enumerated"
+        );
+        assert!(tile_count(&world) > 260_000_000);
+        assert!(!covers_area(&world));
+    }
+
+    #[test]
+    fn the_intact_copy_of_a_clipped_building_wins_on_area() {
+        // A square, and the same square cut in half by a tile edge. Clipping
+        // added a vertex, so the truncated copy has MORE vertices - which is
+        // why area, not vertex count, decides.
+        let whole = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)];
+        let clipped = [(0.0, 0.0), (0.5, 0.0), (0.5, 0.5), (0.5, 1.0), (0.0, 1.0)];
+        assert!(clipped.len() > whole.len(), "setup: clipping adds vertices");
+        assert!(ring_area2(&whole) > ring_area2(&clipped));
+
+        // Winding must not decide it either; area is taken unsigned.
+        let reversed: Vec<(f64, f64)> = whole.iter().rev().copied().collect();
+        assert!((ring_area2(&whole) - ring_area2(&reversed)).abs() < 1e-12);
     }
 
     #[test]

--- a/src/overture/tiles.rs
+++ b/src/overture/tiles.rs
@@ -1,0 +1,582 @@
+//! Overture buildings read from the published PMTiles vector tiles.
+//!
+//! Overture ships every release twice: as GeoParquet partitions (512 files,
+//! ~277 GB) and as a single planet PMTiles archive per theme in the
+//! `overturemaps-extras` bucket. Both carry the same buildings and the same
+//! attributes; they differ in what it costs to read a city out of them.
+//!
+//! The Parquet path must download a ~233 KB catalogue, then a ~1.3 MB footer
+//! per overlapping partition, before a single building is read. The tile path
+//! reads a 16 KB header, one directory page, and then only the z14 tiles the
+//! bounding box actually covers - about 1.3 MB for a whole city, and nothing at
+//! all on a repeat run, because tiles are keyed by an immutable release and
+//! cached on disk.
+//!
+//! ## What the tiles cost in fidelity
+//!
+//! Tiles quantise coordinates to the z14 lattice: 4096 steps across a tile,
+//! which is 0.40 m at 48° latitude and 0.60 m at the equator. Measured against
+//! the OSM originals for the same buildings, the resulting geometry error is a
+//! median of 0.09 m and a maximum of 0.24 m - under a third of a block at
+//! `--scale 1.0`. Vertices dropped by the tile build are collinear ones, which
+//! cost nothing. No minimum-area filter runs at the archive's maximum zoom, so
+//! footprints down to 0.1 m² are present.
+//!
+//! ## Where this path deliberately differs from Parquet
+//!
+//! A feature whose geometry is a multipolygon contributes its largest exterior
+//! ring. The Parquet reader drops such a row outright (`parse_wkb_polygon`
+//! handles WKB type 3 only), which loses the building; taking the largest part
+//! keeps one footprint per Overture row either way.
+
+use std::collections::HashMap;
+
+use rayon::prelude::*;
+use reqwest::blocking::Client;
+
+use super::cache;
+use super::mvt;
+use super::pmtiles::{self, Archive};
+use super::{
+    intern_facade_material, intern_roof_material, intern_roof_orientation, intern_roof_shape,
+    OsmAttributeHint, OsmRef, OvertureBuilding, OvertureCollection,
+};
+use crate::coordinate_system::geographic::LLBBox;
+use colored::Colorize;
+
+/// Bucket holding the pre-built vector tiles for each release.
+const OVERTURE_TILES_BUCKET: &str =
+    "https://overturemaps-extras-us-west-2.s3.us-west-2.amazonaws.com";
+
+/// Theme to read. Buildings is the only one Arnis consumes from Overture.
+const TILES_THEME: &str = "buildings";
+
+/// Layer inside the archive.
+///
+/// The archive also carries a `building_part` layer, which the Parquet path has
+/// no equivalent for. Reading it would add footprints that the other provider
+/// cannot produce, so it is deliberately left alone: swapping the transport must
+/// not change what a world contains.
+const BUILDING_LAYER: &str = "building";
+
+/// Zoom to read. The archive's maximum, and therefore its full resolution;
+/// anything lower is a generalised rendering of the same data.
+const QUERY_ZOOM: u8 = 14;
+
+/// Past this many tiles the archive stops being the cheaper option: a
+/// continental bounding box is better served by the Parquet path, which reads
+/// whole row groups covering whole regions rather than one request per square
+/// kilometre. At mid latitudes this is roughly 8,700 km².
+pub(super) const MAX_TILES: usize = 4096;
+
+/// Whether this bounding box is small enough for the tile path to be the
+/// cheaper transport. Checked before any release is tried, so a continental
+/// request goes straight to Parquet instead of failing once per release.
+pub(super) fn covers_area(bbox: &LLBBox) -> bool {
+    tiles_for_bbox(bbox).len() <= MAX_TILES
+}
+
+/// Concurrent range requests. Enough to keep the link busy, few enough that a
+/// large area cannot exhaust the process's sockets or look like an attack to
+/// the bucket.
+const FETCH_THREADS: usize = 8;
+
+/// One pool for the process, not one per fetch: the 3D preview re-fetches on
+/// every pan, and spawning eight threads each time would cost more than the
+/// requests do. Kept separate from the global Rayon pool so that blocking on
+/// HTTP cannot starve the generation work sharing it.
+fn fetch_pool() -> Result<&'static rayon::ThreadPool> {
+    static POOL: std::sync::OnceLock<std::result::Result<rayon::ThreadPool, String>> =
+        std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(FETCH_THREADS)
+            .thread_name(|i| format!("overture-tiles-{i}"))
+            .build()
+            .map_err(|e| format!("could not start the tile fetch pool: {e}"))
+    })
+    .as_ref()
+    .map_err(String::clone)
+}
+
+pub type Result<T> = std::result::Result<T, String>;
+
+/// URL of the buildings archive for one release.
+fn archive_url(release: &str) -> String {
+    format!("{OVERTURE_TILES_BUCKET}/tiles/{release}/{TILES_THEME}.pmtiles")
+}
+
+/// Cache directory for one release's tile artefacts, or `None` when the release
+/// name is not one we will build a path from.
+fn archive_cache_dir(release: &str) -> Option<std::path::PathBuf> {
+    cache::release_dir(release).map(|d| d.join("tiles").join(TILES_THEME))
+}
+
+/// Every z14 tile the bounding box touches.
+fn tiles_for_bbox(bbox: &LLBBox) -> Vec<(u32, u32)> {
+    let (min_x, min_y) = pmtiles::lonlat_to_tile(bbox.min().lng(), bbox.max().lat(), QUERY_ZOOM);
+    let (max_x, max_y) = pmtiles::lonlat_to_tile(bbox.max().lng(), bbox.min().lat(), QUERY_ZOOM);
+    let mut tiles = Vec::new();
+    for x in min_x..=max_x {
+        for y in min_y..=max_y {
+            tiles.push((x, y));
+        }
+    }
+    tiles
+}
+
+/// Tiles fetched per round. The budget is checked between rounds, so this also
+/// bounds how far past it a dense area can read: at most this many tiles' worth
+/// of footprints beyond the cap.
+const TILE_BATCH: usize = 64;
+
+/// What one tile yielded: footprints to keep, and attribute hints harvested from
+/// the OSM-sourced rows whose geometry is not kept.
+#[derive(Default)]
+struct TileHarvest {
+    buildings: Vec<TileBuilding>,
+    hints: Vec<(OsmRef, OsmAttributeHint)>,
+}
+
+/// A building as it came out of one tile, before duplicates across tile buffers
+/// are resolved.
+struct TileBuilding {
+    /// GERS id, which is stable across tiles and is what deduplication keys on.
+    gers_id: String,
+    building: OvertureBuilding,
+    /// Vertices in the ring before it was converted. A polygon clipped by a tile
+    /// boundary keeps fewer of them than the same polygon carried whole inside a
+    /// neighbouring tile's buffer, so this picks the intact copy.
+    vertex_count: usize,
+}
+
+/// Pull the OSM back-reference out of the tiles' `sources` attribute.
+///
+/// In a tile this is the same structure the Parquet column holds, serialised as
+/// a JSON array: `[{"dataset":"OpenStreetMap","record_id":"w106766186@8",...}]`.
+fn parse_sources(sources: &str) -> Option<OsmRef> {
+    let parsed: serde_json::Value = serde_json::from_str(sources).ok()?;
+    for entry in parsed.as_array()? {
+        // An entry missing `dataset` is skipped, not fatal: bailing out here
+        // would let one unrecognised source hide the OpenStreetMap entry behind
+        // it, and silently cost the height enrichment for that building.
+        let Some(dataset) = entry.get("dataset").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if !dataset.eq_ignore_ascii_case("OpenStreetMap") {
+            continue;
+        }
+        if let Some(reference) = entry
+            .get("record_id")
+            .and_then(|v| v.as_str())
+            .and_then(super::parse_record_id)
+        {
+            return Some(reference);
+        }
+    }
+    None
+}
+
+/// Convert one tile feature into a building, in geographic coordinates.
+///
+/// Returns `None` for a feature that is not a polygon, has no id, or whose
+/// rings are all degenerate.
+fn feature_to_building(
+    layer: &mvt::Layer,
+    feature: &mvt::Feature,
+    tile_x: u32,
+    tile_y: u32,
+) -> Option<TileBuilding> {
+    if feature.geom_type != mvt::GEOM_POLYGON {
+        return None;
+    }
+    let gers_id = layer.attr_str(feature, "id")?.to_string();
+
+    // Largest exterior ring; holes are dropped, as they are on the Parquet path.
+    let ring = feature
+        .rings
+        .iter()
+        .filter(|r| r.exterior && r.points.len() >= 3)
+        .max_by_key(|r| r.points.len())?;
+
+    let extent = f64::from(layer.extent);
+    let exterior_ring: Vec<(f64, f64)> = ring
+        .points
+        .iter()
+        .map(|&(x, y)| {
+            (
+                pmtiles::tile_x_to_lon(QUERY_ZOOM, tile_x, f64::from(x) / extent),
+                pmtiles::tile_y_to_lat(QUERY_ZOOM, tile_y, f64::from(y) / extent),
+            )
+        })
+        .collect();
+
+    let sources = layer.attr_str(feature, "sources");
+    let osm_ref = sources.and_then(parse_sources);
+    // `@geometry_source` states the primary source directly, which is exactly
+    // what the Parquet path infers by scanning the sources struct for the same
+    // name. Either answering yes is enough: misclassifying a building as
+    // OSM-sourced costs a duplicate footprint that OSM already provides, while
+    // missing one adds a second copy of a building the world already has.
+    let is_osm_sourced = layer
+        .attr_str(feature, "@geometry_source")
+        .is_some_and(|s| s.eq_ignore_ascii_case("OpenStreetMap"))
+        || sources.is_some_and(|s| s.contains("OpenStreetMap"));
+
+    Some(TileBuilding {
+        vertex_count: ring.points.len(),
+        gers_id: gers_id.clone(),
+        building: OvertureBuilding {
+            id: gers_id,
+            exterior_ring,
+            is_osm_sourced,
+            osm_ref,
+            height: layer.attr_f64(feature, "height"),
+            min_height: layer.attr_f64(feature, "min_height"),
+            num_floors: layer
+                .attr_f64(feature, "num_floors")
+                .filter(|f| f.is_finite() && (i32::MIN as f64..=i32::MAX as f64).contains(f))
+                .map(|f| f as i32),
+            subtype: layer.attr_str(feature, "subtype").map(str::to_owned),
+            class: layer.attr_str(feature, "class").map(str::to_owned),
+            roof_shape: layer
+                .attr_str(feature, "roof_shape")
+                .and_then(intern_roof_shape),
+            roof_material: layer
+                .attr_str(feature, "roof_material")
+                .and_then(intern_roof_material),
+            roof_orientation: layer
+                .attr_str(feature, "roof_orientation")
+                .and_then(intern_roof_orientation),
+            facade_color: layer.attr_str(feature, "facade_color").map(str::to_owned),
+            roof_color: layer.attr_str(feature, "roof_color").map(str::to_owned),
+            roof_height: layer.attr_f64(feature, "roof_height"),
+            facade_material: layer
+                .attr_str(feature, "facade_material")
+                .and_then(intern_facade_material),
+        },
+    })
+}
+
+/// Whether a footprint's own extent reaches the requested area.
+///
+/// Tiles carry a buffer of neighbouring geometry so that a polygon crossing a
+/// tile edge can still be drawn whole, which means a tile routinely contains
+/// buildings well outside it. Those are dropped here rather than carried through
+/// the coordinate transform.
+fn ring_overlaps_bbox(ring: &[(f64, f64)], bbox: &LLBBox) -> bool {
+    let (mut min_lng, mut max_lng) = (f64::MAX, f64::MIN);
+    let (mut min_lat, mut max_lat) = (f64::MAX, f64::MIN);
+    for &(lng, lat) in ring {
+        min_lng = min_lng.min(lng);
+        max_lng = max_lng.max(lng);
+        min_lat = min_lat.min(lat);
+        max_lat = max_lat.max(lat);
+    }
+    max_lng >= bbox.min().lng()
+        && min_lng <= bbox.max().lng()
+        && max_lat >= bbox.min().lat()
+        && min_lat <= bbox.max().lat()
+}
+
+/// Read every Overture building overlapping `bbox` from the tile archive.
+///
+/// Mirrors [`super::collect_overture_buildings`]: OSM-sourced rows are mined for
+/// height hints and then dropped unless `include_osm_sourced`, and the result is
+/// capped at `max_buildings`.
+pub fn collect_from_tiles(
+    client: &Client,
+    bbox: &LLBBox,
+    release: &str,
+    include_osm_sourced: bool,
+    max_buildings: usize,
+    report_gaps: bool,
+    debug: bool,
+) -> Result<OvertureCollection> {
+    let tiles = tiles_for_bbox(bbox);
+    if tiles.len() > MAX_TILES {
+        return Err(format!(
+            "area needs {} tiles at zoom {QUERY_ZOOM}, past the {MAX_TILES} this path is \
+             cheaper for",
+            tiles.len()
+        ));
+    }
+    if tiles.is_empty() {
+        return Ok(OvertureCollection::default());
+    }
+
+    let url = archive_url(release);
+    let mut archive = Archive::open(client, &url, archive_cache_dir(release))?;
+    let (min_zoom, max_zoom) = (archive.header().min_zoom, archive.header().max_zoom);
+    if !(min_zoom..=max_zoom).contains(&QUERY_ZOOM) {
+        return Err(format!(
+            "archive covers zoom {min_zoom}..={max_zoom}, which does not include the \
+             {QUERY_ZOOM} this reader needs"
+        ));
+    }
+
+    // Resolving is serial because it memoises leaf directories - a city sits
+    // behind one or two, so this is a couple of requests and then a lookup per
+    // tile. The bodies are fetched in parallel afterwards.
+    let mut located: Vec<(u32, u32, pmtiles::TileLocation)> = Vec::new();
+    for &(x, y) in &tiles {
+        match archive.locate(client, QUERY_ZOOM, x, y)? {
+            // A tile the archive does not hold is open water or empty land, not
+            // an error: there are simply no buildings there.
+            None => continue,
+            Some(location) => located.push((x, y, location)),
+        }
+    }
+
+    if debug {
+        println!(
+            "Overture tiles: {} tile(s) cover the bbox, {} hold data",
+            tiles.len(),
+            located.len()
+        );
+    }
+    let pool = fetch_pool()?;
+    let archive = &archive;
+
+    // Deduplicate across tile buffers. The same building appears in every tile
+    // whose buffer reaches it, sometimes clipped; the copy with the most
+    // vertices is the one that was carried whole.
+    let mut best: HashMap<String, TileBuilding> = HashMap::new();
+    let mut hints = super::OvertureHints::default();
+    let mut lost_tiles = 0usize;
+    let mut capped = false;
+
+    // Tiles are fetched a batch at a time rather than all at once, so the
+    // building budget can stop the fetch. Reading every tile first would hold
+    // the whole area's footprints in memory before the cap was ever consulted,
+    // which for a dense metropolitan bbox is millions of polygons.
+    for batch in located.chunks(TILE_BATCH) {
+        let results: Vec<std::result::Result<TileHarvest, String>> = pool.install(|| {
+            batch
+                .par_iter()
+                .map(|&(x, y, location)| {
+                    let raw = archive.tile(client, QUERY_ZOOM, x, y, location)?;
+                    if raw.is_empty() {
+                        return Ok(TileHarvest::default());
+                    }
+                    let layers = mvt::decode_tile(&raw)?;
+                    let mut harvest = TileHarvest::default();
+                    for layer in layers.iter().filter(|l| l.name == BUILDING_LAYER) {
+                        for feature in &layer.features {
+                            let Some(candidate) = feature_to_building(layer, feature, x, y) else {
+                                continue;
+                            };
+                            if !ring_overlaps_bbox(&candidate.building.exterior_ring, bbox) {
+                                continue;
+                            }
+                            if candidate.building.is_osm_sourced {
+                                // An OSM-sourced row is a duplicate footprint
+                                // that still carries conflated Microsoft / Esri
+                                // / 3DEP values. Unless the caller wants the
+                                // geometry too, only those values are kept -
+                                // in a European city they are 99% of the rows,
+                                // so carrying their rings would dominate memory
+                                // for data that is then thrown away.
+                                if let Some(key) = candidate.building.osm_ref {
+                                    harvest.hints.push((
+                                        key,
+                                        OsmAttributeHint {
+                                            height_m: candidate.building.height,
+                                            num_floors: candidate.building.num_floors,
+                                        },
+                                    ));
+                                }
+                                if !include_osm_sourced {
+                                    continue;
+                                }
+                            }
+                            harvest.buildings.push(candidate);
+                        }
+                    }
+                    Ok(harvest)
+                })
+                .collect()
+        });
+
+        for result in results {
+            match result {
+                Ok(harvest) => {
+                    for (key, hint) in harvest.hints {
+                        hints.insert(key, hint);
+                    }
+                    for candidate in harvest.buildings {
+                        match best.entry(candidate.gers_id.clone()) {
+                            std::collections::hash_map::Entry::Occupied(mut slot) => {
+                                if candidate.vertex_count > slot.get().vertex_count {
+                                    slot.insert(candidate);
+                                }
+                            }
+                            std::collections::hash_map::Entry::Vacant(slot) => {
+                                slot.insert(candidate);
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    lost_tiles += 1;
+                    if debug {
+                        eprintln!("Warning: Overture tile could not be read: {e}");
+                    }
+                }
+            }
+        }
+
+        if best.len() >= max_buildings {
+            capped = true;
+            break;
+        }
+    }
+
+    if report_gaps && lost_tiles > 0 {
+        eprintln!(
+            "{} Overture Maps data incomplete: {lost_tiles} tile(s) could not be read. \
+             Buildings are missing from the areas they cover.",
+            "Warning:".yellow().bold()
+        );
+    }
+
+    // A HashMap iterates in an order the standard library deliberately
+    // randomises per process, and the budget below truncates. Sorting by the
+    // GERS id makes which buildings survive a property of the data rather than
+    // of this run, so two runs of one bbox produce the same world.
+    let mut collected: Vec<TileBuilding> = best.into_values().collect();
+    collected.sort_unstable_by(|a, b| a.gers_id.cmp(&b.gers_id));
+    capped |= collected.len() > max_buildings;
+    collected.truncate(max_buildings);
+    let buildings: Vec<OvertureBuilding> = collected.into_iter().map(|c| c.building).collect();
+
+    if report_gaps && capped {
+        eprintln!(
+            "{} Reached the Overture Maps building limit ({max_buildings}); footprints \
+             beyond it were dropped, which leaves whole districts without them. \
+             Use a smaller area for full coverage.",
+            "Warning:".yellow().bold()
+        );
+    }
+
+    Ok(OvertureCollection { buildings, hints })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bbox(min_lat: f64, min_lng: f64, max_lat: f64, max_lng: f64) -> LLBBox {
+        LLBBox::new(min_lat, min_lng, max_lat, max_lng).unwrap()
+    }
+
+    #[test]
+    fn the_osm_back_reference_is_read_out_of_the_tiles_sources_json() {
+        // Verbatim shape of the attribute in Overture's published tiles.
+        let sources = r#"[{"resource":"planet","version":"2026-08-02T00:00:00.000Z","license":"ODbL-1.0","record_id":"w106766186@8","update_time":"2025-05-18T16:28:13.000Z","provider":"osm","property":"","dataset":"OpenStreetMap"}]"#;
+        let reference = parse_sources(sources).expect("OSM reference");
+        assert_eq!(reference, super::super::OsmRef::way(106_766_186));
+
+        // A non-OSM dataset contributes no reference.
+        assert!(
+            parse_sources(r#"[{"dataset":"Microsoft ML Buildings","record_id":"x1"}]"#).is_none()
+        );
+        // The OSM entry is found even when it is not the first.
+        let mixed = r#"[{"dataset":"Esri","record_id":"e1"},{"dataset":"OpenStreetMap","record_id":"r42@2"}]"#;
+        assert_eq!(
+            parse_sources(mixed),
+            Some(super::super::OsmRef::relation(42))
+        );
+        // An entry that does not even name a dataset must not hide the one
+        // behind it, or that building silently loses its height enrichment.
+        let ragged =
+            r#"[{"note":"unknown"},{"dataset":42},{"dataset":"OpenStreetMap","record_id":"w7"}]"#;
+        assert_eq!(parse_sources(ragged), Some(super::super::OsmRef::way(7)));
+        // Likewise an OSM entry whose record_id is unusable: keep looking.
+        let two_osm = r#"[{"dataset":"OpenStreetMap","record_id":"n9"},{"dataset":"OpenStreetMap","record_id":"w8"}]"#;
+        assert_eq!(parse_sources(two_osm), Some(super::super::OsmRef::way(8)));
+        // Malformed input costs the reference, never a panic.
+        for bad in [
+            "",
+            "null",
+            "{}",
+            "[",
+            "[{}]",
+            r#"[{"dataset":"OpenStreetMap"}]"#,
+        ] {
+            assert!(parse_sources(bad).is_none(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn a_bbox_covers_every_tile_it_touches() {
+        // A degenerate bbox still needs the one tile containing it.
+        let single = tiles_for_bbox(&bbox(48.137, 11.575, 48.1371, 11.5751));
+        assert_eq!(single.len(), 1);
+        assert_eq!(
+            single[0],
+            pmtiles::lonlat_to_tile(11.575, 48.137, QUERY_ZOOM)
+        );
+
+        // Main's benchmark bbox needs a small, exact rectangle of tiles.
+        let munich = tiles_for_bbox(&bbox(48.125768, 11.552296, 48.148565, 11.593838));
+        let xs: Vec<u32> = munich.iter().map(|t| t.0).collect();
+        let ys: Vec<u32> = munich.iter().map(|t| t.1).collect();
+        let width = xs.iter().max().unwrap() - xs.iter().min().unwrap() + 1;
+        let height = ys.iter().max().unwrap() - ys.iter().min().unwrap() + 1;
+        assert_eq!(munich.len() as u32, width * height);
+        assert_eq!(munich.len(), 6);
+    }
+
+    #[test]
+    fn tile_ranges_are_ordered_north_to_south() {
+        // Tile y grows southward while latitude grows northward, so the corners
+        // have to be taken from opposite edges or the range comes out empty.
+        let tiles = tiles_for_bbox(&bbox(-34.0, 18.3, -33.8, 18.6));
+        assert!(
+            !tiles.is_empty(),
+            "southern-hemisphere bbox produced no tiles"
+        );
+    }
+
+    #[test]
+    fn buffer_geometry_outside_the_request_is_dropped() {
+        let area = bbox(48.10, 11.50, 48.20, 11.60);
+        // Wholly inside.
+        assert!(ring_overlaps_bbox(
+            &[(11.55, 48.15), (11.56, 48.15), (11.56, 48.16)],
+            &area
+        ));
+        // Straddling the edge - kept, because part of it is in the world.
+        assert!(ring_overlaps_bbox(
+            &[(11.49, 48.15), (11.51, 48.15), (11.51, 48.16)],
+            &area
+        ));
+        // Entirely outside, which is what a tile buffer routinely holds.
+        assert!(!ring_overlaps_bbox(
+            &[(11.30, 48.15), (11.40, 48.15), (11.40, 48.16)],
+            &area
+        ));
+        assert!(!ring_overlaps_bbox(
+            &[(11.55, 48.30), (11.56, 48.30), (11.56, 48.31)],
+            &area
+        ));
+    }
+
+    #[test]
+    fn a_continental_bbox_is_handed_back_to_the_parquet_path() {
+        // Far more than MAX_TILES at zoom 14.
+        assert!(tiles_for_bbox(&bbox(42.0, -5.0, 51.0, 8.0)).len() > MAX_TILES);
+    }
+
+    #[test]
+    fn the_archive_url_is_built_from_the_release() {
+        assert_eq!(
+            archive_url("2026-08-19.0"),
+            "https://overturemaps-extras-us-west-2.s3.us-west-2.amazonaws.com/tiles/2026-08-19.0/buildings.pmtiles"
+        );
+        // A malformed release never becomes a cache path.
+        assert!(archive_cache_dir("../escape").is_none());
+        assert!(archive_cache_dir("2026-08-19.0").is_some());
+    }
+}

--- a/src/overture/tiles.rs
+++ b/src/overture/tiles.rs
@@ -96,21 +96,36 @@ fn tile_count(bbox: &LLBBox) -> u64 {
     u64::from(max_x - min_x + 1) * u64::from(max_y - min_y + 1)
 }
 
-/// Concurrent range requests. Enough to keep the link busy, few enough that a
-/// large area cannot exhaust the process's sockets or look like an attack to
-/// the bucket.
-const FETCH_THREADS: usize = 8;
+/// Ceiling on concurrent range requests: enough to keep the link busy, few
+/// enough that a large area cannot exhaust the process's sockets or look like
+/// an attack to the bucket.
+const FETCH_THREADS_MAX: usize = 8;
+
+/// Threads for the tile fetch pool.
+///
+/// The work is latency-bound, so concurrency past the core count would still
+/// pay - but Arnis allocates through mimalloc, which gives every thread its own
+/// heap and segments, and decoding a tile allocates hard. On a four-core CI
+/// runner a fixed eight threads therefore cost more in resident allocator
+/// arenas than the extra overlap saves on a fetch that is a handful of tiles.
+/// Scaling with the machine keeps the overlap where there are cores to hold it.
+fn fetch_thread_count() -> usize {
+    std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(2)
+        .clamp(2, FETCH_THREADS_MAX)
+}
 
 /// One pool for the process, not one per fetch: the 3D preview re-fetches on
-/// every pan, and spawning eight threads each time would cost more than the
-/// requests do. Kept separate from the global Rayon pool so that blocking on
-/// HTTP cannot starve the generation work sharing it.
+/// every pan, and spawning threads each time would cost more than the requests
+/// do. Kept separate from the global Rayon pool so that blocking on HTTP cannot
+/// starve the generation work sharing it.
 fn fetch_pool() -> Result<&'static rayon::ThreadPool> {
     static POOL: std::sync::OnceLock<std::result::Result<rayon::ThreadPool, String>> =
         std::sync::OnceLock::new();
     POOL.get_or_init(|| {
         rayon::ThreadPoolBuilder::new()
-            .num_threads(FETCH_THREADS)
+            .num_threads(fetch_thread_count())
             .thread_name(|i| format!("overture-tiles-{i}"))
             .build()
             .map_err(|e| format!("could not start the tile fetch pool: {e}"))

--- a/src/preview_3d.rs
+++ b/src/preview_3d.rs
@@ -209,6 +209,9 @@ pub fn build_buildings_geojson(bbox_text: &str) -> Result<String, String> {
     let buildings = overture::collect_overture_buildings(
         &client,
         &bbox,
+        // The preview is a repeated fetch over a small area, which is exactly
+        // where the cached tile archive costs least.
+        crate::args::OvertureSource::Auto,
         true,
         BUILDINGS_MAX_FEATURES,
         // report_gaps: the feature cap here is a render budget, not missing data,


### PR DESCRIPTION
Overture publishes every release twice: as 512 GeoParquet partitions (~277 GB) and as one planet PMTiles archive per theme. We only ever read the Parquet, which costs a ~233 KB catalogue plus a ~1.3 MB footer per overlapping partition before a single building is parsed, and re-pays all of it on every run because nothing about Overture was cached.

Adds a second transport that reads the published tiles, and a disk cache that both transports share.

Measured on the CI benchmark bbox (Munich, 8 km²), same binary, same release, identical output - 83 non-OSM buildings found, 53 added, heights filled on 197 OSM buildings either way:

  |         | cold                  | warm                 |
  |---------|-----------------------|----------------------|
  | tiles   | 1.25 MB, 9 req, 6.6s  | 0 MB, 1 req, 0.9s    |
  | parquet | 8.56 MB, 8 req, 9.5s  | 0 MB, 1 req, 4.2s    |

The one remaining warm request is release discovery, which is the freshness check and must not be cached.

Fidelity: tiles quantise to the z14 lattice, 0.40 m per step at 48°. Measured against the OSM originals for six Munich buildings, the geometry error is a median of 0.09 m and a maximum of 0.24 m - under a third of a block at scale 1.0. The dropped vertices are collinear. No minimum-area filter runs at the archive's maximum zoom, so 0.1 m² footprints survive. Every attribute the Parquet reader consumes is present in the tiles, including `sources` for the OSM dedup and height enrichment. On a sparse bbox in Nigeria the tiles find 11129 buildings against Parquet's 11127, the difference being multipolygons that `parse_wkb_polygon` drops outright and the tile path keeps the largest ring of.

Routing: `--overture-source auto` (the default) reads tiles and falls back to Parquet if the archive cannot be read, or if the area needs more than 4096 z14 tiles - past which whole row groups beat one request per square kilometre. `tiles` and `parquet` pin one transport.

Caching is keyed by release. Releases are immutable, so a cached read needs no revalidation and there is no TTL to get wrong; only which release is newest ages, and discovery answers that every run. Writes are atomic, older release directories are pruned, and the GUI's clear-cache button empties this cache with the others.

Also fixes two things the retention rule was about to break. The bundled fallback release was 2026-07-22.0, whose objects carry `expiry-date="Mon, 21 Sep 2026"` - 13 days out. It now points at 2026-08-19.0, and behind the discovered list we try the release that last actually served data on this machine before falling back to the constant, so a date baked in at build time stops being load-bearing.