### PR TITLE
Fix extended build height with elevation terrain

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -48,9 +48,8 @@ pub struct Args {
     #[arg(long, value_enum, default_value_t = crate::celestial::CelestialBody::Earth)]
     pub body: crate::celestial::CelestialBody,
 
-    /// Projection mode for coordinate mapping
-    /// local: each generation starts at Minecraft (0,0) (default)
-    /// web_mercator: not supported, it stretches the world north-south by 1/cos(latitude)
+    /// Projection mode for coordinate mapping.
+    /// local: each generation starts at Minecraft (0,0). The only supported mode.
     #[arg(long, default_value = "local")]
     pub projection: crate::projection::ProjectionKind,
 
@@ -361,11 +360,12 @@ pub fn validate_args(args: &Args) -> Result<(), String> {
         return Err("--map-preview is not supported for Luanti worlds.".to_string());
     }
 
-    // X gets a cos(lat) factor and Z does not, so the world comes out stretched north-south
-    // by 1/cos(lat) against both the elevation grid and its own east-west scale.
+    // Never shipped working: X gets a cos(lat) factor and Z does not, so the world comes out
+    // stretched north-south by 1/cos(lat) against both the elevation grid and its own
+    // east-west scale. Still parsed so an old command line gets this instead of a parse error.
     if args.projection == crate::projection::ProjectionKind::WebMercator {
         return Err(
-            "--projection web_mercator is currently broken: it stretches the world north-south by 1/cos(latitude) (about 1.5x at 47 degrees), so OSM objects come out elongated and misaligned with the terrain. Use --projection local."
+            "--projection web_mercator was experimental and never worked: it stretches the world north-south by 1/cos(latitude) (about 1.5x at 47 degrees), so objects come out elongated and misaligned with the terrain. Use --projection local."
                 .to_string(),
         );
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -50,12 +50,12 @@ pub struct Args {
 
     /// Projection mode for coordinate mapping
     /// local: each generation starts at Minecraft (0,0) (default)
-    /// web_mercator: global projection for multi-generation worlds
+    /// web_mercator: not supported, it stretches the world north-south by 1/cos(latitude)
     #[arg(long, default_value = "local")]
     pub projection: crate::projection::ProjectionKind,
 
     /// Ground level to use in the Minecraft world
-    #[arg(long, default_value_t = -62)]
+    #[arg(long, default_value_t = -62, allow_hyphen_values = true)]
     pub ground_level: i32,
 
     /// What to generate, mirroring the GUI's generation mode dropdown:
@@ -361,6 +361,15 @@ pub fn validate_args(args: &Args) -> Result<(), String> {
         return Err("--map-preview is not supported for Luanti worlds.".to_string());
     }
 
+    // X gets a cos(lat) factor and Z does not, so the world comes out stretched north-south
+    // by 1/cos(lat) against both the elevation grid and its own east-west scale.
+    if args.projection == crate::projection::ProjectionKind::WebMercator {
+        return Err(
+            "--projection web_mercator is currently broken: it stretches the world north-south by 1/cos(latitude) (about 1.5x at 47 degrees), so OSM objects come out elongated and misaligned with the terrain. Use --projection local."
+                .to_string(),
+        );
+    }
+
     // A bounding box is required unless a local --file supplies one to derive it from.
     // Terrain-only mode ignores --file (it never loads OSM objects), so it always needs --bbox.
     if args.bbox.is_none() {
@@ -450,7 +459,25 @@ pub fn validate_args(args: &Args) -> Result<(), String> {
         return Err("Rotation angle must be between -90 and 90 degrees.".to_string());
     }
 
+    let (floor, ceiling) = ground_level_bounds(args);
+    if args.ground_level < floor || args.ground_level > ceiling {
+        return Err(format!(
+            "--ground-level must be between {floor} and {ceiling} for this world format (got {}).",
+            args.ground_level
+        ));
+    }
+
     Ok(())
+}
+
+/// Legal `--ground-level` range for the chosen output format. The scaler clamps every column
+/// into `[ground_level, ceiling]`, so a base above the ceiling makes that clamp's min exceed
+/// its max and aborts the run after the whole elevation download.
+fn ground_level_bounds(args: &Args) -> (i32, i32) {
+    let floor = crate::ground::extended_min_y_for(args) + 2;
+    let ceiling =
+        crate::ground::world_top_y_for(args) - crate::elevation::postprocess::TERRAIN_HEIGHT_BUFFER;
+    (floor, ceiling)
 }
 
 fn parse_duration(arg: &str) -> Result<std::time::Duration, std::num::ParseIntError> {
@@ -501,6 +528,88 @@ mod tests {
         let mut cmd: Vec<&str> = base.to_vec();
         cmd.extend_from_slice(&["--mode", "objects"]);
         assert!(Args::try_parse_from(cmd.iter()).is_err());
+    }
+
+    #[test]
+    fn web_mercator_projection_is_rejected() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let tmp_path = tmpdir.path().to_str().unwrap();
+        let parse = |extra: &[&str]| {
+            let mut cmd = vec!["arnis", "--output-dir", tmp_path, "--bbox", "1,2,3,4"];
+            cmd.extend_from_slice(extra);
+            Args::parse_from(cmd.iter())
+        };
+
+        assert!(validate_args(&parse(&["--projection", "local"])).is_ok());
+        let err = validate_args(&parse(&["--projection", "web_mercator"])).unwrap_err();
+        assert!(err.contains("--projection local"), "unhelpful error: {err}");
+        // Not just the terrain path: geo-only is distorted too.
+        assert!(
+            validate_args(&parse(&["--projection", "mercator", "--mode", "geo-only"])).is_err()
+        );
+    }
+
+    #[test]
+    fn ground_level_is_bounded_by_the_world_ceiling() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let tmp_path = tmpdir.path().to_str().unwrap();
+        let parse = |extra: &[&str]| {
+            let mut cmd = vec!["arnis", "--output-dir", tmp_path, "--bbox", "1,2,3,4"];
+            cmd.extend_from_slice(extra);
+            Args::parse_from(cmd.iter())
+        };
+
+        let gl = |flags: &[&str], level: i32| {
+            let mut args = parse(flags);
+            args.ground_level = level;
+            validate_args(&args)
+        };
+
+        assert!(validate_args(&parse(&[])).is_ok());
+        // Vanilla ceiling is 319 - 15; above it the scaler's clamp has min > max and panics.
+        assert!(gl(&[], 304).is_ok());
+        assert!(gl(&[], 305).is_err());
+        assert!(gl(&[], 400).is_err());
+        // Below the bedrock plane there is nothing to stand on.
+        assert!(gl(&[], -63).is_err());
+
+        // The tall datapack raises the ceiling to 2031; Bedrock's pack stops far below it.
+        let dhl: &[&str] = &["--disable-height-limit"];
+        assert!(gl(dhl, 2016).is_ok());
+        assert!(gl(dhl, 2017).is_err());
+        assert!(gl(dhl, -2030).is_ok());
+        assert!(gl(dhl, -2031).is_err());
+        assert!(gl(&["--bedrock", "--disable-height-limit"], 500).is_err());
+    }
+
+    #[test]
+    fn formats_without_an_extended_dimension_keep_the_vanilla_ground_level_range() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let tmp_path = tmpdir.path().to_str().unwrap();
+        let gl = |flags: &[&str], level: i32| {
+            let mut cmd = vec!["arnis", "--output-dir", tmp_path, "--bbox", "1,2,3,4"];
+            cmd.extend_from_slice(flags);
+            let mut args = Args::parse_from(cmd.iter());
+            args.ground_level = level;
+            validate_args(&args)
+        };
+
+        for flags in [
+            &["--luanti"][..],
+            &["--luanti", "--disable-height-limit"][..],
+            &["--bedrock"][..],
+        ] {
+            assert!(gl(flags, -62).is_ok(), "{flags:?} rejected the default");
+            assert!(gl(flags, 304).is_ok(), "{flags:?} rejected 304");
+            assert!(gl(flags, 305).is_err(), "{flags:?} accepted 305");
+            assert!(gl(flags, -63).is_err(), "{flags:?} accepted -63");
+        }
+
+        // Bedrock's behavior pack raises the ceiling to 511 but leaves the floor vanilla.
+        let bedrock_dhl: &[&str] = &["--bedrock", "--disable-height-limit"];
+        assert!(gl(bedrock_dhl, 496).is_ok());
+        assert!(gl(bedrock_dhl, 497).is_err());
+        assert!(gl(bedrock_dhl, -63).is_err());
     }
 
     #[test]

--- a/src/data_processing.rs
+++ b/src/data_processing.rs
@@ -488,16 +488,15 @@ fn process_element(
 /// Whether to stream regions to disk (lower peak RAM) for `num_regions` regions. Auto-enabled
 /// when the estimated resident world would crowd available RAM; trades some time for RAM, output
 /// unchanged (3D models + subways preserved). `ARNIS_STREAM_TO_DISK=1/0` overrides; constants tunable.
-fn should_stream_to_disk(num_regions: usize, available_mb: u64) -> bool {
+fn should_stream_to_disk(num_regions: usize, available_mb: u64, fillground: bool) -> bool {
     match std::env::var("ARNIS_STREAM_TO_DISK").ok().as_deref() {
         Some("1") => return true,
         Some("0") => return false,
         _ => {}
     }
-    // Calibrated on a dense full-feature run (terrain + land cover + Overture + 3D): ~26 MB/region.
     const BASE_MB: u64 = 500;
-    const PER_REGION_MB: u64 = 26;
-    let est_peak_mb = BASE_MB + PER_REGION_MB * num_regions as u64;
+    let est_peak_mb =
+        BASE_MB + crate::world_editor::per_region_estimate_mb(fillground) * num_regions as u64;
 
     // Stream once the estimate would use >55% of available RAM (unknown memory -> fast path).
     available_mb > 0 && est_peak_mb * 100 > available_mb * 55
@@ -629,9 +628,16 @@ pub fn generate_world_with_options(
     bench.mark("ground_warm");
     // Load the schematic tree pack once (None keeps procedural trees); shared with tile editors.
     // Uses the ground's real base, not args: the montane check measures blocks above it, and
-    // the base sinks when the relief needs the extended floor.
-    let tree_pack =
-        crate::trees::tree_pack::load(args, llbbox, args.scale, ground.base_level()).map(Arc::new);
+    // the base sinks when the relief needs the extended floor. Its blocks-per-metre turns those
+    // blocks back into metres, which compression makes far smaller than args.scale.
+    let tree_pack = crate::trees::tree_pack::load(
+        args,
+        llbbox,
+        args.scale,
+        ground.base_level(),
+        ground.blocks_per_meter(),
+    )
+    .map(Arc::new);
     bench.reset();
 
     // Per-cell water depth field from the LC_WATER mask; empty without land cover.
@@ -818,7 +824,7 @@ pub fn generate_world_with_options(
         // optimistic figure would skip streaming in exactly the runs that need it.
         let available_mb = available_memory_mb();
         eviction_active = matches!(world_format, WorldFormat::JavaAnvil)
-            && should_stream_to_disk(tiles.len(), available_mb);
+            && should_stream_to_disk(tiles.len(), available_mb, args.fillground);
 
         // Regions any 3D placement may write to: kept resident (not evicted in-loop)
         // so the post-merge placement pass lands in RAM, then flushed at finalize.
@@ -835,8 +841,11 @@ pub fn generate_world_with_options(
         };
 
         if eviction_active {
-            let (flush_threads, flush_queue) =
-                crate::world_editor::flush_pool_params(tile_batch_size, available_mb);
+            let (flush_threads, flush_queue) = crate::world_editor::flush_pool_params(
+                tile_batch_size,
+                available_mb,
+                args.fillground,
+            );
             if args.benchmark {
                 eprintln!("[BENCHMARK] flush_threads={flush_threads} flush_queue={flush_queue}");
             }

--- a/src/element_processing/waterways.rs
+++ b/src/element_processing/waterways.rs
@@ -23,10 +23,8 @@ pub fn generate_waterways(editor: &mut WorldEditor, element: &ProcessedWay) {
             let prev_node = nodes_pair[0].xz();
             let current_node = nodes_pair[1].xz();
 
-            // Compute flat water level for this segment (min of both endpoints)
-            let seg_water_y = editor
-                .get_water_level(prev_node.x, prev_node.z)
-                .min(editor.get_water_level(current_node.x, current_node.z));
+            let y0 = editor.get_water_level(prev_node.x, prev_node.z);
+            let y1 = editor.get_water_level(current_node.x, current_node.z);
 
             // Draw a line between the current and previous node
             let bresenham_points: Vec<(i32, i32, i32)> = bresenham_line(
@@ -38,7 +36,18 @@ pub fn generate_waterways(editor: &mut WorldEditor, element: &ProcessedWay) {
                 current_node.z,
             );
 
-            for (bx, _, bz) in bresenham_points {
+            // A flat Y per segment leaves puddles near the lower node, so ramp between
+            // the endpoints and clamp to the local surface so the sheet never floats.
+            let last = bresenham_points.len().saturating_sub(1) as i64;
+            let dy = i64::from(y1 - y0);
+            for (i, (bx, _, bz)) in bresenham_points.into_iter().enumerate() {
+                let ramped = if last > 0 {
+                    let num = dy * i as i64;
+                    y0 + ((2 * num + last * dy.signum()) / (2 * last)) as i32
+                } else {
+                    y0.min(y1)
+                };
+                let seg_water_y = ramped.min(editor.get_water_level(bx, bz));
                 create_water_channel(editor, bx, bz, waterway_width, seg_water_y);
             }
         }
@@ -123,7 +132,7 @@ fn create_water_channel(
     center_x: i32,
     center_z: i32,
     width: i32,
-    flat_water_y: i32,
+    target_water_y: i32,
 ) {
     const BANK_TOLERANCE: i32 = 2;
     let half_width = width / 2;
@@ -138,9 +147,9 @@ fn create_water_channel(
                 let ground_y = editor.get_ground_level(x, z);
                 // Only place water where terrain is at or below the water surface,
                 // but allow small elevation steps to avoid gaps on gentle slopes.
-                let water_y = if ground_y <= flat_water_y {
-                    Some(flat_water_y)
-                } else if ground_y <= flat_water_y + BANK_TOLERANCE
+                let water_y = if ground_y <= target_water_y {
+                    Some(target_water_y)
+                } else if ground_y <= target_water_y + BANK_TOLERANCE
                     && !editor.block_exists_absolute(x, ground_y, z)
                 {
                     Some(ground_y)
@@ -162,6 +171,121 @@ fn create_water_channel(
                     );
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod waterway_profile_tests {
+    use super::*;
+    use crate::coordinate_system::cartesian::XZBBox;
+    use crate::coordinate_system::geographic::LLBBox;
+    use crate::ground::Ground;
+    use crate::osm_parser::ProcessedNode;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    const SIDE: usize = 64;
+    const CENTER_X: i32 = 32;
+    const FIRST_Z: i32 = 4;
+    const LAST_Z: i32 = 52;
+
+    fn world_bbox() -> XZBBox {
+        XZBBox::rect_from_min_max(0, 0, SIDE as i32 - 1, SIDE as i32 - 1).unwrap()
+    }
+
+    /// Terrain dropping `per_block` blocks per step along Z, gentle enough that
+    /// `water_level` never snaps, so a column's expected surface is its own level.
+    fn editor_over_slope(bbox: &XZBBox, top: f64, per_block: f64) -> WorldEditor<'_> {
+        let heights: Vec<Vec<f32>> = (0..SIDE)
+            .map(|z| vec![(top - per_block * z as f64) as f32; SIDE])
+            .collect();
+        let ground = Ground::new_elevation_test(heights, SIDE, SIDE);
+        let llbbox = LLBBox::new(54.6, 9.9, 54.61, 9.91).unwrap();
+        let mut editor = WorldEditor::new(PathBuf::from("/dev/null/unused"), bbox, llbbox);
+        editor.set_ground(Arc::new(ground));
+        editor
+    }
+
+    fn stream(from_z: i32, to_z: i32) -> ProcessedWay {
+        let node = |id: u64, z: i32| ProcessedNode {
+            id,
+            tags: HashMap::new(),
+            x: CENTER_X,
+            z,
+        };
+        let mut tags = HashMap::new();
+        tags.insert("waterway".to_string(), "stream".to_string());
+        ProcessedWay {
+            id: 1,
+            nodes: vec![node(1, from_z), node(2, to_z)],
+            tags,
+        }
+    }
+
+    fn water_ys(editor: &WorldEditor, x: i32, z: i32) -> Vec<i32> {
+        (-8..40)
+            .filter(|&y| editor.check_for_block_absolute(x, y, z, Some(&[WATER]), None))
+            .collect()
+    }
+
+    #[test]
+    fn a_dropping_channel_follows_the_terrain_instead_of_pooling_at_the_lower_node() {
+        let bbox = world_bbox();
+        let mut editor = editor_over_slope(&bbox, 16.0, 0.25);
+        generate_waterways(&mut editor, &stream(FIRST_Z, LAST_Z));
+
+        let upper = editor.get_water_level(CENTER_X, FIRST_Z);
+        let lower = editor.get_water_level(CENTER_X, LAST_Z);
+        assert_eq!((upper, lower), (15, 3), "test fixture no longer drops 12");
+
+        for z in FIRST_Z..=LAST_Z {
+            let local = editor.get_water_level(CENTER_X, z);
+            let ys = water_ys(&editor, CENTER_X, z);
+            assert!(!ys.is_empty(), "dry gap at z={z}, local level {local}");
+            let top = *ys.iter().max().unwrap();
+            assert!(
+                (top - local).abs() <= 1,
+                "z={z}: surface {top} does not track the local level {local}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_flat_channel_sits_at_the_single_shared_level() {
+        let bbox = world_bbox();
+        let mut editor = editor_over_slope(&bbox, 8.0, 0.0);
+        generate_waterways(&mut editor, &stream(FIRST_Z, LAST_Z));
+
+        for z in FIRST_Z..=LAST_Z {
+            assert_eq!(
+                water_ys(&editor, CENTER_X, z),
+                vec![8],
+                "flat terrain must place one sheet at the shared level, z={z}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_one_block_drop_moves_the_upper_half_by_at_most_one_block() {
+        let bbox = world_bbox();
+        let mut editor = editor_over_slope(&bbox, 8.0, 0.02);
+        generate_waterways(&mut editor, &stream(FIRST_Z, LAST_Z));
+
+        let upper = editor.get_water_level(CENTER_X, FIRST_Z);
+        let lower = editor.get_water_level(CENTER_X, LAST_Z);
+        assert_eq!((upper, lower), (8, 7), "test fixture no longer drops 1");
+
+        let top_at =
+            |editor: &WorldEditor, z: i32| *water_ys(editor, CENTER_X, z).iter().max().unwrap();
+        assert_eq!(top_at(&editor, FIRST_Z), upper, "upstream end left behind");
+        assert_eq!(top_at(&editor, LAST_Z), lower, "downstream end lifted");
+        for z in FIRST_Z..=LAST_Z {
+            let top = top_at(&editor, z);
+            assert!(
+                top == lower || top == lower + 1,
+                "z={z}: {top} is more than one block off the pre-ramp level {lower}"
+            );
         }
     }
 }

--- a/src/elevation/mod.rs
+++ b/src/elevation/mod.rs
@@ -41,6 +41,10 @@ pub struct ElevationData {
     /// elevation (e.g. the snow line) to a Minecraft Y threshold.
     pub(crate) min_height_m: f64,
     pub(crate) blocks_per_meter: f64,
+    /// Converts a Minecraft-Y difference into the `8 * tan(incline)` units the
+    /// slope thresholds are documented in: `args.scale / blocks_per_meter`.
+    /// 1.0 whenever vertical compression did not fire.
+    pub(crate) slope_correction: f64,
     /// Terrain base actually used: the requested ground level, or lower if the relief
     /// needed the extended floor. Every consumer of the affine must use this, not args.
     pub(crate) ground_level: i32,
@@ -57,9 +61,10 @@ pub struct ElevationData {
 /// capped and block-level elevation is filled via bilinear interpolation
 /// — terrain remains generated, just with sub-native sampling.
 ///
-/// Memory note: a full 16384 × 16384 f64 grid is ~2 GB; with the
-/// water_blend_grid and a snapshot during repair we can peak around
-/// 6 GB for the maximum case. Target deployment (MapSmith) has >20 GB
+/// Memory note: a full 16384 × 16384 f64 grid is ~2.1 GB. The peak is the
+/// land-cover Gaussian, which holds the height grid, one blur buffer of the
+/// same size and an f32 feathered mask alongside the land-cover grids: about
+/// 6.5 GB for the maximum case. Target deployment (MapSmith) has >20 GB
 /// available. Typical user bboxes stay well below the cap.
 pub const MAX_ELEVATION_GRID_DIM: usize = 16384;
 
@@ -152,13 +157,16 @@ pub fn fetch_elevation_data(
 
     // Shared post-processing pipeline
     let mut height_grid = raw.heights_meters;
-    // Both passes target Earth DSM defects and actively damage altimetry: a lunar
-    // mare is flat to within metres, so its IQR is near zero and a real central
-    // peak reads as corruption. PDS gaps are already NaN, so fill is all we need.
+    let (bbox_height_m, bbox_width_m) = geo_distance(bbox.min(), bbox.max());
+    let m_per_cell = (bbox_width_m / grid_width as f64 + bbox_height_m / grid_height as f64) * 0.5;
+    // Both passes target Earth DSM defects and actively damage altimetry: the outlier
+    // gate is calibrated on Earth's elevation range, and a lunar mare is flat to within
+    // metres so a real central peak reads as an anomaly to the MAD filter. PDS gaps are
+    // already NaN, so fill is all we need.
     if source_mode.allows_earth_fallback() {
         filter_elevation_outliers(&mut height_grid);
         bench.mark("elev_filter_outliers");
-        repair_terrain_anomalies(&mut height_grid);
+        repair_terrain_anomalies(&mut height_grid, m_per_cell);
         bench.mark("elev_repair_anomalies");
     }
     emit_gui_progress_update(14.0, "Processing elevation...");
@@ -188,8 +196,6 @@ pub fn fetch_elevation_data(
     // cliff with stepped stone walls.
     const BUILT_UP_SIGMA_M: f64 = 30.0;
     const COASTAL_PULL_M: f64 = 25.0;
-    let (bbox_height_m, bbox_width_m) = geo_distance(bbox.min(), bbox.max());
-    let m_per_cell = (bbox_width_m / grid_width as f64 + bbox_height_m / grid_height as f64) * 0.5;
     let (built_up_sigma_cells, coastal_pull_cells) = if m_per_cell > 0.0 {
         (
             BUILT_UP_SIGMA_M / m_per_cell,
@@ -255,6 +261,11 @@ pub fn fetch_elevation_data(
         world_height,
         min_height_m,
         blocks_per_meter,
+        slope_correction: if blocks_per_meter > 0.0 {
+            scale / blocks_per_meter
+        } else {
+            1.0
+        },
         ground_level: effective_ground_level,
     })
 }

--- a/src/elevation/postprocess.rs
+++ b/src/elevation/postprocess.rs
@@ -6,7 +6,7 @@ use std::collections::VecDeque;
 const MAX_Y: i32 = 319;
 
 /// Buffer at the top for buildings, trees, and other structures
-const TERRAIN_HEIGHT_BUFFER: i32 = 15;
+pub(crate) const TERRAIN_HEIGHT_BUFFER: i32 = 15;
 
 /// Largest water component a steep-slope shadow blob can be. Real bodies are bigger.
 const MAX_STEEP_WATER_AREA_M2: f64 = 250_000.0;
@@ -32,7 +32,11 @@ const MIN_PERCHED_FRACTION: f64 = 0.10;
 /// writes only into the inner cells of `heights`, so the per-row work is independent
 /// and parallelised with rayon. On a 16k² grid (the worst case the elevation
 /// pipeline allows) this is the dominant elevation post-processing cost.
-pub fn repair_terrain_anomalies(heights: &mut [Vec<f64>]) {
+///
+/// `m_per_cell` keeps the erosion reach at a constant physical scale: the window is
+/// cell-based, so at tens of metres per cell (a capped grid, or a very low `--scale`)
+/// the default 10 passes eat real landforms hundreds of metres across.
+pub fn repair_terrain_anomalies(heights: &mut [Vec<f64>], m_per_cell: f64) {
     let grid_h = heights.len();
     if grid_h < 5 {
         return;
@@ -43,9 +47,12 @@ pub fn repair_terrain_anomalies(heights: &mut [Vec<f64>]) {
     }
 
     const RADIUS: i32 = 2; // 5x5 window (24 neighbors)
-    const PASSES: usize = 10; // max passes; early-break when no more anomalies found
-    const ABS_THRESHOLD: f64 = 6.0; // minimum deviation in meters
     const RELATIVE_FACTOR: f64 = 3.0; // deviation must exceed this × MAD
+
+    // At block resolution this is the 6 m / 10 pass behaviour; past a few metres per cell the
+    // window covers real landforms, so widen the gate and stop early.
+    let abs_threshold = 6.0f64.max(0.25 * m_per_cell);
+    let passes = if m_per_cell > 4.0 { 2 } else { 10 };
 
     let r = RADIUS as usize;
     // Reuse the snapshot buffer across passes (saves ~128 MB/pass of allocs
@@ -54,7 +61,7 @@ pub fn repair_terrain_anomalies(heights: &mut [Vec<f64>]) {
     let mut total_repaired = 0usize;
     let mut passes_ran = 0usize;
 
-    for pass in 0..PASSES {
+    for pass in 0..passes {
         if pass > 0 {
             // Refresh the snapshot to last pass's writes — also done in
             // parallel because both sides are large contiguous allocs and
@@ -110,7 +117,7 @@ pub fn repair_terrain_anomalies(heights: &mut [Vec<f64>]) {
                         let mad = abs_devs[mad_mid];
 
                         let deviation = (center - median).abs();
-                        if deviation > ABS_THRESHOLD && deviation > RELATIVE_FACTOR * mad.max(1.0) {
+                        if deviation > abs_threshold && deviation > RELATIVE_FACTOR * mad.max(1.0) {
                             row[x] = median;
                             row_repaired += 1;
                         }
@@ -139,7 +146,7 @@ pub fn repair_terrain_anomalies(heights: &mut [Vec<f64>]) {
 
 /// Apply land-cover-aware repair to the raw elevation grid (in meters).
 ///
-/// This runs after the general MAD/IQR cleanup to target artifacts that are
+/// This runs after the general MAD cleanup to target artifacts that are
 /// too coherent for a small-window outlier filter:
 ///
 /// - **Small water blobs on steep terrain** (ESA shadow on cliff faces) are dropped
@@ -1259,43 +1266,25 @@ fn smooth_built_up_gaussian(
         return;
     }
 
-    // Binary built-up mask (1.0 = built-up, 0.0 = everything else).
-    let mask: Vec<Vec<f64>> = lc_grid
-        .par_iter()
-        .map(|row| {
-            row.iter()
-                .map(|&c| if c == LC_BUILT_UP { 1.0 } else { 0.0 })
-                .collect()
-        })
-        .collect();
-
-    // Blur the mask itself -> feathered weights with a smooth 0..1 falloff
-    // across the built-up boundary. Without this we'd get a visible seam.
+    // Blur the binary built-up mask -> feathered weights with a smooth 0..1 falloff
+    // across the built-up boundary. Without this we'd get a visible seam. The mask is
+    // read straight out of lc_grid and kept as f32: it is only ever a lerp weight.
     // Mask blur is the first half of this step's progress, heights blur the second.
-    let feathered_mask = gaussian_blur_grid_reported(&mask, sigma_cells, &|f| report(0.5 * f));
-    drop(mask);
+    let feathered_mask =
+        gaussian_blur_mask_to_f32_reported(lc_grid, LC_BUILT_UP, w, h, sigma_cells, &|f| {
+            report(0.5 * f)
+        });
 
-    // Build the source for the heights blur with *water-surface* cells set
-    // to NaN so they don't contribute. Without this the blur averages water
-    // (low) into nearby built-up cells and produces a visible "rising ramp"
-    // from water into the city — the coastal artifact we already fix with
-    // the explicit pull-down pass. Using is_water_surface (not LC_WATER)
-    // means canyon wall cells misclassified as water still contribute like
-    // the terrain they actually are.
-    let heights_for_blur: Vec<Vec<f64>> = heights
-        .par_iter()
-        .zip(is_water_surface.par_iter())
-        .map(|(h_row, ws_row)| {
-            h_row
-                .iter()
-                .zip(ws_row.iter())
-                .map(|(&v, &is_ws)| if is_ws { f64::NAN } else { v })
-                .collect()
-        })
-        .collect();
+    // Blur the heights with *water-surface* cells read as NaN so they don't
+    // contribute. Without this the blur averages water (low) into nearby built-up
+    // cells and produces a visible "rising ramp" from water into the city, the
+    // coastal artifact we already fix with the explicit pull-down pass. Using
+    // is_water_surface (not LC_WATER) means canyon wall cells misclassified as
+    // water still contribute like the terrain they actually are.
     let blurred_heights =
-        gaussian_blur_grid_reported(&heights_for_blur, sigma_cells, &|f| report(0.5 + 0.5 * f));
-    drop(heights_for_blur);
+        gaussian_blur_heights_masked(heights, is_water_surface, sigma_cells, &|f| {
+            report(0.5 + 0.5 * f)
+        });
 
     // Blend through the feathered mask. Water-surface cells are skipped so
     // the leveled water surface from the previous pass survives intact.
@@ -1305,7 +1294,7 @@ fn smooth_built_up_gaussian(
             if is_water_surface[y][x] {
                 continue;
             }
-            let m = feathered_mask[y][x].clamp(0.0, 1.0);
+            let m = (feathered_mask[y][x] as f64).clamp(0.0, 1.0);
             if m <= 1.0e-4 {
                 continue;
             }
@@ -1356,90 +1345,137 @@ fn gaussian_blur_grid_reported(
         return vec![Vec::new(); h];
     }
 
-    // ~10 chunks per pass: enough to animate the bar, few enough that the extra
-    // rayon barriers cost nothing measurable.
-    const CHUNKS: usize = 10;
-
-    // Horizontal pass — rows are independent.
-    let row_chunk = h.div_ceil(CHUNKS);
+    let row_chunk = h.div_ceil(BLUR_CHUNKS);
     let mut after_h: Vec<Vec<f64>> = Vec::with_capacity(h);
     for rows in grid.chunks(row_chunk) {
         let mut part: Vec<Vec<f64>> = rows
             .par_iter()
-            .map(|row| {
-                let row_len = row.len() as i32;
-                (0..row.len())
-                    .map(|i| {
-                        let mut sum = 0.0;
-                        let mut wsum = 0.0;
-                        for (j, &k) in kernel.iter().enumerate() {
-                            let idx = i as i32 + j as i32 - half;
-                            if idx >= 0 && idx < row_len {
-                                let v = row[idx as usize];
-                                if v.is_finite() {
-                                    sum += v * k;
-                                    wsum += k;
-                                }
-                            }
-                        }
-                        if wsum > 0.0 {
-                            sum / wsum
-                        } else {
-                            f64::NAN
-                        }
-                    })
-                    .collect()
-            })
+            .map(|row| blur_line(row.len(), &kernel, half, |i| row[i]))
             .collect();
         after_h.append(&mut part);
         report(0.5 * (after_h.len() as f64 / h as f64));
     }
 
-    // Vertical pass — columns are independent. Work column-at-a-time to keep
-    // memory access sequential within each parallel task.
-    let col_chunk = w.div_ceil(CHUNKS);
-    let mut out: Vec<Vec<f64>> = vec![vec![0.0; w]; h];
+    gaussian_blur_vertical_in_place(&mut after_h, &kernel, half, w, report);
+    after_h
+}
+
+/// `gaussian_blur_grid_reported` over `heights` with every `masked` cell read as NaN,
+/// so it contributes nothing. Identical output to blurring a pre-built masked copy,
+/// without allocating one.
+fn gaussian_blur_heights_masked(
+    heights: &[Vec<f64>],
+    masked: &[Vec<bool>],
+    sigma: f64,
+    report: &dyn Fn(f64),
+) -> Vec<Vec<f64>> {
+    let kernel_size: usize = (sigma * 3.0).ceil() as usize * 2 + 1;
+    let kernel = create_gaussian_kernel(kernel_size, sigma);
+    let half = kernel_size as i32 / 2;
+
+    let h = heights.len().min(masked.len());
+    if h == 0 {
+        return Vec::new();
+    }
+    let w = heights[0].len().min(masked[0].len());
+    if w == 0 {
+        return vec![Vec::new(); h];
+    }
+
+    let row_chunk = h.div_ceil(BLUR_CHUNKS);
+    let mut after_h: Vec<Vec<f64>> = Vec::with_capacity(h);
+    let mut y0 = 0usize;
+    while y0 < h {
+        let y1 = (y0 + row_chunk).min(h);
+        let mut part: Vec<Vec<f64>> = (y0..y1)
+            .into_par_iter()
+            .map(|y| {
+                let (row, m_row) = (&heights[y], &masked[y]);
+                let len = row.len().min(m_row.len());
+                blur_line(
+                    len,
+                    &kernel,
+                    half,
+                    |i| if m_row[i] { f64::NAN } else { row[i] },
+                )
+            })
+            .collect();
+        after_h.append(&mut part);
+        y0 = y1;
+        report(0.5 * (after_h.len() as f64 / h as f64));
+    }
+
+    gaussian_blur_vertical_in_place(&mut after_h, &kernel, half, w, report);
+    after_h
+}
+
+/// ~10 chunks per pass: enough to animate the bar, few enough that the extra
+/// rayon barriers cost nothing measurable.
+const BLUR_CHUNKS: usize = 10;
+
+/// One separable pass over a line of `len` samples. `get` supplies the source value so
+/// a caller can synthesise masked-out cells without materialising a copy of the grid.
+/// Edges are handled by renormalizing over the valid samples.
+#[inline]
+fn blur_line(len: usize, kernel: &[f64], half: i32, get: impl Fn(usize) -> f64) -> Vec<f64> {
+    let line_len = len as i32;
+    (0..len)
+        .map(|i| {
+            let mut sum = 0.0;
+            let mut wsum = 0.0;
+            for (j, &k) in kernel.iter().enumerate() {
+                let idx = i as i32 + j as i32 - half;
+                if idx >= 0 && idx < line_len {
+                    let v = get(idx as usize);
+                    if v.is_finite() {
+                        sum += v * k;
+                        wsum += k;
+                    }
+                }
+            }
+            if wsum > 0.0 {
+                sum / wsum
+            } else {
+                f64::NAN
+            }
+        })
+        .collect()
+}
+
+/// Vertical half of the separable blur, written back over the horizontal result.
+/// Every column is copied out before it is computed and only reads its own column, and
+/// a chunk's writes land after all of its columns have been read, so nothing reads a
+/// cell that was already overwritten and no second full-grid buffer is needed.
+fn gaussian_blur_vertical_in_place(
+    after_h: &mut [Vec<f64>],
+    kernel: &[f64],
+    half: i32,
+    w: usize,
+    report: &dyn Fn(f64),
+) {
+    let col_chunk = w.div_ceil(BLUR_CHUNKS);
     let mut x0 = 0usize;
     while x0 < w {
         let x1 = (x0 + col_chunk).min(w);
-        let blurred: Vec<(usize, Vec<f64>)> = (x0..x1)
-            .into_par_iter()
-            .map(|x| {
-                let column: Vec<f64> = after_h.iter().map(|row| row[x]).collect();
-                let col_len = column.len() as i32;
-                let col: Vec<f64> = (0..column.len())
-                    .map(|y| {
-                        let mut sum = 0.0;
-                        let mut wsum = 0.0;
-                        for (j, &k) in kernel.iter().enumerate() {
-                            let idx = y as i32 + j as i32 - half;
-                            if idx >= 0 && idx < col_len {
-                                let v = column[idx as usize];
-                                if v.is_finite() {
-                                    sum += v * k;
-                                    wsum += k;
-                                }
-                            }
-                        }
-                        if wsum > 0.0 {
-                            sum / wsum
-                        } else {
-                            f64::NAN
-                        }
-                    })
-                    .collect();
-                (x, col)
-            })
-            .collect();
+        let blurred: Vec<(usize, Vec<f64>)> = {
+            let src: &[Vec<f64>] = after_h;
+            (x0..x1)
+                .into_par_iter()
+                .map(|x| {
+                    let column: Vec<f64> = src.iter().map(|row| row[x]).collect();
+                    let col = blur_line(column.len(), kernel, half, |i| column[i]);
+                    (x, col)
+                })
+                .collect()
+        };
         for (x, col) in blurred {
             for (y, v) in col.into_iter().enumerate() {
-                out[y][x] = v;
+                after_h[y][x] = v;
             }
         }
         x0 = x1;
         report(0.5 + 0.5 * (x0 as f64 / w as f64));
     }
-    out
 }
 
 /// Blur a binary `grid == target` mask straight to f32. Same kernel and f64
@@ -1453,6 +1489,19 @@ pub(crate) fn gaussian_blur_mask_to_f32(
     width: usize,
     height: usize,
     sigma: f64,
+) -> Vec<Vec<f32>> {
+    gaussian_blur_mask_to_f32_reported(grid, target, width, height, sigma, &|_| {})
+}
+
+/// `gaussian_blur_mask_to_f32` with the same progress reporting as
+/// `gaussian_blur_grid_reported`.
+pub(crate) fn gaussian_blur_mask_to_f32_reported(
+    grid: &[Vec<u8>],
+    target: u8,
+    width: usize,
+    height: usize,
+    sigma: f64,
+    report: &dyn Fn(f64),
 ) -> Vec<Vec<f32>> {
     let kernel_size: usize = (sigma * 3.0).ceil() as usize * 2 + 1;
     let kernel = create_gaussian_kernel(kernel_size, sigma);
@@ -1504,6 +1553,7 @@ pub(crate) fn gaussian_blur_mask_to_f32(
             })
             .collect();
         after_h.append(&mut part);
+        report(0.5 * (after_h.len() as f64 / h as f64));
     }
 
     // Vertical pass: f64 throughout, cast only on store.
@@ -1547,6 +1597,7 @@ pub(crate) fn gaussian_blur_mask_to_f32(
             }
         }
         x0 = x1;
+        report(0.5 + 0.5 * (x0 as f64 / w as f64));
     }
     out
 }
@@ -1579,9 +1630,16 @@ pub fn fill_nan_values(height_grid: &mut [Vec<f64>]) {
     }
     let width: usize = height_grid[0].len();
 
-    let mut changes_made: bool = true;
-    while changes_made {
-        let snapshot: Vec<Vec<f64>> = height_grid.to_vec();
+    if !height_grid
+        .par_iter()
+        .any(|row| row.iter().any(|v| v.is_nan()))
+    {
+        return;
+    }
+
+    // One snapshot buffer for the whole loop; refreshed in place per iteration.
+    let mut snapshot: Vec<Vec<f64>> = height_grid.to_vec();
+    loop {
         let snapshot_ref: &[Vec<f64>] = &snapshot;
 
         let any_changed = height_grid
@@ -1617,65 +1675,33 @@ pub fn fill_nan_values(height_grid: &mut [Vec<f64>]) {
             })
             .reduce(|| false, |a, b| a || b);
 
-        changes_made = any_changed;
+        if !any_changed {
+            break;
+        }
+        snapshot
+            .par_iter_mut()
+            .zip(height_grid.par_iter())
+            .for_each(|(dst, src)| dst.clone_from(src));
     }
 }
 
-/// Filter extreme elevation outliers using IQR-based detection.
-/// Uses 3× the interquartile range beyond Q1/Q3 to identify true outliers
-/// (corrupted data, sea-floor artifacts) without clipping real terrain on
-/// mountains or deep valleys.
+/// NaN out physically impossible elevations (provider sentinels, sea-floor artifacts),
+/// then interpolate the holes shut.
 ///
-/// A count guard prevents filtering when >5% of values fall outside the bounds,
-/// which indicates bimodal terrain (e.g., deep canyons) rather than corruption.
+/// A fixed gate, not a statistical one: a global IQR band flags any lone landform that
+/// stands well clear of its surroundings, so an island or an inselberg reads as
+/// corruption and gets levelled. Isolated spikes are `repair_terrain_anomalies`' job.
+/// The bounds sit outside the real range (Dead Sea shore ~-430 m, Everest 8849 m) with
+/// enough margin for providers that report ellipsoidal instead of orthometric heights.
 pub fn filter_elevation_outliers(height_grid: &mut [Vec<f64>]) {
+    const MIN_REASONABLE_M: f64 = -500.0;
+    const MAX_REASONABLE_M: f64 = 9000.0;
+
     let height = height_grid.len();
     if height == 0 {
         return;
     }
     let width = height_grid[0].len();
-
-    // Collect finite heights in parallel — flat-mapping per row, each thread
-    // builds its own Vec, then rayon stitches the segments together. Avoids
-    // a single sequential sweep over the whole grid.
-    let mut all_heights: Vec<f64> = height_grid
-        .par_iter()
-        .flat_map_iter(|row| row.iter().filter(|h| !h.is_nan() && h.is_finite()).copied())
-        .collect();
-
-    if all_heights.len() < 4 {
-        return;
-    }
-
-    let len = all_heights.len();
-    let q1_idx = len / 4;
-    let q3_idx = (len * 3) / 4;
-
-    let (_, q1_val, _) =
-        all_heights.select_nth_unstable_by(q1_idx, |a, b| a.partial_cmp(b).unwrap());
-    let q1 = *q1_val;
-
-    let (_, q3_val, _) =
-        all_heights.select_nth_unstable_by(q3_idx, |a, b| a.partial_cmp(b).unwrap());
-    let q3 = *q3_val;
-
-    let iqr = q3 - q1;
-    let min_reasonable = q1 - 3.0 * iqr;
-    let max_reasonable = q3 + 3.0 * iqr;
-
-    // Count guard: if >5% of values fall outside a bound, that tail represents
-    // real terrain (e.g., canyon floor), not corrupted data — skip that bound.
-    let (below_count, above_count) = all_heights
-        .par_iter()
-        .map(|&h| ((h < min_reasonable) as usize, (h > max_reasonable) as usize))
-        .reduce(|| (0, 0), |a, b| (a.0 + b.0, a.1 + b.1));
-    let threshold = (len as f64 * 0.05) as usize;
-    let filter_lower = below_count > 0 && below_count <= threshold;
-    let filter_upper = above_count > 0 && above_count <= threshold;
-
-    if !filter_lower && !filter_upper {
-        return;
-    }
 
     // Per-row NaN-out, then sum the per-row counts back together. Each row
     // is mutated independently so this is data-race-free.
@@ -1685,13 +1711,9 @@ pub fn filter_elevation_outliers(height_grid: &mut [Vec<f64>]) {
         .map(|row| {
             let mut row_count = 0usize;
             for h in row.iter_mut().take(width) {
-                if !h.is_nan() {
-                    let is_outlier = (filter_lower && *h < min_reasonable)
-                        || (filter_upper && *h > max_reasonable);
-                    if is_outlier {
-                        *h = f64::NAN;
-                        row_count += 1;
-                    }
+                if !h.is_nan() && (*h < MIN_REASONABLE_M || *h > MAX_REASONABLE_M) {
+                    *h = f64::NAN;
+                    row_count += 1;
                 }
             }
             row_count
@@ -1700,8 +1722,8 @@ pub fn filter_elevation_outliers(height_grid: &mut [Vec<f64>]) {
 
     if outliers_filtered > 0 {
         eprintln!(
-            "Filtered {} extreme outliers (IQR bounds: {:.1}m to {:.1}m, lower={}, upper={})",
-            outliers_filtered, min_reasonable, max_reasonable, filter_lower, filter_upper
+            "Filtered {} impossible elevations (outside {:.0}m..{:.0}m)",
+            outliers_filtered, MIN_REASONABLE_M, MAX_REASONABLE_M
         );
         fill_nan_values(height_grid);
     }
@@ -1709,7 +1731,8 @@ pub fn filter_elevation_outliers(height_grid: &mut [Vec<f64>]) {
 
 /// Scale raw elevation (meters) to Minecraft Y coordinates, keeping f64 precision.
 /// `extended_max_y` is the cap when `disable_height_limit` is on (Java datapack:
-/// 2031; Bedrock BP: 512); ignored otherwise.
+/// 2031; Bedrock BP: 512; Luanti has no pack, so it keeps the vanilla ceiling);
+/// ignored otherwise.
 /// Scales real-world metre heights to Minecraft Y. Also returns the affine
 /// parameters `(min_height_m, blocks_per_meter)` so a real-world elevation can
 /// be converted back to a Minecraft Y threshold (e.g. for the snow line), plus the
@@ -1830,6 +1853,13 @@ pub fn scale_to_minecraft(
     } else {
         0.0
     };
+    // The map preview shades over the band the terrain fills, so publish where it ended up.
+    crate::world_editor::common::set_terrain_top_y(
+        (ground_level as f64 + scaled_range)
+            .min(upper_clamp)
+            .round() as i32,
+    );
+
     (mc_heights, min_height, blocks_per_meter, ground_level)
 }
 
@@ -2200,5 +2230,234 @@ mod tests {
                 assert!(!h.is_nan(), "NaN values should be filled");
             }
         }
+    }
+
+    fn wobbly(w: usize, h: usize) -> Vec<Vec<f64>> {
+        let mut s = 0x2545_f491_4f6c_dd1du64;
+        (0..h)
+            .map(|_| {
+                (0..w)
+                    .map(|_| {
+                        s = s.wrapping_mul(6364136223846793005).wrapping_add(1);
+                        ((s >> 40) % 2000) as f64 * 0.5
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn assert_bits_eq(got: &[Vec<f64>], want: &[Vec<f64>]) {
+        assert_eq!(got.len(), want.len());
+        for (y, (a, b)) in got.iter().zip(want.iter()).enumerate() {
+            assert_eq!(a.len(), b.len(), "row {y} length");
+            for (x, (p, q)) in a.iter().zip(b.iter()).enumerate() {
+                assert_eq!(p.to_bits(), q.to_bits(), "cell ({x},{y})");
+            }
+        }
+    }
+
+    /// Separable blur written with two buffers and no parallelism, in the same tap
+    /// order as the production kernel loop.
+    fn two_buffer_blur(grid: &[Vec<f64>], sigma: f64) -> Vec<Vec<f64>> {
+        let kernel_size: usize = (sigma * 3.0).ceil() as usize * 2 + 1;
+        let kernel = create_gaussian_kernel(kernel_size, sigma);
+        let half = kernel_size as i32 / 2;
+        let h = grid.len();
+        let w = grid[0].len();
+        let tap = |get: &dyn Fn(usize) -> f64, len: usize, i: usize| {
+            let mut sum = 0.0;
+            let mut wsum = 0.0;
+            for (j, &k) in kernel.iter().enumerate() {
+                let idx = i as i32 + j as i32 - half;
+                if idx >= 0 && idx < len as i32 {
+                    let v = get(idx as usize);
+                    if v.is_finite() {
+                        sum += v * k;
+                        wsum += k;
+                    }
+                }
+            }
+            if wsum > 0.0 {
+                sum / wsum
+            } else {
+                f64::NAN
+            }
+        };
+        let after_h: Vec<Vec<f64>> = (0..h)
+            .map(|y| (0..w).map(|x| tap(&|i| grid[y][i], w, x)).collect())
+            .collect();
+        (0..h)
+            .map(|y| (0..w).map(|x| tap(&|i| after_h[i][x], h, y)).collect())
+            .collect()
+    }
+
+    #[test]
+    fn the_vertical_blur_pass_writing_over_its_own_input_changes_nothing() {
+        let g = wobbly(37, 29);
+        assert_bits_eq(&gaussian_blur_grid(&g, 2.5), &two_buffer_blur(&g, 2.5));
+        let tall = wobbly(9, 61);
+        assert_bits_eq(
+            &gaussian_blur_grid(&tall, 1.5),
+            &two_buffer_blur(&tall, 1.5),
+        );
+    }
+
+    #[test]
+    fn blurring_through_a_mask_matches_blurring_a_masked_copy() {
+        let heights = wobbly(41, 33);
+        let masked: Vec<Vec<bool>> = (0..33)
+            .map(|y| (0..41).map(|x| (x * 7 + y * 3) % 5 == 0).collect())
+            .collect();
+        let materialised: Vec<Vec<f64>> = heights
+            .iter()
+            .zip(masked.iter())
+            .map(|(hr, mr)| {
+                hr.iter()
+                    .zip(mr.iter())
+                    .map(|(&v, &m)| if m { f64::NAN } else { v })
+                    .collect()
+            })
+            .collect();
+        assert_bits_eq(
+            &gaussian_blur_heights_masked(&heights, &masked, 3.0, &|_| {}),
+            &gaussian_blur_grid(&materialised, 3.0),
+        );
+    }
+
+    #[test]
+    fn the_reported_mask_blur_returns_the_same_grid_and_a_monotone_fraction() {
+        let lc: Vec<Vec<u8>> = (0..29)
+            .map(|y| {
+                (0..37)
+                    .map(|x| {
+                        if (x + y) % 3 == 0 {
+                            LC_BUILT_UP
+                        } else {
+                            LC_GRASSLAND
+                        }
+                    })
+                    .collect()
+            })
+            .collect();
+        let seen = std::cell::RefCell::new(Vec::new());
+        let got = gaussian_blur_mask_to_f32_reported(&lc, LC_BUILT_UP, 37, 29, 2.0, &|f| {
+            seen.borrow_mut().push(f)
+        });
+        let want = gaussian_blur_mask_to_f32(&lc, LC_BUILT_UP, 37, 29, 2.0);
+        assert_eq!(got, want);
+        let seen = seen.into_inner();
+        assert!(seen.windows(2).all(|p| p[0] <= p[1]), "{seen:?}");
+        assert_eq!(seen.last().copied(), Some(1.0));
+    }
+
+    #[test]
+    fn a_nan_free_grid_comes_back_untouched() {
+        let g = wobbly(19, 17);
+        let mut filled = g.clone();
+        fill_nan_values(&mut filled);
+        assert_bits_eq(&filled, &g);
+    }
+
+    #[test]
+    fn a_nan_blob_wider_than_one_dilation_ring_is_filled_from_the_previous_pass() {
+        let mut g = vec![vec![10.0; 13]; 13];
+        for row in g.iter_mut().take(9).skip(4) {
+            for c in row.iter_mut().take(9).skip(4) {
+                *c = f64::NAN;
+            }
+        }
+        fill_nan_values(&mut g);
+        assert!(g.iter().flatten().all(|v| *v == 10.0));
+    }
+
+    #[test]
+    fn a_lone_island_survives_the_elevation_gate() {
+        let mut g = vec![vec![0.0f64; 100]; 100];
+        for row in g.iter_mut().take(60).skip(40) {
+            for c in row.iter_mut().take(60).skip(40) {
+                *c = 900.0;
+            }
+        }
+        filter_elevation_outliers(&mut g);
+        assert_eq!(g[50][50], 900.0);
+        assert_eq!(g[0][0], 0.0);
+    }
+
+    #[test]
+    fn only_physically_impossible_elevations_are_gated() {
+        let mut g = vec![vec![100.0f64; 21]; 21];
+        g[2][2] = -9999.0;
+        g[2][18] = 1.0e38;
+        g[18][2] = -600.0;
+        g[18][18] = 9500.0;
+        // Real extremes, well outside any IQR band this grid could produce.
+        g[4][10] = -450.0;
+        g[16][10] = 8800.0;
+
+        filter_elevation_outliers(&mut g);
+
+        for (y, x) in [(2, 2), (2, 18), (18, 2), (18, 18)] {
+            assert_eq!(g[y][x], 100.0, "({x},{y}) should have been interpolated");
+        }
+        assert_eq!(g[4][10], -450.0);
+        assert_eq!(g[16][10], 8800.0);
+    }
+
+    /// 41x41 plateau at 100 m with a centred square tower of `width` cells at 180 m.
+    fn plateau_with_tower(width: usize) -> Vec<Vec<f64>> {
+        let mut g = vec![vec![100.0f64; 41]; 41];
+        let lo = 20 - width / 2;
+        for row in g.iter_mut().skip(lo).take(width) {
+            for c in row.iter_mut().skip(lo).take(width) {
+                *c = 180.0;
+            }
+        }
+        g
+    }
+
+    #[test]
+    fn anomaly_repair_keeps_its_six_metre_deviation_at_block_resolution() {
+        let spike = |d: f64| {
+            let mut g = vec![vec![100.0f64; 21]; 21];
+            g[10][10] += d;
+            g
+        };
+        for m_per_cell in [1.0, 4.0] {
+            let mut kept = spike(5.0);
+            repair_terrain_anomalies(&mut kept, m_per_cell);
+            assert_eq!(kept[10][10], 105.0, "at {m_per_cell} m/cell");
+
+            let mut repaired = spike(7.0);
+            repair_terrain_anomalies(&mut repaired, m_per_cell);
+            assert_eq!(repaired[10][10], 100.0, "at {m_per_cell} m/cell");
+        }
+    }
+
+    #[test]
+    fn anomaly_repair_raises_its_deviation_threshold_with_the_cell_size() {
+        let spike = |d: f64| {
+            let mut g = vec![vec![100.0f64; 21]; 21];
+            g[10][10] += d;
+            g
+        };
+        // 40 m/cell puts the gate at 0.25 * 40 = 10 m.
+        let mut kept = spike(7.0);
+        repair_terrain_anomalies(&mut kept, 40.0);
+        assert_eq!(kept[10][10], 107.0);
+
+        let mut repaired = spike(12.0);
+        repair_terrain_anomalies(&mut repaired, 40.0);
+        assert_eq!(repaired[10][10], 100.0);
+    }
+
+    #[test]
+    fn anomaly_repair_stops_eroding_landforms_when_a_cell_is_tens_of_metres() {
+        let mut fine = plateau_with_tower(9);
+        repair_terrain_anomalies(&mut fine, 1.0);
+        assert_eq!(fine[20][20], 100.0, "block resolution must erode as before");
+
+        let mut coarse = plateau_with_tower(9);
+        repair_terrain_anomalies(&mut coarse, 24.4);
+        assert_eq!(coarse[20][20], 180.0, "a 220 m landform must survive");
     }
 }

--- a/src/elevation/providers/aws_terrain.rs
+++ b/src/elevation/providers/aws_terrain.rs
@@ -1,6 +1,7 @@
 use crate::coordinate_system::geographic::LLBBox;
 use crate::elevation::cache::get_cache_dir;
 use crate::elevation::provider::{ElevationProvider, RawElevationGrid};
+use crate::elevation::providers::fixed_tile::MAX_TILES_PER_FETCH;
 #[cfg(feature = "gui")]
 use crate::telemetry::{send_log, LogLevel};
 use rayon::prelude::*;
@@ -204,10 +205,6 @@ fn sample_tile_pixel(
         (pixel[0] as f64 * 256.0 + pixel[1] as f64 + pixel[2] as f64 / 256.0) - TERRARIUM_OFFSET;
     Some(height)
 }
-
-/// Tile budget; as the outage fallback AWS can now serve arbitrarily
-/// large bboxes, and a 1x1 degree area at z15 would be ~8000 tiles.
-const MAX_TILES_PER_FETCH: usize = 2048;
 
 fn calculate_zoom_level(bbox: &LLBBox) -> u8 {
     let lat_diff: f64 = (bbox.max().lat() - bbox.min().lat()).abs();

--- a/src/elevation/providers/fixed_tile.rs
+++ b/src/elevation/providers/fixed_tile.rs
@@ -44,15 +44,16 @@
 //!   hand them the reprojected tile corners via [`mercator_x_to_lon`]
 //!   and [`mercator_y_to_lat`].
 //!
-//! [`fetch_fixed_tile_grid`] handles the rest: choosing the resolution,
-//! enumerating the covering tiles, downloading them with a capped-
-//! concurrency thread pool, decoding the per-tile TIFFs, and bilinear-
-//! sampling into the caller's output grid.
+//! [`fetch_fixed_tile_grid`] handles the rest: choosing the resolution
+//! (within a tile budget), enumerating the covering tiles, downloading
+//! them with a capped-concurrency thread pool, then decoding the per-tile
+//! TIFFs one tile row at a time while bilinear-sampling into the caller's
+//! output grid.
 
 use crate::coordinate_system::geographic::LLBBox;
 use crate::elevation::cache::get_cache_dir;
 use crate::elevation::provider::{ElevationProvider, RawElevationGrid};
-use fnv::FnvHashMap;
+use fnv::{FnvHashMap, FnvHashSet};
 use rayon::prelude::*;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -67,6 +68,11 @@ pub(super) const TILE_PIXELS: usize = 512;
 /// Half-extent of the Web Mercator world in meters (EPSG:3857).
 /// Longitude ±180° maps to mercator X ±MERCATOR_LIMIT.
 pub(super) const MERCATOR_LIMIT: f64 = 20_037_508.342_789_244;
+
+/// Tile budget per fetch, shared with the zoom budgets in `aws_terrain` and
+/// `mapterhorn`; the resolution level (or zoom) is coarsened until the
+/// covering count fits.
+pub(super) const MAX_TILES_PER_FETCH: usize = 2048;
 
 /// Web Mercator has a usable latitude range of approximately ±85.051°.
 pub(super) const MERCATOR_LAT_LIMIT: f64 = 85.051_128_78;
@@ -175,23 +181,43 @@ impl<R: Resolution> TileKey<R> {
 
 // ─── Coverage + level selection ────────────────────────────────────────
 
-/// Enumerate every tile whose mercator bbox intersects the user's bbox.
-pub(super) fn covering_tiles<R: Resolution>(bbox: &LLBBox, level: R) -> Vec<TileKey<R>> {
+/// Inclusive `(min_tx, max_tx, min_ty, max_ty)` tile range covering the
+/// bbox; `None` for a degenerate level span.
+fn covering_tile_range<R: Resolution>(bbox: &LLBBox, level: R) -> Option<(i32, i32, i32, i32)> {
+    let span = level.tile_span_meters();
+    if span <= 0.0 {
+        return None;
+    }
     let sw_mx = lon_to_mercator_x(bbox.min().lng());
     let ne_mx = lon_to_mercator_x(bbox.max().lng());
     let sw_my = lat_to_mercator_y(bbox.min().lat());
     let ne_my = lat_to_mercator_y(bbox.max().lat());
-    let span = level.tile_span_meters();
-    if span <= 0.0 {
-        return Vec::new();
-    }
     let min_tx = ((sw_mx + MERCATOR_LIMIT) / span).floor() as i32;
     let max_tx = (((ne_mx + MERCATOR_LIMIT) / span).ceil() as i32 - 1).max(min_tx);
     let min_ty = ((MERCATOR_LIMIT - ne_my) / span).floor() as i32;
     let max_ty = (((MERCATOR_LIMIT - sw_my) / span).ceil() as i32 - 1).max(min_ty);
+    Some((min_tx, max_tx, min_ty, max_ty))
+}
 
-    let capacity = ((max_tx - min_tx + 1) * (max_ty - min_ty + 1)).max(0) as usize;
-    let mut tiles = Vec::with_capacity(capacity);
+/// Tile count from the range only; allocates nothing, so level selection
+/// can probe it per candidate level.
+pub(super) fn covering_tile_count<R: Resolution>(bbox: &LLBBox, level: R) -> usize {
+    match covering_tile_range(bbox, level) {
+        Some((min_tx, max_tx, min_ty, max_ty)) => {
+            let cols = (max_tx - min_tx + 1).max(0) as usize;
+            let rows = (max_ty - min_ty + 1).max(0) as usize;
+            cols * rows
+        }
+        None => 0,
+    }
+}
+
+/// Enumerate every tile whose mercator bbox intersects the user's bbox.
+pub(super) fn covering_tiles<R: Resolution>(bbox: &LLBBox, level: R) -> Vec<TileKey<R>> {
+    let Some((min_tx, max_tx, min_ty, max_ty)) = covering_tile_range(bbox, level) else {
+        return Vec::new();
+    };
+    let mut tiles = Vec::with_capacity(covering_tile_count(bbox, level));
     for ty in min_ty..=max_ty {
         for tx in min_tx..=max_tx {
             tiles.push(TileKey {
@@ -217,7 +243,9 @@ pub(super) fn covering_tiles<R: Resolution>(bbox: &LLBBox, level: R) -> Vec<Tile
 /// bilinear fill-in.
 ///
 /// `levels` must be ordered finest-to-coarsest. When no level qualifies
-/// the coarsest is returned as a fallback.
+/// the coarsest is returned as a fallback. Resolution alone ignores how
+/// many tiles the bbox spans; callers pass the result through
+/// [`coarsen_to_tile_budget`].
 pub(super) fn select_level_for_cell_size<R: Resolution + Copy>(
     levels: &[R],
     cell_size_m: f64,
@@ -237,6 +265,21 @@ pub(super) fn select_level_for_cell_size<R: Resolution + Copy>(
     *levels.last().unwrap()
 }
 
+/// Step to coarser levels until the covering-tile count fits
+/// [`MAX_TILES_PER_FETCH`], mirroring the zoom budget `aws_terrain` and
+/// `mapterhorn` apply. Returns the coarsest level when none fits.
+pub(super) fn coarsen_to_tile_budget<R: Resolution>(levels: &[R], start: R, bbox: &LLBBox) -> R {
+    let start_idx = levels.iter().position(|l| *l == start).unwrap_or(0);
+    let mut level = start;
+    for &candidate in &levels[start_idx..] {
+        level = candidate;
+        if covering_tile_count(bbox, candidate) <= MAX_TILES_PER_FETCH {
+            break;
+        }
+    }
+    level
+}
+
 /// Approximate physical bbox dimensions in meters. Precise enough for
 /// resolution-level selection.
 pub(super) fn bbox_dimensions_m(bbox: &LLBBox) -> (f64, f64) {
@@ -251,23 +294,57 @@ pub(super) fn bbox_dimensions_m(bbox: &LLBBox) -> (f64, f64) {
 
 // ─── Bilinear tile sampling ────────────────────────────────────────────
 
+/// One decoded tile, flat row-major. The upstream samples are f32, so
+/// keeping them as f64 would quadruple the RAM for no extra precision.
+pub(super) struct TileRaster {
+    width: usize,
+    height: usize,
+    data: Vec<f32>,
+}
+
+impl TileRaster {
+    fn from_rows(rows: Vec<Vec<f64>>) -> Self {
+        let height = rows.len();
+        let width = rows.first().map_or(0, |r| r.len());
+        let mut data = vec![f32::NAN; width * height];
+        for (y, row) in rows.iter().enumerate() {
+            for (x, &v) in row.iter().take(width).enumerate() {
+                data[y * width + x] = v as f32;
+            }
+        }
+        Self {
+            width,
+            height,
+            data,
+        }
+    }
+
+    #[inline]
+    fn get(&self, x: usize, y: usize) -> f64 {
+        self.data[y * self.width + x] as f64
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
 pub(super) fn sample_tile_bilinear<R: Resolution>(
-    tile: &[Vec<f64>],
+    tile: &TileRaster,
     mx: f64,
     my: f64,
     key: &TileKey<R>,
 ) -> f64 {
-    if tile.is_empty() || tile[0].is_empty() {
+    if tile.is_empty() {
         return f64::NAN;
     }
     let mpp = key.level.meters_per_pixel();
     let local_x = (mx - key.min_mx()) / mpp;
     let local_y = (key.max_my() - my) / mpp;
 
-    let height = tile.len() as i32;
-    let width = tile[0].len() as i32;
-    let max_x = width - 1;
-    let max_y = height - 1;
+    let max_x = tile.width as i32 - 1;
+    let max_y = tile.height as i32 - 1;
 
     let x0 = (local_x.floor() as i32).clamp(0, max_x);
     let y0 = (local_y.floor() as i32).clamp(0, max_y);
@@ -275,10 +352,10 @@ pub(super) fn sample_tile_bilinear<R: Resolution>(
     let y1 = (y0 + 1).min(max_y);
     let dx = (local_x - x0 as f64).clamp(0.0, 1.0);
     let dy = (local_y - y0 as f64).clamp(0.0, 1.0);
-    let v00 = tile[y0 as usize][x0 as usize];
-    let v10 = tile[y0 as usize][x1 as usize];
-    let v01 = tile[y1 as usize][x0 as usize];
-    let v11 = tile[y1 as usize][x1 as usize];
+    let v00 = tile.get(x0 as usize, y0 as usize);
+    let v10 = tile.get(x1 as usize, y0 as usize);
+    let v01 = tile.get(x0 as usize, y1 as usize);
+    let v11 = tile.get(x1 as usize, y1 as usize);
     blend_finite_samples(v00, v10, v01, v11, dx, dy)
 }
 
@@ -389,7 +466,19 @@ pub(super) fn fetch_fixed_tile_grid<P: FixedTileProvider>(
     let cell_size_m = cell_x.min(cell_y);
 
     let levels = provider.resolution_levels();
-    let level = select_level_for_cell_size(levels, cell_size_m);
+    let requested = select_level_for_cell_size(levels, cell_size_m);
+    let level = coarsen_to_tile_budget(levels, requested, bbox);
+    if level != requested {
+        eprintln!(
+            "{}: {} would need {} tiles (budget {}), falling back to {} ({:.2} m/px)",
+            provider.log_prefix(),
+            requested.level_id(),
+            covering_tile_count(bbox, requested),
+            MAX_TILES_PER_FETCH,
+            level.level_id(),
+            level.meters_per_pixel(),
+        );
+    }
     let tile_keys = covering_tiles(bbox, level);
     if tile_keys.is_empty() {
         return Err("Fixed-tile bbox outside Mercator coverage".into());
@@ -430,7 +519,7 @@ pub(super) fn fetch_fixed_tile_grid<P: FixedTileProvider>(
         .build()
         .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
 
-    type FetchResult<R> = (TileKey<R>, Result<Vec<Vec<f64>>, String>);
+    type FetchResult<R> = (TileKey<R>, Result<(), String>);
     // Download in paced batches (cache hits short-circuit; result set unchanged) so large strict-upstream requests don't trip rate limiting.
     let batch_size = if P::DOWNLOAD_BATCH_SIZE == 0 {
         tile_keys.len().max(1)
@@ -462,19 +551,19 @@ pub(super) fn fetch_fixed_tile_grid<P: FixedTileProvider>(
                 .map(|key| {
                     let url = provider.tile_url(key);
                     let cache_path = key.cache_path(&cache_dir);
-                    let res = fetch_tile_raster(&url, &cache_path, &client);
+                    let res = download_tile(&url, &cache_path, &client);
                     (*key, res)
                 })
                 .collect()
         });
         tile_results.extend(batch_results);
     }
-    let mut tile_cache: FnvHashMap<TileKey<P::Level>, Vec<Vec<f64>>> = FnvHashMap::default();
+    let mut available: FnvHashSet<TileKey<P::Level>> = FnvHashSet::default();
     let mut failed_keys: Vec<TileKey<P::Level>> = Vec::new();
     for (key, res) in tile_results {
         match res {
-            Ok(raster) => {
-                tile_cache.insert(key, raster);
+            Ok(()) => {
+                available.insert(key);
             }
             Err(e) => {
                 eprintln!(
@@ -497,6 +586,7 @@ pub(super) fn fetch_fixed_tile_grid<P: FixedTileProvider>(
     // gets a fresh attempt at the primary source.
     let primary_failures = failed_keys.len();
     let mut fallback_recovered = 0usize;
+    let mut fallback_tiles: FnvHashMap<TileKey<P::Level>, TileRaster> = FnvHashMap::default();
     if !failed_keys.is_empty() {
         eprintln!(
             "{}: {} tile{} failed; attempting AWS Terrarium fallback...",
@@ -507,7 +597,7 @@ pub(super) fn fetch_fixed_tile_grid<P: FixedTileProvider>(
         for key in &failed_keys {
             match fetch_aws_fallback_tile(key) {
                 Ok(raster) => {
-                    tile_cache.insert(*key, raster);
+                    fallback_tiles.insert(*key, raster);
                     fallback_recovered += 1;
                 }
                 Err(e) => {
@@ -569,82 +659,179 @@ pub(super) fn fetch_fixed_tile_grid<P: FixedTileProvider>(
         .map(|&mx| TileKey::<P::Level>::for_mercator(level, mx, 0.0).tile_x)
         .collect();
 
+    // Same precompute on the row side: mercator Y and its tile_y per
+    // output row, which also groups the rows into tile-row bands below.
+    let row_my: Vec<f64> = (0..grid_height)
+        .map(|gy| {
+            let lat_frac = gy as f64 / h_denom;
+            lat_to_mercator_y(max_lat - lat_frac * lat_span)
+        })
+        .collect();
+    let row_tile_y: Vec<i32> = row_my
+        .iter()
+        .map(|&my| TileKey::<P::Level>::for_mercator(level, 0.0, my).tile_y)
+        .collect();
+
+    // Distinct tile columns, in order; col_tile_x is monotonic in gx.
+    let mut band_tile_x: Vec<i32> = Vec::new();
+    for &tx in &col_tile_x {
+        if band_tile_x.last() != Some(&tx) {
+            band_tile_x.push(tx);
+        }
+    }
+
+    // Sample one tile row at a time. `sample_tile_bilinear` clamps inside
+    // the tile, so a tile only ever serves the output rows whose tile_y it
+    // is: bands are disjoint, every tile still decodes exactly once, and
+    // peak decoded memory is one tile row instead of the whole fetch.
+    //
     // Sampling runs on Rayon's global pool, NOT the download pool.
     // `pool` is sized to `MAX_CONCURRENT_DOWNLOADS` (4) to be polite to
     // upstream providers, but bilinear sampling is CPU-bound and has no
     // reason to be capped to 4 threads on high-core machines — doing so
     // needlessly slows multi-megapixel grids. The global pool defaults
     // to `num_cpus::get()` threads, which is what we want here.
-    let height_grid: Vec<Vec<f64>> = (0..grid_height)
-        .into_par_iter()
-        .map(|gy| {
-            let lat_frac = gy as f64 / h_denom;
-            let lat = max_lat - lat_frac * lat_span;
-            let my = lat_to_mercator_y(lat);
-            let tile_y = TileKey::<P::Level>::for_mercator(level, 0.0, my).tile_y;
-            let mut row = vec![f64::NAN; grid_width];
-            // Carry the current tile reference across cells; tile_x
-            // changes every ~TILE_PIXELS cells, so most cells reuse
-            // the same tile and skip the hashmap lookup entirely.
-            let mut cur_tile_x: i32 = i32::MIN;
-            let mut cur_tile: Option<&Vec<Vec<f64>>> = None;
-            let mut cur_key = TileKey {
-                level,
-                tile_x: 0,
-                tile_y,
-            };
-            for (gx, cell) in row.iter_mut().enumerate() {
-                let tile_x = col_tile_x[gx];
-                if tile_x != cur_tile_x {
-                    cur_tile_x = tile_x;
-                    cur_key = TileKey {
-                        level,
-                        tile_x,
-                        tile_y,
-                    };
-                    cur_tile = tile_cache.get(&cur_key);
+    let mut height_grid: Vec<Vec<f64>> = Vec::with_capacity(grid_height);
+    let mut band_start = 0usize;
+    while band_start < grid_height {
+        let tile_y = row_tile_y[band_start];
+        let mut band_end = band_start + 1;
+        while band_end < grid_height && row_tile_y[band_end] == tile_y {
+            band_end += 1;
+        }
+        let band = load_tile_row(
+            level,
+            tile_y,
+            &band_tile_x,
+            &available,
+            &fallback_tiles,
+            &cache_dir,
+            provider.log_prefix(),
+        );
+
+        let mut rows: Vec<Vec<f64>> = (band_start..band_end)
+            .into_par_iter()
+            .map(|gy| {
+                let my = row_my[gy];
+                let mut row = vec![f64::NAN; grid_width];
+                // Carry the current tile reference across cells; tile_x
+                // changes every ~TILE_PIXELS cells, so most cells reuse
+                // the same tile and skip the hashmap lookup entirely.
+                let mut cur_tile_x: i32 = i32::MIN;
+                let mut cur_tile: Option<&TileRaster> = None;
+                let mut cur_key = TileKey {
+                    level,
+                    tile_x: 0,
+                    tile_y,
+                };
+                for (gx, cell) in row.iter_mut().enumerate() {
+                    let tile_x = col_tile_x[gx];
+                    if tile_x != cur_tile_x {
+                        cur_tile_x = tile_x;
+                        cur_key = TileKey {
+                            level,
+                            tile_x,
+                            tile_y,
+                        };
+                        cur_tile = band.get(&cur_key).or_else(|| fallback_tiles.get(&cur_key));
+                    }
+                    if let Some(tile) = cur_tile {
+                        *cell = sample_tile_bilinear(tile, col_mx[gx], my, &cur_key);
+                    }
                 }
-                if let Some(tile) = cur_tile {
-                    *cell = sample_tile_bilinear(tile, col_mx[gx], my, &cur_key);
-                }
-            }
-            row
-        })
-        .collect();
+                row
+            })
+            .collect();
+        height_grid.append(&mut rows);
+        band_start = band_end;
+    }
 
     Ok(RawElevationGrid {
         heights_meters: height_grid,
     })
 }
 
+/// Decode one tile row from the disk cache. Keys already served by an
+/// in-memory fallback raster, or never downloaded, are skipped.
+fn load_tile_row<R: Resolution>(
+    level: R,
+    tile_y: i32,
+    tile_xs: &[i32],
+    available: &FnvHashSet<TileKey<R>>,
+    fallback: &FnvHashMap<TileKey<R>, TileRaster>,
+    cache_dir: &Path,
+    log_prefix: &str,
+) -> FnvHashMap<TileKey<R>, TileRaster> {
+    let decoded: Vec<(TileKey<R>, Result<TileRaster, String>)> = tile_xs
+        .par_iter()
+        .filter_map(|&tile_x| {
+            let key = TileKey {
+                level,
+                tile_x,
+                tile_y,
+            };
+            if !available.contains(&key) || fallback.contains_key(&key) {
+                return None;
+            }
+            Some((key, decode_cached_tile(&key.cache_path(cache_dir))))
+        })
+        .collect();
+
+    let mut tiles: FnvHashMap<TileKey<R>, TileRaster> = FnvHashMap::default();
+    for (key, res) in decoded {
+        match res {
+            Ok(raster) => {
+                tiles.insert(key, raster);
+            }
+            Err(e) => {
+                eprintln!(
+                    "  {log_prefix} tile ({}, {}) unreadable during sampling: {e}",
+                    key.tile_x, key.tile_y
+                );
+                // Same last resort a failed download gets.
+                if let Ok(raster) = fetch_aws_fallback_tile(&key) {
+                    tiles.insert(key, raster);
+                }
+            }
+        }
+    }
+    tiles
+}
+
 // ─── Tile fetch + TIFF decode ──────────────────────────────────────────
 
-fn fetch_tile_raster(
+/// Ensure the tile is in the disk cache. The payload is dropped here;
+/// sampling decodes it later, one tile row at a time.
+fn download_tile(
     url: &str,
     cache_path: &Path,
     client: &reqwest::blocking::Client,
-) -> Result<Vec<Vec<f64>>, String> {
+) -> Result<(), String> {
     if let Some(parent) = cache_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    let bytes = super::regional::fetch_or_cache(url, cache_path, Some(client))
-        .map_err(|e| e.to_string())?;
+    super::regional::fetch_or_cache(url, cache_path, Some(client))
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+fn decode_cached_tile(cache_path: &Path) -> Result<TileRaster, String> {
+    let bytes = std::fs::read(cache_path).map_err(|e| e.to_string())?;
     let raw = super::regional::decode_geotiff_f32(&bytes, TILE_PIXELS, TILE_PIXELS)
         .map_err(|e| e.to_string())?;
-    Ok(raw.heights_meters)
+    Ok(TileRaster::from_rows(raw.heights_meters))
 }
 
 /// Fill one fixed-grid tile from AWS Terrarium as a last-resort
 /// fallback. Reprojects the tile's mercator bbox into lat/lng and asks
 /// `AwsTerrain::fetch_raw` for a `TILE_PIXELS`-square grid; AWS handles
 /// its own XYZ tile download and bilinear sampling internally. Returns
-/// the result as the same `Vec<Vec<f64>>` shape the primary provider's
-/// TIFF decoder would have produced, so the caller can insert it into
-/// the shared tile cache and the downstream sampler is unaware the
-/// data came from a different source.
+/// the same `TileRaster` the primary provider's TIFF decoder would have
+/// produced, so the downstream sampler is unaware the data came from a
+/// different source.
 fn fetch_aws_fallback_tile<R: Resolution>(
     key: &TileKey<R>,
-) -> Result<Vec<Vec<f64>>, Box<dyn std::error::Error>> {
+) -> Result<TileRaster, Box<dyn std::error::Error>> {
     let min_lng = mercator_x_to_lon(key.min_mx());
     let max_lng = mercator_x_to_lon(key.max_mx());
     let min_lat = mercator_y_to_lat(key.min_my());
@@ -652,7 +839,7 @@ fn fetch_aws_fallback_tile<R: Resolution>(
     let bbox = LLBBox::new(min_lat, min_lng, max_lat, max_lng)
         .map_err(|e| format!("Invalid AWS fallback bbox: {e}"))?;
     let raw = super::aws_terrain::AwsTerrain.fetch_raw(&bbox, TILE_PIXELS, TILE_PIXELS)?;
-    Ok(raw.heights_meters)
+    Ok(TileRaster::from_rows(raw.heights_meters))
 }
 
 // ─── Tests ─────────────────────────────────────────────────────────────
@@ -684,6 +871,21 @@ mod tests {
                 Self::M10 => 10.307_921_510_4,
             }
         }
+    }
+
+    const LEVELS: &[TestLevel] = &[TestLevel::M1, TestLevel::M3, TestLevel::M10];
+
+    /// Square bbox of the given side in kilometres, anchored at the given latitude.
+    fn square_km(lat: f64, side_km: f64) -> LLBBox {
+        let dlat = side_km * 1000.0 / 111_320.0;
+        let dlon = dlat / lat.to_radians().cos();
+        LLBBox::new(lat, -105.0, lat + dlat, -105.0 + dlon).unwrap()
+    }
+
+    /// What `fetch_fixed_tile_grid` does: resolution first, then the tile budget.
+    fn selected_level(bbox: &LLBBox, cell_size_m: f64) -> TestLevel {
+        let requested = select_level_for_cell_size(LEVELS, cell_size_m);
+        coarsen_to_tile_budget(LEVELS, requested, bbox)
     }
 
     #[test]
@@ -768,6 +970,36 @@ mod tests {
     }
 
     #[test]
+    fn covering_tile_count_matches_enumeration() {
+        let bbox = LLBBox::new(36.870352, -111.535864, 36.892046, -111.505566).unwrap();
+        for level in [TestLevel::M1, TestLevel::M3, TestLevel::M10] {
+            assert_eq!(
+                covering_tile_count(&bbox, level),
+                covering_tiles(&bbox, level).len()
+            );
+        }
+    }
+
+    #[test]
+    fn tile_budget_coarsens_only_when_exceeded() {
+        let levels = &[TestLevel::M1, TestLevel::M3, TestLevel::M10];
+
+        // Small bbox: well inside the budget, level untouched.
+        let small = LLBBox::new(40.0, -105.0, 40.001, -104.999).unwrap();
+        assert_eq!(
+            coarsen_to_tile_budget(levels, TestLevel::M1, &small),
+            TestLevel::M1
+        );
+
+        // ~33 x 33 km: over 5000 M1 tiles, so it steps to M3.
+        let large = LLBBox::new(40.0, -105.0, 40.3, -104.7).unwrap();
+        assert!(covering_tile_count(&large, TestLevel::M1) > MAX_TILES_PER_FETCH);
+        let picked = coarsen_to_tile_budget(levels, TestLevel::M1, &large);
+        assert_eq!(picked, TestLevel::M3);
+        assert!(covering_tile_count(&large, picked) <= MAX_TILES_PER_FETCH);
+    }
+
+    #[test]
     fn level_selection_follows_cell_size() {
         let levels = &[TestLevel::M1, TestLevel::M3, TestLevel::M10];
         assert_eq!(select_level_for_cell_size(levels, 0.4), TestLevel::M1);
@@ -790,7 +1022,7 @@ mod tests {
             tile_x: 0,
             tile_y: 0,
         };
-        let tile = vec![vec![42.0; TILE_PIXELS]; TILE_PIXELS];
+        let tile = TileRaster::from_rows(vec![vec![42.0; TILE_PIXELS]; TILE_PIXELS]);
         let mx = (key.min_mx() + key.max_mx()) * 0.5;
         let my = (key.min_my() + key.max_my()) * 0.5;
         assert_eq!(sample_tile_bilinear(&tile, mx, my, &key), 42.0);
@@ -803,13 +1035,15 @@ mod tests {
             tile_x: 0,
             tile_y: 0,
         };
-        let tile: Vec<Vec<f64>> = (0..TILE_PIXELS)
-            .map(|y| {
-                (0..TILE_PIXELS)
-                    .map(|x| x as f64 + y as f64 * 1000.0)
-                    .collect()
-            })
-            .collect();
+        let tile = TileRaster::from_rows(
+            (0..TILE_PIXELS)
+                .map(|y| {
+                    (0..TILE_PIXELS)
+                        .map(|x| x as f64 + y as f64 * 1000.0)
+                        .collect()
+                })
+                .collect(),
+        );
         let mpp = key.level.meters_per_pixel();
         let mx_corner = key.min_mx() + 100.0 * mpp;
         let my_corner = key.max_my() - 50.0 * mpp;
@@ -825,5 +1059,51 @@ mod tests {
         let v = blend_finite_samples(10.0, f64::NAN, 30.0, 40.0, 0.5, 0.5);
         assert!((v - 80.0 / 3.0).abs() < 1e-9);
         assert!(blend_finite_samples(f64::NAN, f64::NAN, f64::NAN, f64::NAN, 0.5, 0.5).is_nan());
+    }
+
+    #[test]
+    fn coarsening_skips_every_level_that_is_still_over_budget() {
+        // One degree square: M1 and M3 both blow the budget, M10 fits.
+        let wide = LLBBox::new(40.0, -105.0, 41.0, -104.0).unwrap();
+        assert!(covering_tile_count(&wide, TestLevel::M3) > MAX_TILES_PER_FETCH);
+        assert_eq!(selected_level(&wide, 1.0), TestLevel::M10);
+        assert!(covering_tile_count(&wide, TestLevel::M10) <= MAX_TILES_PER_FETCH);
+
+        // Nothing fits: the coarsest level is the floor, not an out-of-range index.
+        let huge = LLBBox::new(40.0, -105.0, 42.0, -103.0).unwrap();
+        assert!(covering_tile_count(&huge, TestLevel::M10) > MAX_TILES_PER_FETCH);
+        assert_eq!(selected_level(&huge, 1.0), TestLevel::M10);
+    }
+
+    #[test]
+    fn mercator_inflation_coarsens_the_high_latitude_copy_of_one_bbox() {
+        let span = 0.15;
+        let equator = LLBBox::new(0.0, 0.0, span, span).unwrap();
+        let high = LLBBox::new(60.0, 0.0, 60.0 + span, span).unwrap();
+        assert!(
+            covering_tile_count(&high, TestLevel::M1)
+                > covering_tile_count(&equator, TestLevel::M1),
+            "tile count must grow with latitude"
+        );
+        assert_eq!(selected_level(&equator, 1.0), TestLevel::M1);
+        assert_eq!(selected_level(&high, 1.0), TestLevel::M3);
+    }
+
+    #[test]
+    fn the_budget_never_returns_a_level_finer_than_the_resolution_choice() {
+        let index = |l: TestLevel| LEVELS.iter().position(|c| *c == l).unwrap();
+        for lat in [0.0, 39.0, 60.0] {
+            for side_km in [1.0, 16.0, 24.5, 100.0] {
+                for cell in [0.5, 1.0, 4.0, 12.0] {
+                    let bbox = square_km(lat, side_km);
+                    let requested = select_level_for_cell_size(LEVELS, cell);
+                    let picked = coarsen_to_tile_budget(LEVELS, requested, &bbox);
+                    assert!(
+                        index(picked) >= index(requested),
+                        "lat {lat}, {side_km} km, {cell} m cells: {picked:?} is finer than {requested:?}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/elevation/providers/mapterhorn.rs
+++ b/src/elevation/providers/mapterhorn.rs
@@ -7,6 +7,7 @@
 use crate::coordinate_system::geographic::LLBBox;
 use crate::elevation::cache::get_cache_dir;
 use crate::elevation::provider::{ElevationProvider, RawElevationGrid};
+use crate::elevation::providers::fixed_tile::MAX_TILES_PER_FETCH;
 use fnv::{FnvHashMap, FnvHashSet};
 use rayon::prelude::*;
 use std::path::{Path, PathBuf};
@@ -22,9 +23,6 @@ const MAX_ZOOM: u8 = 17;
 /// Pyramid floor; any land tile exists at z6, only mid-ocean is absent there.
 const MIN_ZOOM: u8 = 6;
 const MAX_CONCURRENT_DOWNLOADS: usize = 8;
-/// Tile budget per fetch; zoom is lowered until the covering count fits.
-/// Worst case ~400 MB downloaded; decoding stays bounded by chunked sampling.
-const MAX_TILES_PER_FETCH: usize = 2048;
 /// Grid rows sampled per chunk; bounds decoded tiles to a few tile rows.
 const SAMPLE_CHUNK_ROWS: usize = 1024;
 /// Chunk size between outage-breaker checks during downloads.

--- a/src/ground.rs
+++ b/src/ground.rs
@@ -35,6 +35,8 @@ pub struct RotationMask {
 #[derive(Clone)]
 pub struct Ground {
     pub elevation_enabled: bool,
+    /// The output format's pack raised the build ceiling, so relief stays close to metre scale.
+    extended_ceiling: bool,
     ground_level: i32,
     elevation_data: Option<ElevationData>,
     land_cover: Option<LandCoverData>,
@@ -95,6 +97,7 @@ impl Ground {
     pub fn new_flat(ground_level: i32) -> Self {
         Self {
             elevation_enabled: false,
+            extended_ceiling: false,
             ground_level,
             elevation_data: None,
             land_cover: None,
@@ -128,6 +131,7 @@ impl Ground {
         }
         Self {
             elevation_enabled: false,
+            extended_ceiling: false,
             ground_level,
             elevation_data: None,
             land_cover,
@@ -149,6 +153,7 @@ impl Ground {
     ) -> Self {
         Self {
             elevation_enabled: false,
+            extended_ceiling: false,
             ground_level: 0,
             elevation_data: None,
             land_cover: Some(land_cover),
@@ -184,6 +189,7 @@ impl Ground {
         );
         Self {
             elevation_enabled: true,
+            extended_ceiling: false,
             ground_level: 0,
             elevation_data: Some(crate::elevation::ElevationData {
                 heights,
@@ -193,6 +199,7 @@ impl Ground {
                 world_height,
                 min_height_m: 0.0,
                 blocks_per_meter: 1.0,
+                slope_correction: 1.0,
                 ground_level: 0,
             }),
             land_cover: None,
@@ -290,6 +297,8 @@ impl Ground {
                     let canopy = canopy_job.and_then(|h| h.join().ok()).flatten();
                     Self {
                         elevation_enabled: true,
+                        extended_ceiling: disable_height_limit
+                            && extended_max_y > crate::world_editor::DEFAULT_MAX_Y,
                         ground_level: base,
                         elevation_data: Some(elevation_data),
                         land_cover,
@@ -319,6 +328,7 @@ impl Ground {
                     drop(canopy_job.and_then(|h| h.join().ok()));
                     Self {
                         elevation_enabled: false,
+                        extended_ceiling: false,
                         ground_level,
                         elevation_data: None,
                         land_cover: None,
@@ -610,8 +620,9 @@ impl Ground {
     /// Computes terrain slope at the given coordinates.
     ///
     /// Slope is the difference between the maximum and minimum elevation of
-    /// 4 cardinal neighbors sampled at a step distance. Higher values indicate
-    /// steeper terrain.
+    /// 4 cardinal neighbors sampled at a step distance, corrected back out of
+    /// compressed block space into the `8 * tan(incline)` units the thresholds
+    /// downstream are documented in. Higher values indicate steeper terrain.
     ///
     /// Returns 0 if elevation data is not available.
     #[inline(always)]
@@ -630,7 +641,23 @@ impl Ground {
         let min_val = east.min(west).min(north).min(south);
         // Saturate: pathological CLI input (e.g. very negative ground_level)
         // can push max - min past i32::MAX.
-        max_val.saturating_sub(min_val)
+        let raw = max_val.saturating_sub(min_val);
+        let correction = self
+            .elevation_data
+            .as_ref()
+            .map(|d| d.slope_correction)
+            .unwrap_or(1.0);
+        (raw as f64 * correction).round() as i32
+    }
+
+    /// Vertical blocks per real-world metre, 1.0 without elevation (or with zero
+    /// relief), so callers inverting the metre->Y affine can divide unconditionally.
+    #[inline(always)]
+    pub fn blocks_per_meter(&self) -> f64 {
+        match &self.elevation_data {
+            Some(d) if self.elevation_enabled && d.blocks_per_meter > 0.0 => d.blocks_per_meter,
+            _ => 1.0,
+        }
     }
 
     /// Returns the ground level at the given coordinates
@@ -648,9 +675,8 @@ impl Ground {
     /// Returns the appropriate Y level for water placement.
     /// On steep terrain, snaps to the local minimum within a small radius to
     /// correct spatial misalignment between water classification (OSM/ESA) and
-    /// the elevation DEM. The snap is skipped across a real cliff/falls (a drop
-    /// larger than the snap radius), where the cell keeps its own level so the
-    /// waterfront isn't terraced into a step.
+    /// the elevation DEM. The snap is skipped across a real cliff/falls, where the
+    /// cell keeps its own level so the waterfront isn't terraced into a step.
     pub fn water_level(&self, coord: XZPoint) -> i32 {
         let center = self.level(coord);
         if !self.elevation_enabled {
@@ -680,10 +706,18 @@ impl Ground {
                 min_y = min_y.min(neighbor);
             }
         }
-        // A drop larger than the snap radius is a real cliff/falls, not
-        // misalignment; snapping across it terraces the waterfront into a step.
+        // A real cliff/falls is not misalignment; snapping across it terraces the
+        // waterfront into a step. Under a raised ceiling the drop is a metre-space concept,
+        // so scale it by blocks-per-metre; the vanilla ceiling keeps the block-space radius
+        // it was tuned against, where an 8-block quay wall is a wall and not a rounding error.
         // saturating_sub guards against overflow on pathological elevations.
-        if center.saturating_sub(min_y) > SNAP_RADIUS {
+        const CLIFF_DROP_M: f64 = 25.0;
+        let cliff_drop = if self.extended_ceiling {
+            ((CLIFF_DROP_M * self.blocks_per_meter()).round() as i32).max(SNAP_RADIUS)
+        } else {
+            SNAP_RADIUS
+        };
+        if center.saturating_sub(min_y) > cliff_drop {
             return center;
         }
         min_y
@@ -964,6 +998,9 @@ impl Ground {
 }
 
 pub fn generate_ground_data(args: &Args, bbox: LLBBox) -> Ground {
+    // Cleared before the scaler publishes its own: in the GUI a previous run's terrain top
+    // would misgrade this world's map preview.
+    crate::world_editor::common::set_terrain_top_y(args.ground_level);
     if args.terrain() {
         println!("{} Fetching elevation...", "[3/7]".bold());
         let ground = Ground::new_enabled(
@@ -1010,10 +1047,14 @@ fn filler_block_for(body: CelestialBody) -> crate::block_definitions::Block {
 }
 
 /// Per-format build-height cap when the user opts into extended build height:
-/// 2031 for the Java datapack, 512 for the Bedrock behavior pack.
+/// 2031 for the Java datapack, 512 for the Bedrock behavior pack, and the vanilla
+/// ceiling for Luanti, which has no pack and whose spawn search only scans the
+/// vanilla range. Must stay gated like `world_top_y_for` / `extended_min_y_for`.
 pub(crate) fn extended_max_y_for(args: &Args) -> i32 {
     if args.bedrock {
         512
+    } else if args.luanti {
+        crate::world_editor::DEFAULT_MAX_Y
     } else {
         2031
     }
@@ -1023,14 +1064,18 @@ pub(crate) fn extended_max_y_for(args: &Args) -> i32 {
 /// (dimension_type min_y=-2032, height=4064), so the only thing keeping Arnis at -64 was the
 /// old constant. Java only: the Bedrock behavior pack declares -512, but the LevelDB subchunk
 /// writer is unverified below -64, and Luanti has no such pack at all.
-/// Dimension ceiling actually declared to the engine: the tall datapack's 2031, or vanilla's
-/// 319. Gated identically to `extended_min_y_for` — chunk serialization sizes heightmaps from
-/// the span between the two, so the pair must always describe the same dimension.
+/// Dimension ceiling actually declared to the engine: the tall datapack's 2031, the Bedrock
+/// behavior pack's 512 (511 here, since an editor ceiling has to end a section), or vanilla's
+/// 319. Must never sit below the ceiling the scaler aims at (`extended_max_y_for`), or the
+/// block store drops the terrain the scaler just placed. On Java it also pairs with
+/// `extended_min_y_for`: chunk serialization sizes heightmaps from the span between the two.
 pub(crate) fn world_top_y_for(args: &Args) -> i32 {
-    if args.disable_height_limit && !args.bedrock && !args.luanti {
-        2031
-    } else {
+    if !args.disable_height_limit || args.luanti {
         crate::world_editor::DEFAULT_MAX_Y
+    } else if args.bedrock {
+        511
+    } else {
+        2031
     }
 }
 
@@ -1066,6 +1111,7 @@ mod tests {
         let w = heights[0].len();
         Ground {
             elevation_enabled: true,
+            extended_ceiling: false,
             ground_level: 0,
             elevation_data: Some(ElevationData {
                 heights,
@@ -1075,6 +1121,7 @@ mod tests {
                 world_height: h,
                 min_height_m: 0.0,
                 blocks_per_meter: 1.0,
+                slope_correction: 1.0,
                 ground_level: 0,
             }),
             land_cover: None,
@@ -1187,6 +1234,7 @@ mod tests {
             world_height: 2,
             min_height_m: min_m,
             blocks_per_meter: bpm,
+            slope_correction: 1.0,
             ground_level: 0,
         };
         // 46 deg snow line is 3000 m; at 0.1 block/m from min 0 m, ground 64 => Y 364.
@@ -1194,5 +1242,157 @@ mod tests {
         // Flat terrain: never below the line, always above it.
         assert_eq!(snow_threshold_for(&ed(100.0, 0.0), 46.0, 64), i32::MAX);
         assert_eq!(snow_threshold_for(&ed(4000.0, 0.0), 46.0, 64), i32::MIN);
+    }
+
+    fn scaled_ground(
+        heights: Vec<Vec<f32>>,
+        blocks_per_meter: f64,
+        slope_correction: f64,
+    ) -> Ground {
+        let mut g = ground_with(heights);
+        let d = g.elevation_data.as_mut().unwrap();
+        d.blocks_per_meter = blocks_per_meter;
+        d.slope_correction = slope_correction;
+        g
+    }
+
+    /// heights[z][x] = x * per_block, so `level` is exact at integer coordinates.
+    fn ramp(per_block: f64) -> Vec<Vec<f32>> {
+        (0..16)
+            .map(|_| (0..16).map(|x| (x as f64 * per_block) as f32).collect())
+            .collect()
+    }
+
+    #[test]
+    fn slope_reports_the_same_incline_whatever_the_vertical_compression() {
+        // 8 blocks of rise across the 8-block sampling span is 45 degrees, which the
+        // downstream thresholds spell 8 * tan(incline) = 8.
+        let uncompressed = scaled_ground(ramp(1.0), 1.0, 1.0);
+        assert_eq!(uncompressed.slope(XZPoint::new(8, 8)), 8);
+
+        // Same hillside with the relief squeezed 4:1 into the vanilla ceiling.
+        let compressed = scaled_ground(ramp(0.25), 0.25, 4.0);
+        assert_eq!(compressed.slope(XZPoint::new(8, 8)), 8);
+    }
+
+    #[test]
+    fn blocks_per_metre_falls_back_to_one_without_a_vertical_affine() {
+        let mut g = scaled_ground(vec![vec![0.0; 4]; 4], 0.25, 4.0);
+        assert_eq!(g.blocks_per_meter(), 0.25);
+
+        g.elevation_data.as_mut().unwrap().blocks_per_meter = 0.0;
+        assert_eq!(
+            g.blocks_per_meter(),
+            1.0,
+            "zero relief leaves no affine to invert"
+        );
+
+        g.elevation_data.as_mut().unwrap().blocks_per_meter = 0.25;
+        g.elevation_enabled = false;
+        assert_eq!(g.blocks_per_meter(), 1.0);
+    }
+
+    #[test]
+    fn the_water_snap_cliff_cutoff_only_scales_under_a_raised_ceiling() {
+        let step = |drop: f64| -> Vec<Vec<f32>> {
+            (0..16)
+                .map(|_| {
+                    (0..16)
+                        .map(|x| if x <= 7 { drop as f32 } else { 0.0 })
+                        .collect()
+                })
+                .collect()
+        };
+        let at = |drop: f64, bpm: f64, correction: f64, extended: bool| {
+            let mut g = scaled_ground(step(drop), bpm, correction);
+            g.extended_ceiling = extended;
+            g.water_level(XZPoint::new(7, 8))
+        };
+
+        // Vanilla ceiling: the cutoff is the 3-block snap radius at any scaling, so a quay
+        // wall a few blocks above the basin still keeps its own level.
+        assert_eq!(at(3.0, 1.0, 1.0, false), 0);
+        assert_eq!(at(4.0, 1.0, 1.0, false), 4);
+        assert_eq!(at(4.0, 0.12, 8.33, false), 4);
+
+        // Raised ceiling, compressed: 25 m is under the snap radius, so the cutoff stays 3.
+        assert_eq!(at(3.0, 0.12, 8.33, true), 0);
+        assert_eq!(at(4.0, 0.12, 8.33, true), 4);
+
+        // Raised ceiling, 1:1 vertical: the cutoff is the 25 m cliff the guard was written for.
+        assert_eq!(at(10.0, 1.0, 1.0, true), 0);
+        assert_eq!(at(26.0, 1.0, 1.0, true), 26);
+    }
+
+    #[test]
+    fn the_extended_ceiling_agrees_with_the_declared_world_top() {
+        use clap::Parser;
+        let args = |extra: &[&str]| {
+            let mut cmd: Vec<&str> = vec![
+                "arnis",
+                "--output-dir",
+                ".",
+                "--bbox",
+                "1,2,3,4",
+                "--disable-height-limit",
+            ];
+            cmd.extend_from_slice(extra);
+            Args::parse_from(cmd.iter())
+        };
+
+        let java = args(&[]);
+        assert_eq!(extended_max_y_for(&java), 2031);
+        assert_eq!(world_top_y_for(&java), 2031);
+
+        let bedrock = args(&["--bedrock"]);
+        assert_eq!(extended_max_y_for(&bedrock), 512);
+        // Ends a section, and still covers the 497 the scaler clamps to.
+        assert_eq!(world_top_y_for(&bedrock), 511);
+
+        let luanti = args(&["--luanti"]);
+        assert_eq!(
+            extended_max_y_for(&luanti),
+            crate::world_editor::DEFAULT_MAX_Y
+        );
+        assert_eq!(world_top_y_for(&luanti), crate::world_editor::DEFAULT_MAX_Y);
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    /// Ground carrying an elevation grid *and* land cover; the water-field tests need
+    /// both and neither single-purpose test constructor supplies the pair.
+    pub(crate) fn ground_with_land_cover_and_elevation(
+        land_cover: LandCoverData,
+        world_width: usize,
+        world_height: usize,
+    ) -> Ground {
+        let (gw, gh) = (land_cover.width, land_cover.height);
+        Ground {
+            elevation_enabled: true,
+            extended_ceiling: false,
+            ground_level: 0,
+            elevation_data: Some(ElevationData {
+                heights: vec![vec![0.0f32; gw]; gh],
+                width: gw,
+                height: gh,
+                world_width,
+                world_height,
+                min_height_m: 0.0,
+                blocks_per_meter: 1.0,
+                slope_correction: 1.0,
+                ground_level: 0,
+            }),
+            land_cover: Some(land_cover),
+            canopy: None,
+            world_width,
+            world_height,
+            rotation_mask: None,
+            snow_threshold_y: i32::MAX,
+            climate: crate::climate::Climate::Temperate,
+            body: CelestialBody::Earth,
+        }
     }
 }

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -597,8 +597,7 @@ fn set_player_spawn_in_level_dat(
     Ok(())
 }
 
-// Function to update player spawn Y coordinate based on terrain height after generation
-// This updates the spawn Y coordinate to be at terrain height + 3 blocks
+// Puts the player on the world spawn column at terrain height + 3, after generation.
 // `xzbbox` must be the box the world was generated from, post-rotation when a
 // rotation was applied, since `ground` is indexed against it.
 pub fn update_player_spawn_y_after_generation(
@@ -677,15 +676,21 @@ pub fn update_player_spawn_y_after_generation(
     // Update player position and world spawn point
     if let Value::Compound(ref mut root) = nbt_data {
         if let Some(Value::Compound(ref mut data)) = root.get_mut("Data") {
-            // Only update the Y coordinate, keep existing X and Z
             data.insert("SpawnY".to_string(), Value::Int(spawn_y));
 
-            // Update player position - only Y coordinate
+            // The template pins Pos to (-5, -5), a column that is neither the spawn point
+            // nor inside the generated regions. Move it onto the column just sampled,
+            // matching what set_spawn_in_level_dat writes.
             if let Some(Value::Compound(ref mut player)) = data.get_mut("Player") {
                 if let Some(Value::List(ref mut pos)) = player.get_mut("Pos") {
-                    // Safely update Y position with bounds checking
+                    if let Some(Value::Double(ref mut pos_x)) = pos.get_mut(0) {
+                        *pos_x = existing_spawn_x as f64;
+                    }
                     if let Some(Value::Double(ref mut pos_y)) = pos.get_mut(1) {
                         *pos_y = spawn_y as f64;
+                    }
+                    if let Some(Value::Double(ref mut pos_z)) = pos.get_mut(2) {
+                        *pos_z = existing_spawn_z as f64;
                     }
                 }
             }
@@ -1072,6 +1077,9 @@ fn gui_start_generation(
     } else {
         celestial_body.world_scale()
     };
+    // apply_body_defaults clears this off Earth, but it runs after the datapack install below
+    // and after the Args literal is built, so both would still see the raw frontend value.
+    let disable_height_limit = disable_height_limit && celestial_body.is_earth();
 
     // The GUI builds Args directly and never runs validate_args, so guard the scale here
     // rather than letting it panic deep in the coordinate transform after the fetch.
@@ -1374,7 +1382,8 @@ fn gui_start_generation(
                 signage: crate::args::SignageLevel::from_str_lossy(&signage),
                 body: celestial_body,
             };
-            // Same helper the CLI uses, so the two cannot diverge.
+            // Same helper the CLI uses. Anything read before this point (the world prep
+            // above) has to apply the body rules on its own.
             crate::args::apply_body_defaults(&mut args);
             let args = args;
 
@@ -1652,6 +1661,70 @@ mod locale_tests {
             errors.is_empty(),
             "Locale key mismatches:\n{}",
             errors.join("\n")
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_level_dat(world: &Path) -> Value {
+        let raw = fs::read(world.join("level.dat")).unwrap();
+        let mut buf = Vec::new();
+        GzDecoder::new(raw.as_slice())
+            .read_to_end(&mut buf)
+            .unwrap();
+        fastnbt::from_bytes(&buf).unwrap()
+    }
+
+    fn write_level_dat(world: &Path, root: &Value) {
+        let bytes = fastnbt::to_bytes(root).unwrap();
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(&bytes).unwrap();
+        fs::write(world.join("level.dat"), encoder.finish().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn the_player_starts_on_the_world_spawn_column() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world = PathBuf::from(crate::world_utils::create_new_world(tmp.path()).unwrap());
+
+        let mut root = read_level_dat(&world);
+        let Value::Compound(ref mut map) = root else {
+            panic!("root not a compound")
+        };
+        let Some(Value::Compound(data)) = map.get_mut("Data") else {
+            panic!("missing Data")
+        };
+        data.insert("SpawnX".to_string(), Value::Int(120));
+        data.insert("SpawnZ".to_string(), Value::Int(-340));
+        write_level_dat(&world, &root);
+
+        let xzbbox = XZBBox::rect_from_min_max(0, 0, 511, 511).unwrap();
+        update_player_spawn_y_after_generation(&world, &xzbbox, &Ground::new_flat(-62)).unwrap();
+
+        let root = read_level_dat(&world);
+        let Value::Compound(map) = root else {
+            panic!("root not a compound")
+        };
+        let Some(Value::Compound(data)) = map.get("Data") else {
+            panic!("missing Data")
+        };
+        assert_eq!(data.get("SpawnY"), Some(&Value::Int(-61)));
+        let Some(Value::Compound(player)) = data.get("Player") else {
+            panic!("missing Player")
+        };
+        let Some(Value::List(pos)) = player.get("Pos") else {
+            panic!("missing Pos")
+        };
+        assert_eq!(
+            pos.as_slice(),
+            [
+                Value::Double(120.0),
+                Value::Double(-61.0),
+                Value::Double(-340.0)
+            ]
         );
     }
 }

--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -1312,10 +1312,21 @@ input[type="range"] {
   }
 }
 
-/* Options that do not apply to the selected celestial body */
+/* Options that do not apply to the selected celestial body or world format */
 .settings-row-unavailable {
   opacity: 0.4;
   pointer-events: none;
+}
+
+/* What a setting costs, shown under its row while it is on */
+.settings-row-note {
+  border-left: 3px solid #fecc44;
+  margin: 0 0 8px;
+  padding: 4px 10px;
+  font-size: 0.75em;
+  line-height: 1.4;
+  color: #b8b8b8;
+  text-align: left;
 }
 
 .segmented-disabled {

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -48,6 +48,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   await initSavePath();
   initSettings();
   initVoxyLightingCoupling();
+  initHeightLimitNote();
   // After initSettings(), so the slider label and rotation handlers exist
   // before restored values are applied. Labels get localized a few lines below.
   initSettingsStore({ resetWorldFormat: () => setWorldFormat('java') });
@@ -483,6 +484,9 @@ function setCelestialBody(body) {
     group.classList.toggle('segmented-disabled', off);
     markRow(group);
   });
+
+  // Also format-gated, so it cannot simply follow the earth-only loop.
+  refreshHeightLimitRow();
 
   const notice = document.getElementById('off-earth-notice');
   if (notice) {
@@ -1265,18 +1269,57 @@ function getEffectiveWorldFormat() {
   return selectedWorldFormat;
 }
 
+// The extended dimension is declared by the Java datapack and the Bedrock
+// behavior pack; Luanti ships neither, and off Earth the relief already fits
+// vanilla height, so the backend forces the flag off there.
+function heightLimitAvailable(format) {
+  return selectedCelestialBody === 'earth' && format !== 'luanti';
+}
+
+function refreshHeightLimitRow(format) {
+  const toggle = document.getElementById('disable-height-limit-toggle');
+  if (!toggle) return;
+
+  const available = heightLimitAvailable(format || selectedWorldFormat);
+  toggle.disabled = !available;
+
+  const row = toggle.closest('.settings-row');
+  if (row) {
+    // Cleared, not set to 1: an inline value would beat the class rule.
+    row.style.opacity = '';
+    row.classList.toggle('settings-row-unavailable', !available);
+  }
+
+  const note = document.getElementById('height-limit-note');
+  if (note) note.hidden = !(available && toggle.checked);
+}
+
+// Consequences the CLI prints to stderr, which a GUI user never sees.
+function initHeightLimitNote() {
+  const toggle = document.getElementById('disable-height-limit-toggle');
+  const row = toggle && toggle.closest('.settings-row');
+  if (!row || document.getElementById('height-limit-note')) return;
+
+  const note = document.createElement('div');
+  note.id = 'height-limit-note';
+  note.className = 'settings-row-note';
+  note.hidden = true;
+  note.textContent =
+    'Needs Java 1.21.4+ or Bedrock 1.21.40+. First load asks to enable Experimental ' +
+    'Features, the world cannot be uploaded to Realms, and generation is slower and ' +
+    'the world bigger.';
+  row.after(note);
+
+  toggle.addEventListener('change', () => refreshHeightLimitRow());
+  refreshHeightLimitRow();
+}
+
 function updateFormatToggleUI(format) {
   const javaBtn = document.getElementById('format-java');
   const bedrockBtn = document.getElementById('format-bedrock');
   const luantiBtn = document.getElementById('format-luanti');
 
-  const heightLimitToggle = document.getElementById('disable-height-limit-toggle');
-
-  // Toggle now supported on both formats (Java datapack + Bedrock BP).
-  if (heightLimitToggle) {
-    heightLimitToggle.disabled = false;
-    heightLimitToggle.parentElement.closest('.settings-row').style.opacity = '1';
-  }
+  refreshHeightLimitRow(format);
 
   javaBtn.classList.remove('format-active');
   bedrockBtn.classList.remove('format-active');
@@ -2005,7 +2048,9 @@ async function startGeneration() {
     var maxTreeSize = maxTreeSizeBtn ? maxTreeSizeBtn.dataset.maxTreeSize : "giant";
     var overture = document.getElementById("overture-toggle").checked;
     var use_3d = document.getElementById("use-3d-toggle").checked;
-    var disable_height_limit = document.getElementById("disable-height-limit-toggle").checked;
+    var heightLimitToggle = document.getElementById("disable-height-limit-toggle");
+    // Disabled means unsupported for this body or format, so never send a stale tick.
+    var disable_height_limit = !heightLimitToggle.disabled && heightLimitToggle.checked;
     var aws_only_elevation = document.getElementById("aws-only-elevation-toggle").checked;
     var bake_lighting = document.getElementById("bake-lighting-toggle").checked;
     var voxy_lod = document.getElementById("voxy-lod-toggle").checked;

--- a/src/map_renderer.rs
+++ b/src/map_renderer.rs
@@ -15,6 +15,9 @@ use std::sync::Mutex;
 /// Longest allowed output image side; larger worlds are box-averaged down.
 const MAX_OUTPUT_SIDE: u32 = 4096;
 const COLOR_LUT_LIMIT: u16 = 512;
+/// Narrowest elevation band the shading spreads over. A bbox with no relief would otherwise
+/// split into two tones at the terrain base, with every roof pinned to the bright end.
+const MIN_SHADING_BAND: i32 = 128;
 
 /// Shared name->color table for the LUT builder and the out-of-range fallback.
 static BLOCK_COLORS: Lazy<FnvHashMap<&'static str, Rgb<u8>>> = Lazy::new(get_block_colors);
@@ -69,6 +72,9 @@ pub struct PreviewAccumulator {
     stride: u32,
     out_w: u32,
     out_h: u32,
+    /// Elevation band the shading normalises over: terrain base, half the terrain's own span.
+    shade_base: i32,
+    shade_half_band: f32,
     /// Per output pixel: [r_sum, g_sum, b_sum, sample_count].
     frame: Mutex<Vec<[u16; 4]>>,
 }
@@ -85,6 +91,12 @@ impl PreviewAccumulator {
         let step = width.max(height).div_ceil(max_side.max(1)).max(1);
         let out_w = width.div_ceil(step);
         let out_h = height.div_ceil(step);
+        // Read once: the scaler has settled long before the first region is written, and the
+        // band has to be the same for every sample that lands in the frame.
+        let shade_base = crate::world_editor::base_chunk_y();
+        let shade_band = crate::world_editor::common::terrain_top_y()
+            .saturating_sub(shade_base)
+            .max(MIN_SHADING_BAND);
         Self {
             min_x: xzbbox.min_x(),
             max_x: xzbbox.max_x(),
@@ -94,6 +106,8 @@ impl PreviewAccumulator {
             stride: step.div_ceil(16),
             out_w,
             out_h,
+            shade_base,
+            shade_half_band: shade_band as f32 / 2.0,
             frame: Mutex::new(vec![[0u16; 4]; out_w as usize * out_h as usize]),
         }
     }
@@ -145,7 +159,12 @@ impl PreviewAccumulator {
                         continue;
                     }
                     if let Some((color, y)) = top_block_color(&sections, lx as u8, lz as u8) {
-                        let c = apply_elevation_shading(color, y);
+                        let c = apply_elevation_shading(
+                            color,
+                            y,
+                            self.shade_base,
+                            self.shade_half_band,
+                        );
                         let px = (wx - self.min_x) as u32 / self.step;
                         let pz = (wz - self.min_z) as u32 / self.step;
                         let cell = &mut local[(pz - pz0) as usize * pw + (px - px0) as usize];
@@ -247,27 +266,15 @@ fn top_block_color(sections: &[(i8, &SectionToModify)], x: u8, z: u8) -> Option<
     None
 }
 
-/// Applies elevation-based shading to a color
-/// Higher elevations are brighter, lower are darker
+/// Applies elevation-based shading to a color: higher is brighter, lower is darker.
+/// The band is the terrain's own span, not the dimension's: the base sinks with the tall
+/// datapack, and terrain fills only a slice of a 4000-block build range.
 #[inline]
-fn apply_elevation_shading(color: Rgb<u8>, y: i32) -> Rgb<u8> {
-    // Base brightness boost of 10%, plus elevation shading
-    // Shading range: -20% darker to +20% brighter (asymmetric, more bright than dark)
+fn apply_elevation_shading(color: Rgb<u8>, y: i32, base: i32, half_band: f32) -> Rgb<u8> {
+    let normalized = (((y - base) as f32 - half_band) / half_band).clamp(-1.0, 1.0);
 
-    // Normalize Y to a -1.0 to 1.0 range (roughly)
-    // y=0 -> -0.5, y=0 -> 0, y=200 -> +1.0
-    let normalized = (y as f32 / 100.0).clamp(-1.0, 1.0);
-
-    // Base 10% brightness boost + asymmetric elevation shading
-    let elevation_adjust = if normalized >= 0.0 {
-        // Above sea level: up to +20% brighter
-        normalized * 0.20
-    } else {
-        // Below sea level: up to -20% darker
-        normalized * 0.20
-    };
-
-    let multiplier = 1.10 + elevation_adjust;
+    // Base 10% brightness boost, plus -20%..+20% for elevation.
+    let multiplier = 1.10 + normalized * 0.20;
 
     Rgb([
         (color.0[0] as f32 * multiplier).clamp(0.0, 255.0) as u8,
@@ -921,11 +928,11 @@ mod tests {
         assert_eq!(img.dimensions(), (16, 16));
         assert_eq!(
             *img.get_pixel(0, 0),
-            apply_elevation_shading(Rgb([128, 128, 128]), 0)
+            apply_elevation_shading(Rgb([128, 128, 128]), 0, a.shade_base, a.shade_half_band)
         );
         assert_eq!(
             *img.get_pixel(1, 0),
-            apply_elevation_shading(Rgb([86, 125, 70]), 5)
+            apply_elevation_shading(Rgb([86, 125, 70]), 5, a.shade_base, a.shade_half_band)
         );
         // Untouched column stays white.
         assert_eq!(*img.get_pixel(5, 5), Rgb([255, 255, 255]));
@@ -946,8 +953,8 @@ mod tests {
         halo.get_or_create_chunk(0, 0).set_block(0, 0, 0, STONE);
         a.ingest_region(-1, -1, &halo);
 
-        let s = apply_elevation_shading(Rgb([128, 128, 128]), 0);
-        let w = apply_elevation_shading(Rgb([59, 86, 165]), 0);
+        let s = apply_elevation_shading(Rgb([128, 128, 128]), 0, a.shade_base, a.shade_half_band);
+        let w = apply_elevation_shading(Rgb([59, 86, 165]), 0, a.shade_base, a.shade_half_band);
         let expected = Rgb([
             ((s.0[0] as u32 + w.0[0] as u32) / 2) as u8,
             ((s.0[1] as u32 + w.0[1] as u32) / 2) as u8,
@@ -960,5 +967,69 @@ mod tests {
         assert_eq!(img.dimensions(), (4096, 8));
         assert_eq!(*img.get_pixel(0, 0), expected);
         assert_eq!(*img.get_pixel(1, 0), Rgb([255, 255, 255]));
+    }
+}
+
+#[cfg(test)]
+mod elevation_shading_tests {
+    use super::*;
+
+    const GREY: Rgb<u8> = Rgb([100, 100, 100]);
+
+    fn shade(y: i32, base: i32, top: i32) -> i32 {
+        let half_band = (top - base).max(MIN_SHADING_BAND) as f32 / 2.0;
+        i32::from(apply_elevation_shading(GREY, y, base, half_band).0[0])
+    }
+
+    #[test]
+    fn a_city_band_spans_the_whole_multiplier_range() {
+        // Vanilla city: terrain -62..64, nowhere near the 319 dimension ceiling.
+        assert_eq!(shade(-62, -62, 64), 90, "terrain base is the darkest");
+        // 126 blocks of relief is just under the floor band, so the top lands a shade short.
+        assert!(
+            shade(64, -62, 64) >= 129,
+            "the highest hill is the brightest"
+        );
+        assert!(shade(-40, -62, 64) < shade(20, -62, 64));
+    }
+
+    #[test]
+    fn a_sunk_base_grades_the_whole_relief() {
+        // Matterhorn at scale 4: base -1876, terrain up to 2016.
+        assert_eq!(shade(-1876, -1876, 2016), 90);
+        assert_eq!(shade(2016, -1876, 2016), 130);
+        assert!(
+            shade(-100, -1876, 2016) < shade(1500, -1876, 2016),
+            "a 1600-block climb must change the shade"
+        );
+
+        // Y=0 carries no meaning in a 4000-block world: columns either side of it are
+        // 5% of the band apart and must shade alike, not split the range in two.
+        let across_zero = shade(101, -1876, 2016) - shade(-101, -1876, 2016);
+        assert!(across_zero * 4 < 40, "shading splits at Y=0: {across_zero}");
+    }
+
+    #[test]
+    fn a_flat_bbox_still_grades_what_stands_on_it() {
+        assert_eq!(shade(-62, -62, -62), 90);
+        let roof = shade(-42, -62, -62);
+        assert!(
+            roof > 90 && roof < 130,
+            "roof shade {roof} is a saturated tone"
+        );
+    }
+
+    #[test]
+    fn shading_stays_inside_the_multiplier_bounds_outside_the_band() {
+        assert_eq!(
+            shade(-2032, -1876, 2016),
+            90,
+            "below the base clamps to the darkest"
+        );
+        assert_eq!(
+            shade(4000, -1876, 2016),
+            130,
+            "above the terrain clamps to the brightest"
+        );
     }
 }

--- a/src/ore_generation.rs
+++ b/src/ore_generation.rs
@@ -22,6 +22,10 @@ struct OreDef {
     avg_veins_per_chunk: u32,
 }
 
+/// Deepest ore-bearing column below local ground: the deepest band ends at 65, the rest is the
+/// vanilla column (383 blocks at most), so vanilla is unchanged and a sunk floor is not tracked.
+const MAX_ORE_DEPTH: i32 = 384;
+
 const ORES: &[OreDef] = &[
     OreDef {
         block: COAL_ORE,
@@ -111,10 +115,9 @@ pub fn generate_ores_region(
             let mut rng = coord_rng(chunk_x, chunk_z, 0xC0DE);
 
             for ore in ORES {
-                // Fill the stone column down to the terrain floor at the ore's usual density.
-                // The terrain floor, not the world floor: an extended floor would otherwise
-                // multiply `span` (and with it the vein count) roughly 33x.
-                let y_min = terrain_floor_y() + 1;
+                // Vein count scales with `span`, so a floor that sinks with the base would
+                // multiply it; the band is capped instead of following the floor down.
+                let y_min = (ground_y - MAX_ORE_DEPTH).max(terrain_floor_y() + 1);
                 let y_max = (ground_y - ore.depth_min).max(y_min);
                 if y_min > y_max {
                     continue;
@@ -162,5 +165,86 @@ fn place_vein(
             4 => cz += 1,
             _ => cz -= 1,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinate_system::geographic::LLBBox;
+    use crate::world_editor::{
+        set_terrain_floor_y, set_world_bounds, DEFAULT_MAX_Y, DEFAULT_MIN_Y, FLOOR_TEST_LOCK,
+    };
+    use std::ops::RangeInclusive;
+    use std::path::PathBuf;
+
+    /// Ore blocks placed inside `band` for one chunk with its surface at `ground_y`. Only
+    /// `band` is stone, and veins overwrite nothing else, so anything else there is ore.
+    fn ores_in_band(ground_y: i32, band: RangeInclusive<i32>) -> usize {
+        let xzbbox = XZBBox::rect_from_min_max(0, 0, 15, 15).unwrap();
+        let llbbox = LLBBox::new(54.6, 9.9, 54.61, 9.91).unwrap();
+        let mut editor = WorldEditor::new(PathBuf::from("/dev/null/unused"), &xzbbox, llbbox);
+        editor.register_road_surface_y(8, 8, ground_y);
+        for y in band.clone() {
+            for x in 0..16 {
+                for z in 0..16 {
+                    editor.set_block_absolute(STONE, x, y, z, None, None);
+                }
+            }
+        }
+
+        generate_ores_region(&mut editor, 0, 15, 0, 15, false);
+
+        band.flat_map(|y| (0..16).flat_map(move |x| (0..16).map(move |z| (x, y, z))))
+            .filter(
+                |&(x, y, z)| matches!(editor.get_block_absolute(x, y, z), Some(b) if b != STONE),
+            )
+            .count()
+    }
+
+    #[test]
+    fn the_tallest_vanilla_column_still_mines_down_to_the_bedrock_plane() {
+        let _g = FLOOR_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+        set_terrain_floor_y(DEFAULT_MIN_Y + 2);
+        assert_eq!(terrain_floor_y(), DEFAULT_MIN_Y);
+
+        let floor = terrain_floor_y() + 1;
+        let n = ores_in_band(DEFAULT_MAX_Y, floor..=floor + 39);
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+        set_terrain_floor_y(DEFAULT_MIN_Y + 2);
+        assert!(n > 0, "the cap must not clip the 383 block vanilla column");
+    }
+
+    #[test]
+    fn a_sunk_floor_does_not_extend_the_ore_column_below_the_cap() {
+        let _g = FLOOR_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_world_bounds(-2032, 2031);
+        set_terrain_floor_y(-1888);
+        assert_eq!(terrain_floor_y(), -1952);
+
+        let ground_y = 2000;
+        let below = ores_in_band(ground_y, ground_y - 500..=ground_y - MAX_ORE_DEPTH - 1);
+        let within = ores_in_band(ground_y, ground_y - MAX_ORE_DEPTH..=ground_y - 300);
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+        set_terrain_floor_y(DEFAULT_MIN_Y + 2);
+        assert_eq!(below, 0, "ore reached below the cap");
+        assert!(within > 0, "the capped band carries no ore at all");
+    }
+
+    #[test]
+    fn a_column_shallower_than_the_cap_still_reaches_the_terrain_floor() {
+        let _g = FLOOR_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        set_world_bounds(-2032, 2031);
+        set_terrain_floor_y(-1888);
+
+        let floor = terrain_floor_y() + 1;
+        let n = ores_in_band(-1888, floor..=floor + 50);
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+        set_terrain_floor_y(DEFAULT_MIN_Y + 2);
+        assert!(n > 0, "a column within the cap must still reach bedrock");
     }
 }

--- a/src/projection/web_mercator.rs
+++ b/src/projection/web_mercator.rs
@@ -8,6 +8,12 @@ const EARTH_RADIUS: f64 = 6_371_000.0;
 ///
 /// Orientation follows Minecraft conventions: increasing X points east,
 /// and **north maps to negative Z**.
+///
+/// Anisotropic: `x` carries a `cos(origin_lat)` factor and so comes out in ground
+/// metres, while `z` stays in raw Mercator units and is stretched by `1/cos(lat)`
+/// (1.48x at 47 deg). `validate_args` rejects `--projection web_mercator` for that
+/// reason. `CoordTransformer::transform_point` repeats this formula for every node,
+/// so the two have to be corrected together.
 pub struct WebMercatorProjection {
     /// Reference latitude in degrees.
     pub(crate) origin_lat: f64,
@@ -137,6 +143,31 @@ mod tests {
             z2 < z1,
             "increasing latitude (north) should decrease z: z1={z1}, z2={z2}"
         );
+    }
+
+    #[test]
+    fn z_is_stretched_by_one_over_cos_lat_while_x_is_ground_metres() {
+        const D: f64 = 0.0045;
+        for lat in [0.0045, 47.3745, 61.0045] {
+            let p = WebMercatorProjection::new(lat, 8.5415, 1.0);
+
+            let (x_east, _) = p.forward(lat, 8.5415 + D);
+            let ground_x = EARTH_RADIUS * D.to_radians() * lat.to_radians().cos();
+            assert!(
+                (x_east / ground_x - 1.0).abs() < 1e-9,
+                "x should be ground metres at lat {lat}: got {x_east}, ground {ground_x}"
+            );
+
+            let (_, z_south) = p.forward(lat - D, 8.5415);
+            let (_, z_north) = p.forward(lat + D, 8.5415);
+            let ground_z = EARTH_RADIUS * (2.0 * D).to_radians();
+            let ratio = (z_south - z_north) / ground_z;
+            let expected = 1.0 / lat.to_radians().cos();
+            assert!(
+                (ratio - expected).abs() < 1e-4,
+                "z stretch at lat {lat}: got {ratio}, expected {expected}"
+            );
+        }
     }
 
     #[test]

--- a/src/trees/region.rs
+++ b/src/trees/region.rs
@@ -117,6 +117,7 @@ pub struct RegionLibrary {
     vanilla_pack: Pack,
     scale: f64,
     ground_level: i32,
+    blocks_per_meter: f64,
     sizes: SizeFilter,
     total_realm: usize,
     total_vanilla: usize,
@@ -193,6 +194,7 @@ impl RegionLibrary {
         source: &TreePackSource,
         scale: f64,
         ground_level: i32,
+        blocks_per_meter: f64,
         sizes: SizeFilter,
         exclude_palms: bool,
     ) -> Result<RegionLibrary, String> {
@@ -232,6 +234,7 @@ impl RegionLibrary {
             vanilla_pack,
             scale,
             ground_level,
+            blocks_per_meter,
             sizes,
             total_realm,
             total_vanilla,
@@ -239,8 +242,14 @@ impl RegionLibrary {
     }
 
     fn is_montane(&self, elev_y: i32) -> bool {
-        let blocks_above = f64::from(elev_y - self.ground_level);
-        blocks_above / self.scale.max(0.001) > MONTANE_METRES
+        // Inverting the metre->Y affine needs the vertical blocks per metre, which compression
+        // pulls well below the horizontal scale; fall back to the scale only if it is missing.
+        let per_metre = if self.blocks_per_meter > 0.0 {
+            self.blocks_per_meter
+        } else {
+            self.scale
+        };
+        f64::from(elev_y - self.ground_level) / per_metre.max(0.001) > MONTANE_METRES
     }
 
     pub fn schem(&self, idx: usize) -> &Schematic {
@@ -547,10 +556,30 @@ mod tests {
     }
 
     #[test]
+    fn montane_starts_at_the_same_real_height_whatever_the_compression() {
+        let src = TreePackSource::embedded("eur");
+        let base = -62;
+        let lib = |bpm: f64| {
+            RegionLibrary::load(&src, 1.0, base, bpm, SizeFilter::default(), false)
+                .expect("load eur")
+        };
+
+        let uncompressed = lib(1.0);
+        assert!(!uncompressed.is_montane(base + 450));
+        assert!(uncompressed.is_montane(base + 451));
+
+        // Alps at scale 1 with the vanilla ceiling: 4441 m squeezed into 366 blocks,
+        // so 450 m above the base lands 37.1 blocks up.
+        let compressed = lib(366.0 / 4441.0);
+        assert!(!compressed.is_montane(base + 37));
+        assert!(compressed.is_montane(base + 38));
+    }
+
+    #[test]
     fn ena_palm_gate_removes_trees() {
         let src = TreePackSource::embedded("ena");
-        let incl = RegionLibrary::load(&src, 1.0, -62, SizeFilter::default(), false).unwrap();
-        let excl = RegionLibrary::load(&src, 1.0, -62, SizeFilter::default(), true).unwrap();
+        let incl = RegionLibrary::load(&src, 1.0, -62, 1.0, SizeFilter::default(), false).unwrap();
+        let excl = RegionLibrary::load(&src, 1.0, -62, 1.0, SizeFilter::default(), true).unwrap();
         assert!(
             excl.total_realm < incl.total_realm,
             "palm gate should drop ena palm trees ({} vs {})",
@@ -562,8 +591,8 @@ mod tests {
     #[test]
     fn embedded_eur_loads_and_picks() {
         let src = TreePackSource::embedded("eur");
-        let lib =
-            RegionLibrary::load(&src, 1.0, -62, SizeFilter::default(), false).expect("load eur");
+        let lib = RegionLibrary::load(&src, 1.0, -62, 1.0, SizeFilter::default(), false)
+            .expect("load eur");
         assert!(lib.total_realm > 0);
         for k in 0..200 {
             if let Some((_, _, idx, _)) =
@@ -579,8 +608,8 @@ mod tests {
     #[test]
     fn canopy_size_hint_steers_the_pick() {
         let src = TreePackSource::embedded("eur");
-        let lib =
-            RegionLibrary::load(&src, 1.0, -62, SizeFilter::default(), false).expect("load eur");
+        let lib = RegionLibrary::load(&src, 1.0, -62, 1.0, SizeFilter::default(), false)
+            .expect("load eur");
         let tally = |hint: Option<TreeSize>| {
             let req = SlotRequest {
                 want_size: hint,
@@ -638,8 +667,15 @@ mod tests {
     #[test]
     fn max_tree_size_clamps_the_canopy_hint() {
         let src = TreePackSource::embedded("eur");
-        let lib = RegionLibrary::load(&src, 1.0, -62, SizeFilter::up_to(TreeSize::Small), false)
-            .expect("load eur");
+        let lib = RegionLibrary::load(
+            &src,
+            1.0,
+            -62,
+            1.0,
+            SizeFilter::up_to(TreeSize::Small),
+            false,
+        )
+        .expect("load eur");
         let tally = |want_size| {
             let req = SlotRequest {
                 want_size,

--- a/src/trees/tree_pack.rs
+++ b/src/trees/tree_pack.rs
@@ -69,7 +69,13 @@ pub fn realm_for_latlon(lat: f64, lon: f64) -> &'static str {
 }
 
 /// Load the region tree pack (realm from bbox center), or None for legacy procedural trees.
-pub fn load(args: &Args, bbox: LLBBox, scale: f64, ground_level: i32) -> Option<RegionLibrary> {
+pub fn load(
+    args: &Args,
+    bbox: LLBBox,
+    scale: f64,
+    ground_level: i32,
+    blocks_per_meter: f64,
+) -> Option<RegionLibrary> {
     if args.legacy_trees {
         return None;
     }
@@ -81,7 +87,14 @@ pub fn load(args: &Args, bbox: LLBBox, scale: f64, ground_level: i32) -> Option<
     // No palms outside the subtropics (the wide ena realm also spans the Caribbean).
     let exclude_palms = lat.abs() > 35.0;
 
-    match RegionLibrary::load(&source, scale, ground_level, sizes, exclude_palms) {
+    match RegionLibrary::load(
+        &source,
+        scale,
+        ground_level,
+        blocks_per_meter,
+        sizes,
+        exclude_palms,
+    ) {
         Ok(lib) => {
             lib.report();
             Some(lib)

--- a/src/voxy/lod.rs
+++ b/src/voxy/lod.rs
@@ -236,6 +236,9 @@ pub(crate) struct RegionLod<'a> {
     biome_ids: [u32; 16],
     /// Reused so identifying a palette entry does not allocate per section.
     state_key: String,
+    /// Per-chunk `section_y - from` to index into `sections`, `u32::MAX` for a gap.
+    /// Keeps the per-section lookup O(1) when a tall span meets a filled column.
+    section_at: Vec<u32>,
     scratch: SectionScratch,
     serialized: Vec<u8>,
     /// One compression context for the whole region; building a fresh one per
@@ -268,6 +271,7 @@ impl<'a> RegionLod<'a> {
             palette_ids: Vec::new(),
             biome_ids: [0; 16],
             state_key: String::new(),
+            section_at: Vec::new(),
             scratch: SectionScratch::default(),
             serialized: Vec::with_capacity(MAX_SERIALIZED),
             compressor: zstd::bulk::Compressor::new(super::ZSTD_LEVEL)
@@ -280,12 +284,13 @@ impl<'a> RegionLod<'a> {
 
     /// Feeds one finished chunk.
     ///
-    /// `span` is the range of sections the chunk is written with and `lighting`
-    /// is indexed from its start, exactly as
-    /// [`crate::world_editor::java`] hands them to the NBT builder. Sections in
-    /// the span that `sections` does not carry are air in the chunk file too,
-    /// and are ingested as air: they still hold sky light, which is what lights
-    /// whatever LOD geometry sits underneath them.
+    /// `span` is the outer range [`crate::world_editor::java`] lights the chunk
+    /// over and `lighting` is indexed from its start. Sections in the span that
+    /// `sections` does not carry are air in the chunk file too (the writer
+    /// leaves the empty ones outside the vanilla range out of the NBT entirely,
+    /// and Minecraft fills them back in as air), and are ingested as air here:
+    /// they still hold sky light, which is what lights whatever LOD geometry
+    /// sits underneath them.
     pub(crate) fn ingest_chunk(
         &mut self,
         chunk_x: i32,
@@ -303,6 +308,19 @@ impl<'a> RegionLod<'a> {
         let from = span_min.max(self.min_section_y);
         let to = span_max.min(self.max_section_y);
 
+        // `sections` is keyed by Y and unsorted, and a filled column under the tall
+        // datapack carries one entry per span section, so scanning it per section is
+        // quadratic. Index it once instead.
+        let mut section_at = std::mem::take(&mut self.section_at);
+        section_at.clear();
+        section_at.resize((to - from + 1).max(0) as usize, u32::MAX);
+        for (i, s) in sections.iter().enumerate() {
+            let y = s.y as i32;
+            if (from..=to).contains(&y) {
+                section_at[(y - from) as usize] = i as u32;
+            }
+        }
+
         for section_y in from..=to {
             let light = lighting.and_then(|l| {
                 usize::try_from(section_y - span_min)
@@ -311,19 +329,20 @@ impl<'a> RegionLod<'a> {
             });
             // Nothing this chunk section touches can end up on disk: skip it
             // before decoding a palette or composing a single voxel. Above the
-            // roofline this is almost every section in the chunk.
-            if !(0..=MAX_LOD)
-                .rev()
-                .any(|lvl| self.is_live(lvl, chunk_x, section_y, chunk_z))
-            {
+            // roofline this is almost every section in the chunk. A section live
+            // at any level is live at `MAX_LOD` too (`mark_live` marks every
+            // level from the same chunk section, and equal coordinates at one
+            // shift stay equal at a wider one), so one probe answers all five.
+            if !self.is_live(MAX_LOD, chunk_x, section_y, chunk_z) {
                 continue;
             }
 
-            // A chunk holds at most a couple of dozen sections, so a scan beats
-            // building a map per chunk.
-            let section = sections.iter().find(|s| s.y as i32 == section_y);
+            let slot = section_at[(section_y - from) as usize];
+            let section = (slot != u32::MAX).then(|| &sections[slot as usize]);
             self.ingest_section(chunk_x, section_y, chunk_z, section, light);
         }
+
+        self.section_at = section_at;
     }
 
     /// Called after the four chunks of Morton column `column` have been fed.

--- a/src/water_depth.rs
+++ b/src/water_depth.rs
@@ -24,6 +24,9 @@ const MAX_WATER_DEPTH: i32 = 6;
 /// Cap on water sub-rect cells (bounds memory, keeps u32 indices valid); ~1000 km².
 const MAX_WATER_FIELD_CELLS: usize = 1_000_000_000;
 
+/// Frontier capacity carried between components; a bigger one gives its buffer back.
+const FRONTIER_KEEP: usize = 1 << 16;
+
 #[inline]
 fn nibble_get(buf: &[u8], i: usize) -> u8 {
     let byte = buf[i >> 1];
@@ -53,6 +56,24 @@ fn bit_get(b: &[u64], i: usize) -> bool {
 #[inline]
 fn bit_set(b: &mut [u64], i: usize) {
     b[i >> 6] |= 1u64 << (i & 63);
+}
+
+#[inline]
+fn for_each_neighbor(idx: usize, w: usize, h: usize, mut f: impl FnMut(usize)) {
+    let i = idx % w;
+    let j = idx / w;
+    if i > 0 {
+        f(idx - 1);
+    }
+    if i + 1 < w {
+        f(idx + 1);
+    }
+    if j > 0 {
+        f(idx - w);
+    }
+    if j + 1 < h {
+        f(idx + w);
+    }
 }
 
 /// Baked per-cell carve depth (0..=6), nibble-packed over the water sub-rect.
@@ -169,52 +190,58 @@ pub fn compute_big_water_field(ground: &Ground, xzbbox: &XZBBox) -> BigWaterFiel
     }
     chamfer_3_4_dt(&mut dt, sw, sh);
 
-    // Per-component BFS for the max DT, then bake each cell's depth.
+    // Per-component BFS for the max DT, then a second walk bakes each cell's depth.
+    // Levels are held in swapped frontiers, so residency is the perimeter, not the body.
     let mut depth = vec![0u8; total.div_ceil(2)];
     let mut visited = vec![0u64; total.div_ceil(64)];
-    let mut comp: Vec<u32> = Vec::new();
+    let mut baked = vec![0u64; total.div_ceil(64)];
+    let mut cur: Vec<u32> = Vec::new();
+    let mut next: Vec<u32> = Vec::new();
     for start in 0..total {
         if dt[start] == 0 || bit_get(&visited, start) {
             continue;
         }
-        comp.clear();
-        comp.push(start as u32);
-        bit_set(&mut visited, start);
         let mut comp_max = 0u8;
-        let mut head = 0;
-        while head < comp.len() {
-            let idx = comp[head] as usize;
-            head += 1;
-            comp_max = comp_max.max(dt[idx]);
-            let i = idx % sw;
-            let j = idx / sw;
-            let mut visit = |n: usize, comp: &mut Vec<u32>| {
-                if dt[n] != 0 && !bit_get(&visited, n) {
-                    bit_set(&mut visited, n);
-                    comp.push(n as u32);
-                }
-            };
-            if i > 0 {
-                visit(idx - 1, &mut comp);
+        bit_set(&mut visited, start);
+        cur.clear();
+        cur.push(start as u32);
+        while !cur.is_empty() {
+            next.clear();
+            for &c in &cur {
+                let idx = c as usize;
+                comp_max = comp_max.max(dt[idx]);
+                for_each_neighbor(idx, sw, sh, |n| {
+                    if dt[n] != 0 && !bit_get(&visited, n) {
+                        bit_set(&mut visited, n);
+                        next.push(n as u32);
+                    }
+                });
             }
-            if i + 1 < sw {
-                visit(idx + 1, &mut comp);
-            }
-            if j > 0 {
-                visit(idx - sw, &mut comp);
-            }
-            if j + 1 < sh {
-                visit(idx + sw, &mut comp);
-            }
+            std::mem::swap(&mut cur, &mut next);
         }
+
         let cm = u16::from(comp_max);
-        for &c in &comp {
-            let idx = c as usize;
-            let x = smin_x + (idx % sw) as i32;
-            let z = smin_z + (idx / sw) as i32;
-            let d = ocean_depth_for_cell(x, z, u16::from(dt[idx]), cm);
-            nibble_set(&mut depth, idx, d as u8);
+        bit_set(&mut baked, start);
+        cur.push(start as u32);
+        while !cur.is_empty() {
+            next.clear();
+            for &c in &cur {
+                let idx = c as usize;
+                let x = smin_x + (idx % sw) as i32;
+                let z = smin_z + (idx / sw) as i32;
+                let d = ocean_depth_for_cell(x, z, u16::from(dt[idx]), cm);
+                nibble_set(&mut depth, idx, d as u8);
+                for_each_neighbor(idx, sw, sh, |n| {
+                    if dt[n] != 0 && !bit_get(&baked, n) {
+                        bit_set(&mut baked, n);
+                        next.push(n as u32);
+                    }
+                });
+            }
+            std::mem::swap(&mut cur, &mut next);
         }
+        cur.shrink_to(FRONTIER_KEEP);
+        next.shrink_to(FRONTIER_KEEP);
     }
 
     BigWaterField {
@@ -882,6 +909,200 @@ mod tests {
         }
         for (i, v) in [0u8, 6, 3, 1, 5, 2, 4, 0].iter().enumerate() {
             assert_eq!(nibble_get(&buf, i), *v);
+        }
+    }
+}
+
+#[cfg(test)]
+mod water_field_traversal_tests {
+    use super::*;
+    use crate::ground::test_support::ground_with_land_cover_and_elevation;
+    use crate::land_cover::LandCoverData;
+
+    const SIDE: usize = 48;
+
+    fn ground_from(grid: Vec<Vec<u8>>) -> Ground {
+        let (w, h) = (grid[0].len(), grid.len());
+        let lc = LandCoverData {
+            grid,
+            water_distance: vec![vec![0u8; w]; h],
+            water_blend_cache: once_cell::sync::OnceCell::new(),
+            width: w,
+            height: h,
+            cells_per_meter: 1.0,
+        };
+        ground_with_land_cover_and_elevation(lc, w, h)
+    }
+
+    fn water_grid(cells: impl Fn(usize, usize) -> bool) -> Vec<Vec<u8>> {
+        (0..SIDE)
+            .map(|z| {
+                (0..SIDE)
+                    .map(|x| if cells(x, z) { LC_WATER } else { 10 })
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// Reference traversal: one growing index list per component, walked with a head
+    /// pointer, with the depths baked once the whole component has been collected.
+    fn single_pass_reference(
+        ground: &Ground,
+        xzbbox: &XZBBox,
+    ) -> (Vec<u8>, usize, usize, i32, i32) {
+        let (min_x, max_x) = (xzbbox.min_x(), xzbbox.max_x());
+        let (min_z, max_z) = (xzbbox.min_z(), xzbbox.max_z());
+        let (wmin_x, wmin_z, wmax_x, wmax_z) = match ground.lc_water_block_bounds() {
+            Some((lx, lz, hx, hz)) => (min_x + lx, min_z + lz, min_x + hx, min_z + hz),
+            None => return (Vec::new(), 0, 0, 0, 0),
+        };
+        let smin_x = (wmin_x - 1).max(min_x);
+        let smax_x = (wmax_x + 1).min(max_x);
+        let smin_z = (wmin_z - 1).max(min_z);
+        let smax_z = (wmax_z + 1).min(max_z);
+        let sw = (smax_x - smin_x + 1) as usize;
+        let sh = (smax_z - smin_z + 1) as usize;
+        let total = sw * sh;
+
+        let mut dt = vec![0u8; total];
+        for z in smin_z..=smax_z {
+            let row = (z - smin_z) as usize * sw;
+            for x in smin_x..=smax_x {
+                if ground.cover_class(XZPoint::new(x - min_x, z - min_z)) == LC_WATER {
+                    dt[row + (x - smin_x) as usize] = DT_MAX;
+                }
+            }
+        }
+        chamfer_3_4_dt(&mut dt, sw, sh);
+
+        let mut depth = vec![0u8; total.div_ceil(2)];
+        let mut visited = vec![0u64; total.div_ceil(64)];
+        let mut comp: Vec<u32> = Vec::new();
+        for start in 0..total {
+            if dt[start] == 0 || bit_get(&visited, start) {
+                continue;
+            }
+            comp.clear();
+            comp.push(start as u32);
+            bit_set(&mut visited, start);
+            let mut comp_max = 0u8;
+            let mut head = 0;
+            while head < comp.len() {
+                let idx = comp[head] as usize;
+                head += 1;
+                comp_max = comp_max.max(dt[idx]);
+                let i = idx % sw;
+                let j = idx / sw;
+                let mut visit = |n: usize, comp: &mut Vec<u32>| {
+                    if dt[n] != 0 && !bit_get(&visited, n) {
+                        bit_set(&mut visited, n);
+                        comp.push(n as u32);
+                    }
+                };
+                if i > 0 {
+                    visit(idx - 1, &mut comp);
+                }
+                if i + 1 < sw {
+                    visit(idx + 1, &mut comp);
+                }
+                if j > 0 {
+                    visit(idx - sw, &mut comp);
+                }
+                if j + 1 < sh {
+                    visit(idx + sw, &mut comp);
+                }
+            }
+            let cm = u16::from(comp_max);
+            for &c in &comp {
+                let idx = c as usize;
+                let x = smin_x + (idx % sw) as i32;
+                let z = smin_z + (idx / sw) as i32;
+                let d = ocean_depth_for_cell(x, z, u16::from(dt[idx]), cm);
+                nibble_set(&mut depth, idx, d as u8);
+            }
+        }
+        (depth, sw, sh, smin_x, smin_z)
+    }
+
+    fn assert_matches_reference(label: &str, grid: Vec<Vec<u8>>) -> BigWaterField {
+        let bbox = XZBBox::rect_from_min_max(0, 0, SIDE as i32 - 1, SIDE as i32 - 1).unwrap();
+        let ground = ground_from(grid);
+        let field = compute_big_water_field(&ground, &bbox);
+        let (depth, sw, sh, smin_x, smin_z) = single_pass_reference(&ground, &bbox);
+        assert_eq!((field.width, field.height), (sw, sh), "{label}: sub-rect");
+        assert_eq!(
+            (field.min_x, field.min_z),
+            (smin_x, smin_z),
+            "{label}: origin"
+        );
+        assert_eq!(field.depth, depth, "{label}: baked depths differ");
+        assert!(
+            depth.iter().any(|&b| b != 0),
+            "{label}: no depth was carved, the comparison is vacuous"
+        );
+        field
+    }
+
+    #[test]
+    fn frontier_walk_bakes_the_same_depths_as_the_single_pass_walk() {
+        assert_matches_reference(
+            "one open lake",
+            water_grid(|x, z| (8..40).contains(&x) && (8..40).contains(&z)),
+        );
+
+        assert_matches_reference(
+            "two components of different size",
+            water_grid(|x, z| {
+                ((2..22).contains(&x) && (2..22).contains(&z))
+                    || ((30..44).contains(&x) && (30..44).contains(&z))
+            }),
+        );
+
+        // Diagonal-only contact: 4-connectivity must keep these two components apart,
+        // so each keeps its own comp_max and its own depth tier.
+        assert_matches_reference(
+            "diagonally touching bodies",
+            water_grid(|x, z| {
+                ((2..24).contains(&x) && (2..24).contains(&z))
+                    || ((24..46).contains(&x) && (24..46).contains(&z))
+            }),
+        );
+
+        // A ring around an island, plus a corridor: the re-walk has to reach every cell
+        // through a shape where a level frontier and a head-pointer queue diverge in order.
+        assert_matches_reference(
+            "ring with an island and a corridor",
+            water_grid(|x, z| {
+                let ring = (4..36).contains(&x)
+                    && (4..36).contains(&z)
+                    && !((14..26).contains(&x) && (14..26).contains(&z));
+                let corridor = (36..46).contains(&x) && (18..22).contains(&z);
+                ring || corridor
+            }),
+        );
+    }
+
+    #[test]
+    fn a_second_body_does_not_change_the_first_ones_depths() {
+        let lone = assert_matches_reference(
+            "lone lake",
+            water_grid(|x, z| (2..22).contains(&x) && (2..22).contains(&z)),
+        );
+        let paired = assert_matches_reference(
+            "same lake beside a larger one",
+            water_grid(|x, z| {
+                ((2..22).contains(&x) && (2..22).contains(&z))
+                    || ((26..46).contains(&x) && (26..46).contains(&z))
+            }),
+        );
+        for z in 2..22 {
+            for x in 2..22 {
+                assert_eq!(
+                    lone.depth_at(x, z),
+                    paired.depth_at(x, z),
+                    "cell ({x},{z}) changed when an unrelated component was added"
+                );
+            }
         }
     }
 }

--- a/src/world_editor/common.rs
+++ b/src/world_editor/common.rs
@@ -14,8 +14,7 @@ pub const DEFAULT_MIN_Y: i32 = -64;
 /// this, an extended floor would make every bedrock/fill/ore column ~4000 blocks deep.
 pub const TERRAIN_FLOOR_DEPTH: i32 = 64;
 
-/// Default (vanilla 1.18+) world ceiling. Distinct from `MAX_Y`, which is the highest Y the
-/// editor will store; this is the top of the dimension the engine is actually told about.
+/// Default (vanilla 1.18+) world ceiling; the editor stores nothing above `world_max_y()`.
 pub const DEFAULT_MAX_Y: i32 = 319;
 
 static WORLD_MIN_Y: AtomicI32 = AtomicI32::new(DEFAULT_MIN_Y);
@@ -120,6 +119,19 @@ pub fn base_chunk_y() -> i32 {
     BASE_CHUNK_Y.load(MemOrdering::Relaxed)
 }
 
+static TERRAIN_TOP_Y: AtomicI32 = AtomicI32::new(DEFAULT_GROUND_LEVEL);
+
+/// Highest Y the elevation scaler placed terrain at. Consumers that need the band the terrain
+/// actually fills read this rather than the dimension ceiling, which the relief rarely reaches.
+pub fn set_terrain_top_y(y: i32) {
+    TERRAIN_TOP_Y.store(y, MemOrdering::Relaxed);
+}
+
+#[inline]
+pub fn terrain_top_y() -> i32 {
+    TERRAIN_TOP_Y.load(MemOrdering::Relaxed)
+}
+
 static BASE_CHUNK_BLOCK: AtomicU16 = AtomicU16::new(crate::block_definitions::GRASS_BLOCK.id());
 
 /// Surface block for those filler chunks; grass would ring a lunar world in green.
@@ -131,11 +143,7 @@ pub fn set_base_chunk_block(block: crate::block_definitions::Block) {
 pub fn base_chunk_block() -> crate::block_definitions::Block {
     crate::block_definitions::Block::from_raw_id(BASE_CHUNK_BLOCK.load(MemOrdering::Relaxed))
 }
-/// Maximum Y coordinate in Minecraft (data pack maximum: 2031)
-/// Vanilla limit is 319, but data packs can extend this up to 2031.
-/// The world editor supports the full range; the elevation system controls
-/// the actual heights used based on the disable_height_limit setting.
-const MAX_Y: i32 = 2031;
+
 use fastnbt::{LongArray, Value};
 use fnv::{FnvHashMap, FnvHashSet};
 use serde::{Deserialize, Serialize};
@@ -1146,8 +1154,11 @@ pub(crate) struct ChunkToModify {
 impl ChunkToModify {
     #[inline]
     pub fn get_block(&self, x: u8, y: i32, z: u8) -> Option<Block> {
-        // Clamp Y to valid Minecraft range to prevent TryFromIntError
-        let y = y.clamp(min_y(), MAX_Y);
+        // Above the ceiling nothing was ever stored, and the section index would truncate.
+        if y > world_max_y() {
+            return None;
+        }
+        let y = y.max(min_y());
         let section_idx: i8 = (y >> 4) as i8;
         let section = self.sections.get(&section_idx)?;
         section.get_block(x, (y & 15) as u8, z)
@@ -1155,8 +1166,12 @@ impl ChunkToModify {
 
     #[inline]
     pub fn set_block(&mut self, x: u8, y: i32, z: u8, block: Block) {
-        // Clamp Y to valid Minecraft range to prevent TryFromIntError
-        let y = y.clamp(min_y(), MAX_Y);
+        // Drop, never clamp: clamping would smear a slab across the ceiling under every
+        // overflowing structure. Below the floor still clamps, as the bedrock plane does.
+        if y > world_max_y() {
+            return;
+        }
+        let y = y.max(min_y());
         let section_idx: i8 = (y >> 4) as i8;
         let section = self.sections.entry(section_idx).or_default();
         section.set_block(x, (y & 15) as u8, z, block);
@@ -1170,8 +1185,10 @@ impl ChunkToModify {
         z: u8,
         block_with_props: BlockWithProperties,
     ) {
-        // Clamp Y to valid Minecraft range to prevent TryFromIntError
-        let y = y.clamp(min_y(), MAX_Y);
+        if y > world_max_y() {
+            return;
+        }
+        let y = y.max(min_y());
         let section_idx: i8 = (y >> 4) as i8;
         let section = self.sections.entry(section_idx).or_default();
         section.set_block_with_properties(x, (y & 15) as u8, z, block_with_props);
@@ -1295,7 +1312,7 @@ impl WorldToModify {
         // a fully out-of-world range onto a boundary block and report a hit the
         // caller never asked for.
         let min_y = min_y.max(crate::world_editor::min_y());
-        let max_y = max_y.min(MAX_Y);
+        let max_y = max_y.min(world_max_y());
         if min_y > max_y {
             return None;
         }
@@ -1382,7 +1399,10 @@ impl WorldToModify {
             .entry((chunk_x & 31, chunk_z & 31))
             .or_default();
 
-        let y = y.clamp(min_y(), MAX_Y);
+        if y > world_max_y() {
+            return;
+        }
+        let y = y.max(min_y());
         let section_idx: i8 = (y >> 4) as i8;
         let section = chunk.sections.entry(section_idx).or_default();
 
@@ -1427,8 +1447,12 @@ impl WorldToModify {
         let local_x = (x & 15) as u8;
         let local_z = (z & 15) as u8;
 
-        let y_min = y_min.clamp(min_y(), MAX_Y);
-        let y_max = y_max.clamp(min_y(), MAX_Y);
+        // A range entirely above the ceiling must vanish, not collapse into a slab on it.
+        if y_min > world_max_y() {
+            return;
+        }
+        let y_min = y_min.clamp(min_y(), world_max_y());
+        let y_max = y_max.clamp(min_y(), world_max_y());
 
         for y in y_min..=y_max {
             let section_idx: i8 = (y >> 4) as i8;
@@ -2556,15 +2580,15 @@ mod tests {
 
     #[test]
     fn highest_block_between_rejects_ranges_outside_the_world() {
-        // The clamp reads the world floor, so hold it at the default for the assertions.
+        // The intersection reads the world bounds, so hold them at the default.
         let _g = FLOOR_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let mut world = WorldToModify::default();
         world.set_block_if_absent(3, DEFAULT_MIN_Y, 5, STONE);
-        world.set_block_if_absent(3, MAX_Y, 5, COBBLESTONE);
+        world.set_block_if_absent(3, DEFAULT_MAX_Y, 5, COBBLESTONE);
 
         // Wholly outside the world: no Y in the requested range can answer.
         assert_eq!(
-            world.highest_block_between(3, 5, MAX_Y + 1, MAX_Y + 50),
+            world.highest_block_between(3, 5, DEFAULT_MAX_Y + 1, DEFAULT_MAX_Y + 50),
             None
         );
         assert_eq!(
@@ -2579,9 +2603,117 @@ mod tests {
             Some(DEFAULT_MIN_Y)
         );
         assert_eq!(
-            world.highest_block_between(3, 5, MAX_Y, MAX_Y + 50),
-            Some(MAX_Y)
+            world.highest_block_between(3, 5, DEFAULT_MAX_Y, DEFAULT_MAX_Y + 50),
+            Some(DEFAULT_MAX_Y)
         );
+    }
+
+    #[test]
+    fn writes_above_the_ceiling_are_dropped_not_clamped_onto_it() {
+        let _g = FLOOR_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+        let mut vanilla = ChunkToModify::default();
+        vanilla.set_block(0, DEFAULT_MAX_Y + 1, 0, STONE);
+        vanilla.set_block(1, 2031, 1, COBBLESTONE);
+        assert_eq!(vanilla.sections().count(), 0);
+
+        set_world_bounds(-2032, 2031);
+        let mut tall = ChunkToModify::default();
+        tall.set_block(0, 2031, 0, STONE);
+        tall.set_block(1, 2032, 1, COBBLESTONE);
+        assert_eq!(tall.get_block(0, 2031, 0), Some(STONE));
+        assert_eq!(tall.get_block(1, 2031, 1), None);
+        assert_eq!(tall.sections().count(), 1);
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+    }
+
+    #[test]
+    fn writes_below_the_floor_still_clamp_onto_it() {
+        let _g = FLOOR_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        for (floor, ceiling) in [(DEFAULT_MIN_Y, DEFAULT_MAX_Y), (-2032, 2031)] {
+            set_world_bounds(floor, ceiling);
+            let mut chunk = ChunkToModify::default();
+            chunk.set_block(0, floor - 40, 0, STONE);
+            assert_eq!(chunk.get_block(0, floor, 0), Some(STONE));
+
+            let mut world = WorldToModify::default();
+            world.set_block_if_absent(3, floor - 40, 5, STONE);
+            assert_eq!(world.get_block(3, floor, 5), Some(STONE));
+        }
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+    }
+
+    #[test]
+    fn reads_above_the_ceiling_report_nothing_instead_of_the_top_block() {
+        let _g = FLOOR_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        set_world_bounds(-2032, 2031);
+        let mut tall = ChunkToModify::default();
+        tall.set_block(2, 2031, 2, STONE);
+        assert_eq!(tall.get_block(2, 2031, 2), Some(STONE));
+        assert_eq!(tall.get_block(2, 2032, 2), None);
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+        let mut vanilla = ChunkToModify::default();
+        vanilla.set_block(2, DEFAULT_MAX_Y, 2, STONE);
+        assert_eq!(vanilla.get_block(2, DEFAULT_MAX_Y, 2), Some(STONE));
+        assert_eq!(vanilla.get_block(2, DEFAULT_MAX_Y + 1, 2), None);
+    }
+
+    #[test]
+    fn the_bedrock_extended_ceiling_keeps_writes_above_the_vanilla_top() {
+        let _g = FLOOR_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        // Bedrock's behavior pack declares -512..512, so the editor ceiling is the section
+        // ending under it and the scaler puts terrain as high as Y 497.
+        set_world_bounds(DEFAULT_MIN_Y, 511);
+        let mut chunk = ChunkToModify::default();
+        chunk.set_block(4, 400, 6, STONE);
+        assert_eq!(chunk.get_block(4, 400, 6), Some(STONE));
+
+        let mut world = WorldToModify::default();
+        world.set_block_if_absent(4, 400, 6, STONE);
+        world.fill_column(4, 6, 480, 497, STONE, false);
+        assert_eq!(world.get_block(4, 400, 6), Some(STONE));
+        assert_eq!(
+            world.highest_block_between(4, 6, DEFAULT_MIN_Y, 511),
+            Some(497)
+        );
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+    }
+
+    #[test]
+    fn a_fill_reaching_past_the_ceiling_is_truncated_not_collapsed() {
+        let _g = FLOOR_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+        let mut world = WorldToModify::default();
+        world.fill_column(3, 5, DEFAULT_MAX_Y + 10, DEFAULT_MAX_Y + 40, STONE, false);
+        assert_eq!(
+            world.highest_block_between(3, 5, DEFAULT_MIN_Y, DEFAULT_MAX_Y + 2000),
+            None
+        );
+        world.fill_column(3, 5, DEFAULT_MAX_Y - 2, DEFAULT_MAX_Y + 40, STONE, false);
+        assert_eq!(
+            world.highest_block_between(3, 5, DEFAULT_MIN_Y, DEFAULT_MAX_Y),
+            Some(DEFAULT_MAX_Y)
+        );
+        assert_eq!(world.get_block(3, DEFAULT_MAX_Y - 2, 5), Some(STONE));
+
+        set_world_bounds(-2032, 2031);
+        let mut tall = WorldToModify::default();
+        tall.fill_column(7, 9, 2040, 2050, STONE, false);
+        assert_eq!(tall.highest_block_between(7, 9, -2032, 2031), None);
+        tall.fill_column(7, 9, 2028, 2050, STONE, false);
+        assert_eq!(tall.highest_block_between(7, 9, -2032, 2031), Some(2031));
+        assert_eq!(tall.get_block(7, 2028, 9), Some(STONE));
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
     }
 }
 

--- a/src/world_editor/java.rs
+++ b/src/world_editor/java.rs
@@ -241,7 +241,7 @@ fn write_region_to_disk(
     let base_sections = get_base_chunk_sections();
     let (base_min_y, base_max_y) = chunk_section_span(&base_sections);
     let base_lighting =
-        bake_lighting.then(|| compute_lighting(&base_sections, base_min_y, base_max_y));
+        bake_lighting.then(|| compute_chunk_lighting(&base_sections, (base_min_y, base_max_y)));
 
     let mut lod = voxy.map(|writer| {
         let (min_y, max_y) = region_content_span(region_to_modify);
@@ -277,7 +277,7 @@ fn write_region_to_disk(
                         let sections: Vec<Section> = chunk_to_modify.sections().collect();
                         let span = chunk_section_span(&sections);
                         let lighting =
-                            bake_lighting.then(|| compute_lighting(&sections, span.0, span.1));
+                            bake_lighting.then(|| compute_chunk_lighting(&sections, span));
                         (
                             sections,
                             strip_orphan_block_entities(chunk_to_modify),
@@ -737,18 +737,26 @@ fn pack_light_nibble(arr: &mut [i8], index: usize, value: u8) {
     arr[byte] = new as i8;
 }
 
+/// Sky and block light for a run of sections, as 2048-byte nibble arrays per section.
+type SectionLight = Vec<(Vec<i8>, Vec<i8>)>;
+
 // Sky + block light per section as 2048-byte nibble arrays.
+//
+// `sky_above` is the skylight entering the top of the range: 15 under open sky, or the level
+// leaving the bottom of the range above. Also returns the level leaving this range's bottom,
+// or None when that plane is mixed and a caller stacking ranges cannot carry a single value.
 fn compute_lighting(
     sections: &[Section],
     min_section_y: i8,
     max_section_y: i8,
-) -> Vec<(Vec<i8>, Vec<i8>)> {
+    sky_above: u8,
+) -> (SectionLight, Option<u8>) {
     use std::collections::VecDeque;
 
     let num_sections = (max_section_y as i32 - min_section_y as i32 + 1).max(0) as usize;
     let height = num_sections * 16;
     if height == 0 {
-        return Vec::new();
+        return (Vec::new(), Some(sky_above));
     }
     let idx = |x: usize, y: usize, z: usize| y * 256 + z * 16 + x;
 
@@ -783,11 +791,11 @@ fn compute_lighting(
     // SkyLight: open sky above the highest non-transparent block is 15; flood-fill the band below.
     let top = if any_solid { (htop + 2).min(height) } else { 0 };
     let mut sky = vec![0u8; height * 256];
-    sky[top * 256..].fill(15);
+    sky[top * 256..].fill(sky_above);
     let mut sq: VecDeque<(usize, usize, usize, u8)> = VecDeque::new();
     for z in 0..16usize {
         for x in 0..16usize {
-            let mut level = 15u8;
+            let mut level = sky_above;
             for y in (0..top).rev() {
                 let g = idx(x, y, z);
                 if opacity[g] >= 15 {
@@ -834,6 +842,61 @@ fn compute_lighting(
         }
         out.push((sl, bl));
     }
+
+    let first = sky[0];
+    let sky_below = sky[..256].iter().all(|&v| v == first).then_some(first);
+    (out, sky_below)
+}
+
+/// Light for the sections a chunk actually writes, indexed by `y - span.0` so callers keep
+/// using span offsets. Computed one contiguous run at a time, top down: the working grids then
+/// cover a run's height instead of the whole span, which under the tall datapack is ~180
+/// sections of mostly air between the bedrock plane and the surface.
+///
+/// The skipped gaps are air, so the skylight leaving a run passes through unchanged and seeds
+/// the run below, and block light cannot cross their 16-plus blocks. A gap plane that is not
+/// uniform cannot be carried that way, so those chunks fall back to one full-span pass.
+fn compute_chunk_lighting(sections: &[Section], span: (i8, i8)) -> SectionLight {
+    let (min_section_y, max_section_y) = span;
+    let len = (max_section_y as i32 - min_section_y as i32 + 1).max(0) as usize;
+    let mut out: SectionLight = vec![(Vec::new(), Vec::new()); len];
+
+    let ys = emitted_section_ys(sections, span);
+    let mut runs: Vec<(i8, i8)> = Vec::new();
+    for &y in &ys {
+        match runs.last_mut() {
+            Some(run) if run.1 as i32 + 1 == y as i32 => run.1 = y,
+            _ => runs.push((y, y)),
+        }
+    }
+
+    let mut sky_above = 15u8;
+    let mut gap_top: Option<i8> = None;
+    for &(lo, hi) in runs.iter().rev() {
+        // `compute_lighting` only reads sections inside the range it is given, so the full
+        // slice can be passed without copying the run out of it.
+        let (light, sky_below) = compute_lighting(sections, lo, hi, sky_above);
+        let base = (lo as i32 - min_section_y as i32) as usize;
+        for (k, section_light) in light.into_iter().enumerate() {
+            out[base + k] = section_light;
+        }
+        let Some(sky_below) = sky_below else {
+            return compute_lighting(sections, min_section_y, max_section_y, 15).0;
+        };
+        // A lit gap only happens in a chunk with no terrain over it, so paying for the two
+        // constant arrays there keeps the LOD exact without costing the common case anything.
+        if sky_above > 0 {
+            if let Some(top) = gap_top {
+                let packed = ((sky_above << 4) | sky_above) as i8;
+                for y in hi as i32 + 1..=top as i32 {
+                    let at = (y - min_section_y as i32) as usize;
+                    out[at] = (vec![packed; 2048], vec![0i8; 2048]);
+                }
+            }
+        }
+        sky_above = sky_below;
+        gap_top = Some(lo - 1);
+    }
     out
 }
 
@@ -864,19 +927,26 @@ fn get_structures_value() -> &'static Value {
     })
 }
 
-/// Creates modern chunk NBT data (post-1.18 format, no Level wrapper).
-///
-/// Writes all required fields for server compatibility:
-/// DataVersion, Status, yPos, Heightmaps, biomes, structures, etc.
-/// Section range is determined dynamically: at minimum the vanilla range
-/// (Y=-4 to Y=19), extended upward/downward to cover any sections with content.
-/// Emitted section range: the vanilla span, expanded to cover content. Deliberately NOT
-/// the whole dimension — under the tall datapack that would be 254 sections per chunk
-/// instead of ~24. Minecraft slots each section by its own `Y` and fills the gaps with air,
-/// so a sparse list is fine.
+/// Vanilla build range, in section coordinates (Y=-64 to Y=319).
+const VANILLA_MIN_SECTION_Y: i8 = -4;
+const VANILLA_MAX_SECTION_Y: i8 = 19;
+
+/// Section Ys a chunk writes: the vanilla span, plus any section outside it holding content.
+/// Lighting and the emitted NBT list both come from here so the two cannot drift apart.
+fn emitted_section_ys(sections: &[Section], span: (i8, i8)) -> Vec<i8> {
+    let content: std::collections::HashSet<i8> = sections.iter().map(|s| s.y).collect();
+    (span.0..=span.1)
+        .filter(|y| {
+            (VANILLA_MIN_SECTION_Y..=VANILLA_MAX_SECTION_Y).contains(y) || content.contains(y)
+        })
+        .collect()
+}
+
+/// Outer bounds of a chunk: the vanilla span, widened to reach any section with content.
+/// The sections actually written are a sparse subset of it, see `emitted_section_ys`.
 pub(crate) fn chunk_section_span(sections: &[Section]) -> (i8, i8) {
-    let mut min_section_y: i8 = -4; // vanilla min (Y=-64)
-    let mut max_section_y: i8 = 19; // vanilla max (Y=319)
+    let mut min_section_y: i8 = VANILLA_MIN_SECTION_Y;
+    let mut max_section_y: i8 = VANILLA_MAX_SECTION_Y;
     for section in sections {
         if section.y < min_section_y {
             min_section_y = section.y;
@@ -898,8 +968,8 @@ fn create_chunk_nbt(
     biome_value: &Value,
 ) -> HashMap<String, Value> {
     let (min_section_y, max_section_y) = chunk_section_span(&chunk.sections);
-    let lighting =
-        bake_lighting.then(|| compute_lighting(&chunk.sections, min_section_y, max_section_y));
+    let lighting = bake_lighting
+        .then(|| compute_chunk_lighting(&chunk.sections, (min_section_y, max_section_y)));
     create_chunk_nbt_with_lighting(chunk, lighting, biome_value)
 }
 
@@ -908,7 +978,7 @@ fn create_chunk_nbt(
 /// region loop computes it once and hands it to both.
 fn create_chunk_nbt_with_lighting(
     chunk: &Chunk,
-    lighting: Option<Vec<(Vec<i8>, Vec<i8>)>>,
+    lighting: Option<SectionLight>,
     biome_value: &Value,
 ) -> HashMap<String, Value> {
     // Index existing sections by Y for quick lookup
@@ -934,10 +1004,13 @@ fn create_chunk_nbt_with_lighting(
     let bake_lighting = lighting.is_some();
     let mut lighting = lighting.unwrap_or_default();
 
-    // Build all sections in the determined range
-    let sections: Vec<Value> = (min_section_y..=max_section_y)
-        .enumerate()
-        .map(|(off, y)| {
+    // Sparse section list: the vanilla span plus whatever content sits outside it. Empty gaps
+    // beyond the vanilla span are left out entirely; Minecraft slots each section by its own
+    // `Y` and treats the missing ones as air. Under the tall datapack a chunk otherwise emits
+    // ~180 sections, nearly all of them synthesized air, instead of the usual 24.
+    let sections: Vec<Value> = emitted_section_ys(&chunk.sections, (min_section_y, max_section_y))
+        .into_iter()
+        .map(|y| {
             let mut section_nbt = if let Some(&idx) = section_map.get(&y) {
                 build_section_value(&chunk.sections[idx])
             } else {
@@ -949,6 +1022,8 @@ fn create_chunk_nbt_with_lighting(
             };
             section_nbt.insert("biomes".to_string(), biome_value.clone());
             if bake_lighting {
+                // `lighting` covers the whole span, so index by Y, not by list position.
+                let off = (y as i32 - min_section_y as i32) as usize;
                 let (sky_light, block_light) = std::mem::take(&mut lighting[off]);
                 section_nbt.insert(
                     "SkyLight".to_string(),
@@ -1450,6 +1525,54 @@ mod dimension_bounds_tests {
         }
     }
 
+    /// A chunk with a bedrock plane far below the surface, the shape a sunk terrain base makes.
+    fn chunk_with_plane_at(depths: &[i32]) -> Chunk {
+        let mut c = ChunkToModify::default();
+        for &y in depths {
+            for x in 0..16 {
+                for z in 0..16 {
+                    c.set_block(x, y, z, STONE);
+                }
+            }
+        }
+        Chunk {
+            sections: c.sections().collect(),
+            x_pos: 0,
+            z_pos: 0,
+            is_light_on: 0,
+            other: FnvHashMap::default(),
+        }
+    }
+
+    #[test]
+    fn run_by_run_light_matches_one_pass_over_the_whole_span() {
+        let _g = super::super::common::FLOOR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        set_world_bounds(-2032, 2031);
+
+        // Terrain over a deep plane, a lone deep plane (nothing above it blocks the sky), a
+        // partly filled column, and the vanilla shape.
+        for depths in [
+            &[-2000, -62][..],
+            &[-2000][..],
+            &[-2000, -62, 500][..],
+            &[-62][..],
+        ] {
+            let chunk = chunk_with_plane_at(depths);
+            let span = chunk_section_span(&chunk.sections);
+            let runs = compute_chunk_lighting(&chunk.sections, span);
+            let whole = compute_lighting(&chunk.sections, span.0, span.1, 15).0;
+
+            for y in emitted_section_ys(&chunk.sections, span) {
+                let at = (y as i32 - span.0 as i32) as usize;
+                assert_eq!(runs[at], whole[at], "section {y} of {depths:?}");
+            }
+        }
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+    }
+
     #[test]
     fn heightmaps_follow_the_dimension_not_the_chunk_content() {
         let _g = super::super::common::FLOOR_TEST_LOCK
@@ -1495,6 +1618,137 @@ mod dimension_bounds_tests {
             "expected just the vanilla span, got {}",
             sections.len()
         );
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+    }
+
+    #[test]
+    fn deep_content_adds_its_own_section_without_filling_the_gap() {
+        let _g = super::super::common::FLOOR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        set_world_bounds(-2032, 2031);
+
+        let mut c = ChunkToModify::default();
+        for x in 0..16 {
+            for z in 0..16 {
+                c.set_block(x, -2000, z, STONE);
+                c.set_block(x, -62, z, STONE);
+            }
+        }
+        let chunk = Chunk {
+            sections: c.sections().collect(),
+            x_pos: 0,
+            z_pos: 0,
+            is_light_on: 0,
+            other: FnvHashMap::default(),
+        };
+
+        let nbt = create_chunk_nbt(&chunk, true, &Value::Compound(HashMap::new()));
+        let Value::List(sections) = &nbt["sections"] else {
+            panic!("chunk has no sections")
+        };
+        // Vanilla span plus the one deep section, not the 145 the span covers.
+        assert_eq!(sections.len(), 25);
+
+        let ys: Vec<i8> = sections
+            .iter()
+            .map(|s| match s {
+                Value::Compound(m) => match m["Y"] {
+                    Value::Byte(y) => y,
+                    _ => panic!("Y is not a byte"),
+                },
+                _ => panic!("section is not a compound"),
+            })
+            .collect();
+        assert_eq!(ys[0], -125);
+        assert_eq!(&ys[1..], (-4..=19).collect::<Vec<i8>>());
+
+        // Light must follow the section's own Y, not its position in the list: everything
+        // above the -62 plane is open sky, everything under it is buried. Section -4 straddles
+        // the plane, so it is the one mixed section.
+        for (y, s) in ys.iter().zip(sections).filter(|(y, _)| **y != -4) {
+            let Value::Compound(m) = s else { panic!() };
+            let Value::ByteArray(sky) = &m["SkyLight"] else {
+                panic!("no SkyLight")
+            };
+            let expect: i8 = if *y > -4 { -1 } else { 0 };
+            assert!(
+                sky.iter().all(|&v| v == expect),
+                "section {y} has the wrong skylight"
+            );
+        }
+
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+    }
+
+    fn section_ys(nbt: &HashMap<String, Value>) -> Vec<i8> {
+        let Value::List(sections) = &nbt["sections"] else {
+            panic!("chunk has no sections")
+        };
+        sections
+            .iter()
+            .map(|s| match s {
+                Value::Compound(m) => match m["Y"] {
+                    Value::Byte(y) => y,
+                    _ => panic!("Y is not a byte"),
+                },
+                _ => panic!("section is not a compound"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn vanilla_chunks_emit_exactly_the_vanilla_section_span() {
+        let _g = super::super::common::FLOOR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
+
+        let nbt = create_chunk_nbt(&shallow_chunk(), true, &Value::Compound(HashMap::new()));
+        assert_eq!(section_ys(&nbt), (-4..=19).collect::<Vec<i8>>());
+
+        let Value::List(sections) = &nbt["sections"] else {
+            panic!("chunk has no sections")
+        };
+        for (y, s) in section_ys(&nbt).iter().zip(sections).skip(1) {
+            let Value::Compound(m) = s else { panic!() };
+            let Value::ByteArray(sky) = &m["SkyLight"] else {
+                panic!("no SkyLight")
+            };
+            assert!(
+                sky.iter().all(|&v| v == -1),
+                "section {y} above the surface should be fully skylit"
+            );
+        }
+    }
+
+    #[test]
+    fn content_above_the_vanilla_ceiling_is_emitted_without_the_gap() {
+        let _g = super::super::common::FLOOR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        set_world_bounds(-2032, 2031);
+
+        let mut c = ChunkToModify::default();
+        for x in 0..16 {
+            for z in 0..16 {
+                c.set_block(x, -62, z, STONE);
+                c.set_block(x, 500, z, STONE);
+            }
+        }
+        let chunk = Chunk {
+            sections: c.sections().collect(),
+            x_pos: 0,
+            z_pos: 0,
+            is_light_on: 0,
+            other: FnvHashMap::default(),
+        };
+
+        let nbt = create_chunk_nbt(&chunk, true, &Value::Compound(HashMap::new()));
+        let mut expected: Vec<i8> = (-4..=19).collect();
+        expected.push(31);
+        assert_eq!(section_ys(&nbt), expected);
+
         set_world_bounds(DEFAULT_MIN_Y, DEFAULT_MAX_Y);
     }
 }

--- a/src/world_editor/mod.rs
+++ b/src/world_editor/mod.rs
@@ -20,8 +20,8 @@ pub(crate) use common::WorldToModify;
 pub(crate) use common::FLOOR_TEST_LOCK;
 pub use common::{
     base_chunk_block, base_chunk_y, min_y, set_base_chunk_block, set_base_chunk_y,
-    set_terrain_floor_y, set_world_bounds, terrain_floor_y, world_section_range, DEFAULT_MAX_Y,
-    DEFAULT_MIN_Y,
+    set_terrain_floor_y, set_world_bounds, terrain_floor_y, world_max_y, world_section_range,
+    DEFAULT_MAX_Y, DEFAULT_MIN_Y,
 };
 pub(crate) use common::{
     reset_section_counters, section_counters, BlockStorage, RegionToModify, SectionToModify,
@@ -2224,21 +2224,41 @@ const _: () = {
     }
 };
 
+/// Estimated resident MB of one queued region.
+///
+/// The flat figure is calibrated on a dense full-feature vanilla run (terrain + land cover +
+/// Overture + 3D). `--fillground` is the one mode whose column follows the dimension rather
+/// than the surface, so there it scales with the span the fill actually covers; a vanilla
+/// span reproduces the flat figure exactly.
+pub(crate) fn per_region_estimate_mb(fillground: bool) -> u64 {
+    const BASE_MB: u64 = 26;
+    const VANILLA_SPAN: i32 = DEFAULT_MAX_Y - DEFAULT_MIN_Y;
+    if !fillground {
+        return BASE_MB;
+    }
+    let span = (world_max_y() - terrain_floor_y()).max(VANILLA_SPAN) as u64;
+    BASE_MB * span / VANILLA_SPAN as u64
+}
+
 /// Thread count and queue depth for the flush pool. `threads` is throughput,
 /// `capacity` is RAM. One region is evicted per merged tile, so covering a whole
 /// batch without backpressure would need `capacity + threads >= tile_batch`. That is
 /// the target, not a guarantee: both are clamped and capped by the RAM budget below,
 /// so a wide batch still stalls the producer some. `flush_stall_ms` measures it.
-pub(crate) fn flush_pool_params(tile_batch: usize, available_mb: u64) -> (usize, usize) {
+pub(crate) fn flush_pool_params(
+    tile_batch: usize,
+    available_mb: u64,
+    fillground: bool,
+) -> (usize, usize) {
     let cores = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(4);
     // `capacity + threads + 1` regions are alive at once, so budget the total rather
-    // than each knob. 26 MB/region matches should_stream_to_disk; measured is ~7.
-    const PER_REGION_MB: u64 = 26;
+    // than each knob. Shared with should_stream_to_disk; measured is ~7 on a vanilla run.
+    let per_region_mb = per_region_estimate_mb(fillground);
     let budget = if available_mb > 0 {
         // A tenth of free RAM, floored so the pool always beats the old single writer.
-        ((available_mb / 10 / PER_REGION_MB) as usize).clamp(5, 15)
+        ((available_mb / 10 / per_region_mb) as usize).clamp(5, 15)
     } else {
         15
     };

--- a/src/world_utils.rs
+++ b/src/world_utils.rs
@@ -348,6 +348,62 @@ fn register_tall_datapack_in_level_dat(world_path: &Path) -> Result<(), String> 
     Ok(())
 }
 
+/// Lifts the superflat generator plane to `base_y` by prepending an air layer.
+/// Flat layers stack up from the dimension floor, so with the tall datapack's -2032 floor the
+/// terrain outside the written regions would sit up to ~2000 blocks above the generated plane.
+/// No-op when the plane already lands on `base_y` (a vanilla floor with an unlifted base) and
+/// on worlds whose overworld is not a flat generator.
+fn raise_superflat_floor(root: &mut Value, base_y: i32, min_y: i32) {
+    let air_height = base_y - min_y - 2;
+    if air_height <= 0 {
+        return;
+    }
+
+    let Value::Compound(root_map) = root else {
+        return;
+    };
+    let Some(Value::Compound(data)) = root_map.get_mut("Data") else {
+        return;
+    };
+    let Some(Value::Compound(settings)) = data.get_mut("WorldGenSettings") else {
+        return;
+    };
+    let Some(Value::Compound(dimensions)) = settings.get_mut("dimensions") else {
+        return;
+    };
+    let Some(Value::Compound(overworld)) = dimensions.get_mut("minecraft:overworld") else {
+        return;
+    };
+    let Some(Value::Compound(generator)) = overworld.get_mut("generator") else {
+        return;
+    };
+    if !matches!(generator.get("type"), Some(Value::String(t)) if t == "minecraft:flat") {
+        return;
+    }
+    let Some(Value::Compound(flat)) = generator.get_mut("settings") else {
+        return;
+    };
+    let Some(Value::List(layers)) = flat.get_mut("layers") else {
+        return;
+    };
+
+    match layers.first_mut() {
+        Some(Value::Compound(bottom)) if matches!(bottom.get("block"), Some(Value::String(b)) if b == "minecraft:air") =>
+        {
+            bottom.insert("height".to_string(), Value::Int(air_height));
+        }
+        _ => {
+            let mut air = std::collections::HashMap::new();
+            air.insert(
+                "block".to_string(),
+                Value::String("minecraft:air".to_string()),
+            );
+            air.insert("height".to_string(), Value::Int(air_height));
+            layers.insert(0, Value::Compound(air));
+        }
+    }
+}
+
 // Writes GameType, DayTime and the player's game mode into an existing level.dat.
 pub fn apply_java_world_settings(
     world_path: &Path,
@@ -385,6 +441,14 @@ pub fn apply_java_world_settings(
             player.insert("playerGameType".to_string(), Value::Int(game_type));
         }
     }
+
+    // Folded into this rewrite rather than a second read/write: both need the post-generation
+    // base, which is only known once the terrain has been scaled.
+    raise_superflat_floor(
+        &mut root,
+        crate::world_editor::base_chunk_y(),
+        crate::world_editor::min_y(),
+    );
 
     let serialized =
         fastnbt::to_bytes(&root).map_err(|e| format!("Failed to serialize level.dat: {e}"))?;
@@ -513,6 +577,107 @@ mod tests {
         if let Some(Value::Compound(player)) = data.get("Player") {
             assert_eq!(player.get("playerGameType"), Some(&Value::Int(0)));
         }
+    }
+
+    fn flat_layers(root: &Value) -> Vec<(String, i32)> {
+        let mut node = root;
+        for key in [
+            "Data",
+            "WorldGenSettings",
+            "dimensions",
+            "minecraft:overworld",
+            "generator",
+            "settings",
+            "layers",
+        ] {
+            let Value::Compound(map) = node else {
+                panic!("{key} parent not a compound");
+            };
+            node = map.get(key).unwrap_or_else(|| panic!("missing {key}"));
+        }
+        let Value::List(layers) = node else {
+            panic!("layers not a list");
+        };
+        layers
+            .iter()
+            .map(|l| {
+                let Value::Compound(l) = l else {
+                    panic!("layer not a compound");
+                };
+                match (l.get("block"), l.get("height")) {
+                    (Some(Value::String(b)), Some(Value::Int(h))) => (b.clone(), *h),
+                    _ => panic!("malformed layer"),
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn superflat_floor_follows_the_extended_world_floor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world = PathBuf::from(create_new_world(tmp.path()).unwrap());
+        let raw = fs::read(world.join("level.dat")).unwrap();
+        let mut decompressed = Vec::new();
+        GzDecoder::new(raw.as_slice())
+            .read_to_end(&mut decompressed)
+            .unwrap();
+        let mut root: Value = fastnbt::from_bytes(&decompressed).unwrap();
+        let vanilla = flat_layers(&root);
+
+        raise_superflat_floor(&mut root, -62, crate::world_editor::DEFAULT_MIN_Y);
+        assert_eq!(flat_layers(&root), vanilla);
+
+        raise_superflat_floor(&mut root, -1876, -2032);
+        let layers = flat_layers(&root);
+        assert_eq!(layers[0], ("minecraft:air".to_string(), 154));
+        assert_eq!(layers[1..], vanilla[..]);
+        // grass lands exactly on the terrain base
+        assert_eq!(-2032 + layers.iter().map(|l| l.1).sum::<i32>() - 1, -1876);
+
+        raise_superflat_floor(&mut root, -1876, -2032);
+        assert_eq!(flat_layers(&root), layers);
+    }
+
+    fn level_dat_root(world: &Path) -> Value {
+        let raw = fs::read(world.join("level.dat")).unwrap();
+        let mut decompressed = Vec::new();
+        GzDecoder::new(raw.as_slice())
+            .read_to_end(&mut decompressed)
+            .unwrap();
+        fastnbt::from_bytes(&decompressed).unwrap()
+    }
+
+    #[test]
+    fn applying_world_settings_lifts_the_superflat_plane_to_the_terrain_base() {
+        let _g = crate::world_editor::FLOOR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+
+        let vanilla = PathBuf::from(create_new_world(tmp.path()).unwrap());
+        crate::world_editor::set_world_bounds(
+            crate::world_editor::DEFAULT_MIN_Y,
+            crate::world_editor::DEFAULT_MAX_Y,
+        );
+        crate::world_editor::set_base_chunk_y(-62);
+        apply_java_world_settings(&vanilla, crate::args::GameMode::Creative, 6000).unwrap();
+        let vanilla_layers = flat_layers(&level_dat_root(&vanilla));
+
+        let tall = PathBuf::from(create_new_world(tmp.path()).unwrap());
+        crate::world_editor::set_world_bounds(-2032, 2031);
+        crate::world_editor::set_base_chunk_y(-1876);
+        apply_java_world_settings(&tall, crate::args::GameMode::Creative, 6000).unwrap();
+        let tall_layers = flat_layers(&level_dat_root(&tall));
+
+        crate::world_editor::set_world_bounds(
+            crate::world_editor::DEFAULT_MIN_Y,
+            crate::world_editor::DEFAULT_MAX_Y,
+        );
+        crate::world_editor::set_base_chunk_y(-62);
+
+        assert_eq!(vanilla_layers[0].0, "minecraft:dirt");
+        assert_eq!(tall_layers[0], ("minecraft:air".to_string(), 154));
+        assert_eq!(tall_layers[1..], vanilla_layers[..]);
     }
 
     /// Highest format that still allows the deprecated `formats` key.


### PR DESCRIPTION
Audit of --disable-height-limit combined with real elevation found 15 defects. The superflat generator kept the vanilla floor, so ground outside the bbox sat at Y -2030; the default spawn was written at a column that is never generated; chunks emitted 150-197 contiguous sections; the ore band followed the sunk floor; and the outlier filter deleted isolated landforms.

Slope, the water snap cliff test and is_montane all compared Minecraft Y against thresholds documented in metres, so surface materials, water placement and montane trees flipped on a build-height checkbox. Waterways drew one flat Y per node segment, leaving puddles once a block is a metre.

Also caps the fixed-tile provider to a tile budget, cuts the elevation post-process peak, bounds the water field flood fill, gates the pack on Luanti and off Earth, and rejects web_mercator with terrain.