### PR TITLE
Add optional custom world name for Java worlds

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -357,8 +357,13 @@ fn gui_pick_save_directory(start_path: String) -> Result<String, String> {
 
 /// Creates a new Java Edition world in the given base save directory.
 /// Called when the user clicks "Create World".
+///
+/// `world_name` is `Some` only when the user has enabled the custom world
+/// name setting and typed a name; it is sanitized and de-duplicated by
+/// [`crate::world_utils::create_new_world_with_name`], which falls back to
+/// the default "Arnis World N" scheme when it is `None` or unusable.
 #[tauri::command]
-fn gui_create_world(save_path: String) -> Result<String, i32> {
+fn gui_create_world(save_path: String, world_name: Option<String>) -> Result<String, i32> {
     let trimmed = save_path.trim();
     if trimmed.is_empty() {
         return Err(3);
@@ -367,11 +372,11 @@ fn gui_create_world(save_path: String) -> Result<String, i32> {
     if !base.is_dir() {
         return Err(3); // Error code 3: Failed to create new world
     }
-    create_new_world(&base).map_err(|_| 3)
+    create_new_world(&base, world_name.as_deref()).map_err(|_| 3)
 }
 
-fn create_new_world(base_path: &Path) -> Result<String, String> {
-    crate::world_utils::create_new_world(base_path)
+fn create_new_world(base_path: &Path, custom_name: Option<&str>) -> Result<String, String> {
+    crate::world_utils::create_new_world_with_name(base_path, custom_name)
 }
 
 /// Adds localized area name to the world name in level.dat

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -151,6 +151,7 @@ pub fn run_gui() -> Result<(), String> {
         .plugin(tauri_plugin_shell::init())
         .invoke_handler(tauri::generate_handler![
             gui_create_world,
+            gui_rename_world,
             gui_get_default_save_path,
             gui_get_default_bedrock_save_path,
             gui_get_default_luanti_save_path,
@@ -377,6 +378,22 @@ fn gui_create_world(save_path: String, world_name: Option<String>) -> Result<Str
 
 fn create_new_world(base_path: &Path, custom_name: Option<&str>) -> Result<String, String> {
     crate::world_utils::create_new_world_with_name(base_path, custom_name)
+}
+
+/// Renames an already-created Java world in place (moves its directory and
+/// updates `LevelName` in `level.dat`). Called when the user commits an edit
+/// via the custom-world-name pencil after a world already exists.
+///
+/// Returns the world's new full path on success, or a human-readable error
+/// message on failure (e.g. the world no longer exists, the name is blank,
+/// or the filesystem rename failed).
+#[tauri::command]
+fn gui_rename_world(world_path: String, world_name: String) -> Result<String, String> {
+    let trimmed = world_path.trim();
+    if trimmed.is_empty() {
+        return Err("No world selected".to_string());
+    }
+    crate::world_utils::rename_world(Path::new(trimmed), &world_name)
 }
 
 /// Adds localized area name to the world name in level.dat

--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -182,8 +182,10 @@ a:hover {
   gap: 4px;
   width: 100%;
   min-width: 0;
-  margin-top: 3px;
-  margin-bottom: -3px;
+  padding: 0 12px 8px;
+  background-color: #ffffff;
+  cursor: pointer;
+  transition: background-color 0.3s;
 }
 
 .world-name-label {
@@ -199,8 +201,9 @@ a:hover {
 }
 
 /* Inline editor for the custom world name, swapped in for .world-name-label
-   while editing. Sits inside .start-button, so it must not inherit the
-   button's pointer cursor or centered button text styling. */
+   while editing. Sits inside .world-name-row (a sibling of #start-button,
+   not nested inside it), so it must not inherit the row's pointer cursor or
+   centered button text styling. */
 .world-name-input {
   flex: 1 1 auto;
   min-width: 0;
@@ -223,15 +226,23 @@ a:hover {
 /* Pencil icon toggled on via Settings > Custom World Name. Mirrors
    .setting-revert's colors (the settings modal's per-row "Reset to
    default" icon button) so it reads as the same family of small,
-   golden-accented icon actions. */
+   golden-accented icon actions. A real <button> (valid here since it's
+   nested in .world-name-row, a <div>, not in #start-button), so the
+   generic `button` rule's chrome must be reset first. */
 .world-name-edit-button {
   flex: 0 0 auto;
   width: 16px;
   height: 16px;
+  min-width: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border: none;
   border-radius: 50%;
+  padding: 0;
+  margin: 0;
+  box-shadow: none;
+  background: transparent;
   cursor: pointer;
   transition: background 0.15s ease;
 }
@@ -239,6 +250,7 @@ a:hover {
 .world-name-edit-button:hover,
 .world-name-edit-button:focus-visible {
   background: rgba(254, 204, 68, 0.3);
+  border-color: transparent;
 }
 
 .world-name-edit-button:focus-visible {
@@ -1326,8 +1338,19 @@ input[type="range"] {
   width: 100%;
 }
 
-.start-button {
+.start-button-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   flex: 1;
+}
+
+.start-button-wrap:hover .start-button,
+.start-button-wrap:hover .world-name-row {
+  background-color: #4caf50;
+}
+
+.start-button {
   padding: 14px 20px;
   border: none;
   border-radius: 8px 0 0 0;
@@ -1337,10 +1360,6 @@ input[type="range"] {
   transition: background-color 0.3s;
   margin-top: 0;
   box-shadow: none;
-}
-
-.start-button:hover {
-  background-color: #4caf50;
 }
 
 .settings-button {

--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -229,6 +229,22 @@ a:hover {
   outline: none;
   cursor: text;
   text-align: left;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+/* At the character cap the field's own maxlength silently refuses anything
+   further, which on its own just feels like the keyboard stopped working.
+   Flipping the editor's gold accent to the red used for errors elsewhere is
+   the signal that the name is being held back rather than dropped. */
+.world-name-input[data-at-limit] {
+  color: #fa7878;
+  border-color: #fa7878;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .world-name-input {
+    transition: none;
+  }
 }
 
 /* Pencil icon toggled on via Settings > Custom World Name. Mirrors

--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -175,17 +175,98 @@ a:hover {
   opacity: 1;
 }
 
+.world-name-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+  margin-top: 3px;
+  margin-bottom: -3px;
+}
+
 .world-name-label {
   font-size: 0.8em;
   color: #fecc44;
-  display: block;
   line-height: 1;
   min-height: 1em;
-  margin-top: 3px;
-  margin-bottom: -3px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+/* Inline editor for the custom world name, swapped in for .world-name-label
+   while editing. Sits inside .start-button, so it must not inherit the
+   button's pointer cursor or centered button text styling. */
+.world-name-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 200px;
+  font-size: 0.8em;
+  font-family: inherit;
+  line-height: 1.3;
+  color: #fecc44;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid #fecc44;
+  border-radius: 3px;
+  padding: 1px 5px;
+  margin: 0;
+  box-shadow: none;
+  outline: none;
+  cursor: text;
+  text-align: left;
+}
+
+/* Pencil icon toggled on via Settings > Custom World Name. Mirrors
+   .setting-revert's colors (the settings modal's per-row "Reset to
+   default" icon button) so it reads as the same family of small,
+   golden-accented icon actions. */
+.world-name-edit-button {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.world-name-edit-button:hover,
+.world-name-edit-button:focus-visible {
+  background: rgba(254, 204, 68, 0.3);
+}
+
+.world-name-edit-button:focus-visible {
+  outline: 1px solid #fecc44;
+  outline-offset: 1px;
+}
+
+.world-name-edit-button svg {
+  width: 12px;
+  height: 12px;
+  fill: rgba(254, 204, 68, 0.75);
+  display: block;
+  transition: fill 0.15s ease;
+  pointer-events: none;
+}
+
+.world-name-edit-button:hover svg,
+.world-name-edit-button:focus-visible svg {
+  fill: #fecc44;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .world-name-edit-button {
+    transition: none;
+  }
+  .world-name-edit-button svg {
+    transition: none;
+  }
 }
 
 .map-container {

--- a/src/gui/css/styles.css
+++ b/src/gui/css/styles.css
@@ -175,17 +175,25 @@ a:hover {
   opacity: 1;
 }
 
+/* Bottom strip of the start button. Deliberately paints no background of its
+   own: .start-button-wrap owns the button's fill for both colour schemes, and
+   this row is transparent on top of it, so the row and #start-button read as
+   one button. The horizontal padding mirrors .start-button's, and the 3px/11px
+   vertical split reproduces the label spacing from back when the row was still
+   nested inside the button (3px below the button text, 11px to its bottom
+   edge). */
 .world-name-row {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 4px;
-  width: 100%;
+  /* No `width: 100%`: the row is a stretch item of the flex-column wrapper, so
+     it already spans it. Setting it explicitly would add the padding on top
+     (content-box is the default here) and push the row out past the settings
+     button. */
   min-width: 0;
-  padding: 0 12px 8px;
-  background-color: #ffffff;
+  padding: 3px 20px 11px;
   cursor: pointer;
-  transition: background-color 0.3s;
 }
 
 .world-name-label {
@@ -228,8 +236,11 @@ a:hover {
    default" icon button) so it reads as the same family of small,
    golden-accented icon actions. A real <button> (valid here since it's
    nested in .world-name-row, a <div>, not in #start-button), so the
-   generic `button` rule's chrome must be reset first. */
-.world-name-edit-button {
+   generic `button` rule's chrome must be reset first. The selector is
+   descendant-qualified so `width` outranks `.controls-box button`'s
+   `width: 100%`, which would otherwise stretch the icon across the whole
+   row (the same clash .settings-button solves with !important). */
+.world-name-row .world-name-edit-button {
   flex: 0 0 auto;
   width: 16px;
   height: 16px;
@@ -1338,26 +1349,47 @@ input[type="range"] {
   width: 100%;
 }
 
+/* #start-button and .world-name-row are two elements (the world-name editor
+   can't be nested inside a <button>) that have to look like one. The wrapper
+   paints the fill, corner and hover for both of them; giving each its own
+   background instead would mean re-deriving the generic `button` colours per
+   colour scheme in two places and risking a visible seam between them. */
 .start-button-wrap {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   flex: 1;
+  background-color: #ffffff;
+  border-radius: 8px 0 0 0;
+  cursor: pointer;
+  transition: background-color 0.3s;
 }
 
-.start-button-wrap:hover .start-button,
-.start-button-wrap:hover .world-name-row {
+@media (prefers-color-scheme: dark) {
+  .start-button-wrap {
+    background-color: #0f0f0f98;
+  }
+}
+
+.start-button-wrap:hover {
   background-color: #4caf50;
 }
 
+/* The :active variant is not cosmetic: dark mode's `button:active` rule is
+   more specific than a bare `.start-button`, so without it the button would
+   flash its own fill over the wrapper's while held down. */
+.start-button,
+.start-button:active {
+  background-color: transparent;
+}
+
 .start-button {
-  padding: 14px 20px;
+  padding: 14px 20px 0;
   border: none;
-  border-radius: 8px 0 0 0;
+  border-radius: 0;
   font-size: 16px;
   font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.3s;
   margin-top: 0;
   box-shadow: none;
 }

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -48,6 +48,11 @@
                        button stop propagation so their own clicks don't also trigger it. -->
                   <div class="world-name-row" onclick="startGeneration()">
                     <span id="world-name-label" class="world-name-label" data-placeholder="true">No world generated yet</span>
+                    <!-- maxlength both stops further typing at the cap and mirrors
+                         MAX_CUSTOM_WORLD_NAME_CHARS in src/world_utils.rs, which caps by
+                         characters too - so nothing typed here is ever silently truncated
+                         on the way to disk. main.js reads the limit off this attribute to
+                         colour the field red once it's reached. -->
                     <input type="text" id="world-name-input" class="world-name-input" style="display: none;" maxlength="48" autocomplete="off" spellcheck="false">
                     <button type="button" id="world-name-edit-button" class="world-name-edit-button" title="Set a custom world name" aria-label="Set a custom world name" style="display: none;">
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zm17.71-10.04a1 1 0 0 0 0-1.42l-2.5-2.5a1 1 0 0 0-1.42 0l-1.83 1.83 3.75 3.75z"/></svg>

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -37,18 +37,23 @@
             <!-- Combined Button Block -->
             <div class="button-block">
               <div class="button-block-row">
-                <button type="button" id="start-button" class="start-button" onclick="startGeneration()">
-                  <span data-localize="start_generation">Start Generation</span>
-                  <span class="world-name-row">
+                <div class="start-button-wrap">
+                  <button type="button" id="start-button" class="start-button" onclick="startGeneration()">
+                    <span data-localize="start_generation">Start Generation</span>
+                  </button>
+                  <!-- Lives outside #start-button (not nested inside it): the HTML spec
+                       forbids interactive content (inputs, buttons, or anything with a
+                       tabindex) inside a <button>. Clicking the label/background here
+                       still starts generation via its own onclick; the input and pencil
+                       button stop propagation so their own clicks don't also trigger it. -->
+                  <div class="world-name-row" onclick="startGeneration()">
                     <span id="world-name-label" class="world-name-label" data-placeholder="true">No world generated yet</span>
                     <input type="text" id="world-name-input" class="world-name-input" style="display: none;" maxlength="48" autocomplete="off" spellcheck="false">
-                    <!-- Not a real <button>: it lives inside #start-button, and nested buttons are invalid HTML.
-                         role="button" + tabindex + the keydown handler in main.js keep it keyboard accessible. -->
-                    <span id="world-name-edit-button" class="world-name-edit-button" role="button" tabindex="0" title="Set a custom world name" aria-label="Set a custom world name" style="display: none;">
+                    <button type="button" id="world-name-edit-button" class="world-name-edit-button" title="Set a custom world name" aria-label="Set a custom world name" style="display: none;">
                       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zm17.71-10.04a1 1 0 0 0 0-1.42l-2.5-2.5a1 1 0 0 0-1.42 0l-1.83 1.83 3.75 3.75z"/></svg>
-                    </span>
-                  </span>
-                </button>
+                    </button>
+                  </div>
+                </div>
                 <button type="button" class="settings-button" onclick="openSettings()" aria-label="Settings">
                     <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>
                 </button>

--- a/src/gui/index.html
+++ b/src/gui/index.html
@@ -39,7 +39,15 @@
               <div class="button-block-row">
                 <button type="button" id="start-button" class="start-button" onclick="startGeneration()">
                   <span data-localize="start_generation">Start Generation</span>
-                  <span id="world-name-label" class="world-name-label" data-placeholder="true">No world generated yet</span>
+                  <span class="world-name-row">
+                    <span id="world-name-label" class="world-name-label" data-placeholder="true">No world generated yet</span>
+                    <input type="text" id="world-name-input" class="world-name-input" style="display: none;" maxlength="48" autocomplete="off" spellcheck="false">
+                    <!-- Not a real <button>: it lives inside #start-button, and nested buttons are invalid HTML.
+                         role="button" + tabindex + the keydown handler in main.js keep it keyboard accessible. -->
+                    <span id="world-name-edit-button" class="world-name-edit-button" role="button" tabindex="0" title="Set a custom world name" aria-label="Set a custom world name" style="display: none;">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zm17.71-10.04a1 1 0 0 0 0-1.42l-2.5-2.5a1 1 0 0 0-1.42 0l-1.83 1.83 3.75 3.75z"/></svg>
+                    </span>
+                  </span>
                 </button>
                 <button type="button" class="settings-button" onclick="openSettings()" aria-label="Settings">
                     <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path><circle cx="12" cy="12" r="3"></circle></svg>
@@ -239,6 +247,17 @@
           </label>
           <div class="settings-control">
             <input type="checkbox" id="map-item-toggle" name="map-item-toggle" checked>
+          </div>
+        </div>
+
+        <!-- Custom World Name Toggle -->
+        <div class="settings-row">
+          <label for="custom-world-name-toggle">
+            <span data-localize="custom_world_name">Custom World Name</span>
+            <span class="tooltip-icon" data-tooltip="Show a pencil icon on the Start button to name new worlds yourself instead of the auto-generated 'Arnis World N' (Java only)">?</span>
+          </label>
+          <div class="settings-control">
+            <input type="checkbox" id="custom-world-name-toggle" name="custom-world-name-toggle">
           </div>
         </div>
 

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -780,13 +780,13 @@ function setupProgressListener() {
 
       if (message.startsWith("Error!")) {
         progressInfo.style.color = "#fa7878";
-        generationButtonEnabled = true;
+        setGenerationButtonEnabled(true);
         window.arnisPreview3D?.setGenerationRunning(false);
         setWorldNameLabel("");
         resetEta();
       } else if (message.startsWith("Done!")) {
         progressInfo.style.color = "#7bd864";
-        generationButtonEnabled = true;
+        setGenerationButtonEnabled(true);
         window.arnisPreview3D?.setGenerationRunning(false);
         resetEta();
       } else {
@@ -1955,11 +1955,19 @@ let customWorldName = "";
 // stale real name would keep showing instead of what was just typed).
 let worldNameEditedSinceLastCreate = false;
 
-function isCustomWorldNameEnabled() {
+function isCustomWorldNameFeatureEnabled() {
   const toggle = document.getElementById('custom-world-name-toggle');
   // Custom names are Java-only: creating a Bedrock/Luanti world never calls
-  // gui_create_world, so offering the editor there would silently do nothing.
+  // gui_create_world, so offering the feature there would silently do
+  // nothing.
   return !!(toggle && toggle.checked) && selectedWorldFormat === 'java';
+}
+
+function canEditCustomWorldName() {
+  // While a generation or rename is in flight, the world directory may be
+  // actively written to on disk, so renaming/recreating it out from under
+  // that write would corrupt or orphan the in-progress world.
+  return isCustomWorldNameFeatureEnabled() && generationButtonEnabled;
 }
 
 // Shows the pending custom name (if any) unless a world already exists for
@@ -1967,7 +1975,16 @@ function isCustomWorldNameEnabled() {
 // de-duplicated) name from the backend is authoritative.
 function updateWorldNamePreviewLabel() {
   if (worldPath && !worldNameEditedSinceLastCreate) return;
-  setWorldNameLabel(isCustomWorldNameEnabled() ? customWorldName : "");
+  if (!isCustomWorldNameFeatureEnabled()) {
+    // Feature off: fall back to showing whatever world actually exists
+    // rather than blanking a real name to "".
+    setWorldNameLabel(basenameFromPath(worldPath));
+    return;
+  }
+  // customWorldName can be "" right after committing a blank edit on an
+  // already-existing world; that must keep showing the real name, not the
+  // "no world generated yet" placeholder (setWorldNameLabel("") would).
+  setWorldNameLabel(customWorldName || basenameFromPath(worldPath));
 }
 
 // Cancels any in-progress edit and shows/hides the pencil to match the
@@ -1977,7 +1994,7 @@ function refreshWorldNameEditUI() {
   endWorldNameEdit();
   const editButton = document.getElementById('world-name-edit-button');
   if (editButton) {
-    editButton.style.display = isCustomWorldNameEnabled() ? '' : 'none';
+    editButton.style.display = canEditCustomWorldName() ? '' : 'none';
   }
   updateWorldNamePreviewLabel();
 }
@@ -1987,17 +2004,21 @@ function startWorldNameEdit(event) {
     event.preventDefault();
     event.stopPropagation();
   }
-  if (!isCustomWorldNameEnabled()) return;
+  if (!canEditCustomWorldName()) return;
 
   const label = document.getElementById('world-name-label');
   const input = document.getElementById('world-name-input');
   const editButton = document.getElementById('world-name-edit-button');
   if (!label || !input) return;
 
-  // Prefer an in-progress edit; otherwise pre-fill with the currently
-  // generated world's real name (if any) so re-opening the editor lets the
-  // user rename an already-created world instead of starting from blank.
-  input.value = customWorldName || basenameFromPath(worldPath);
+  // Prefer an in-progress edit; otherwise pre-fill with the currently shown
+  // real world name (if any) so re-opening the editor lets the user rename
+  // an already-created world instead of starting from blank. Falling back
+  // to the directory basename keeps the input useful even if the label was
+  // not yet refreshed from disk.
+  const visibleName = label.hasAttribute('data-placeholder') ? '' : label.textContent.trim();
+  input.value = customWorldName || visibleName || basenameFromPath(worldPath);
+  input.dataset.originalValue = input.value;
   label.style.display = 'none';
   if (editButton) editButton.style.display = 'none';
   input.style.display = '';
@@ -2005,9 +2026,48 @@ function startWorldNameEdit(event) {
   input.select();
 }
 
-function commitWorldNameEdit() {
+// Commits the pencil editor. If no world has been created yet, this just
+// remembers the name for the next generation. If a world already exists,
+// this actually renames it on disk right away via gui_rename_world (moves
+// the directory + updates level.dat), rather than silently deferring to
+// "the next Start Generation click creates a new, separate world" - that
+// would leave the already-generated world's real name unchanged, which is
+// not what "rename" means to someone editing an existing world's name.
+async function commitWorldNameEdit() {
   const input = document.getElementById('world-name-input');
-  if (input) customWorldName = input.value.trim();
+  if (!input) {
+    endWorldNameEdit();
+    return;
+  }
+  const newName = input.value.trim();
+
+  if (worldPath) {
+    const currentName = input.dataset.originalValue || basenameFromPath(worldPath);
+    endWorldNameEdit();
+    if (!newName || newName === currentName) return; // nothing to rename
+
+    // Block Start Generation (and re-opening the editor) for the brief
+    // window the rename is in flight, so nothing else can read/write
+    // worldPath while it's changing.
+    setGenerationButtonEnabled(false);
+    try {
+      const renamedPath = await invoke('gui_rename_world', { worldPath: worldPath, worldName: newName });
+      if (renamedPath) {
+        worldPath = renamedPath;
+        customWorldName = basenameFromPath(renamedPath);
+        setWorldNameLabel(customWorldName);
+      }
+    } catch (error) {
+      console.error("Failed to rename world:", error);
+      // Nothing changed on disk; make sure the label still reflects that.
+      setWorldNameLabel(currentName);
+    } finally {
+      setGenerationButtonEnabled(true);
+    }
+    return;
+  }
+
+  customWorldName = newName;
   worldNameEditedSinceLastCreate = true;
   endWorldNameEdit();
 }
@@ -2032,7 +2092,7 @@ function endWorldNameEdit() {
   if (!input || input.style.display === 'none') return;
   input.style.display = 'none';
   if (label) label.style.display = '';
-  if (editButton && isCustomWorldNameEnabled()) editButton.style.display = '';
+  if (editButton && canEditCustomWorldName()) editButton.style.display = '';
   updateWorldNamePreviewLabel();
 }
 
@@ -2050,16 +2110,13 @@ function initCustomWorldNameToggle() {
   if (editButton) {
     editButton.addEventListener('click', startWorldNameEdit);
     editButton.addEventListener('mousedown', (event) => event.stopPropagation());
-    editButton.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter' || event.key === ' ') {
-        startWorldNameEdit(event);
-      }
-    });
   }
 
   if (input) {
-    // The input lives inside #start-button; without this, any click to
-    // place the caret bubbles up and triggers startGeneration().
+    // The input lives inside .world-name-row, a sibling of #start-button
+    // (not nested inside it) that has its own onclick="startGeneration()"
+    // for clicks on the label/background; without this, placing the caret
+    // would bubble up and trigger that too.
     input.addEventListener('click', (event) => event.stopPropagation());
     input.addEventListener('mousedown', (event) => event.stopPropagation());
     input.addEventListener('keydown', (event) => {
@@ -2107,6 +2164,14 @@ function handleWorldSelectionError(errorCode) {
 
 let generationButtonEnabled = true;
 
+// Central setter so every place that toggles generation state also
+// refreshes the world-name pencil (hidden/blocked while a generation, or a
+// rename, is in flight - see canEditCustomWorldName()).
+function setGenerationButtonEnabled(enabled) {
+  generationButtonEnabled = enabled;
+  refreshWorldNameEditUI();
+}
+
 /**
  * Initiates the world generation process
  * Validates required inputs and sends generation parameters to the backend
@@ -2119,7 +2184,7 @@ async function startGeneration() {
   // Claim the guard before the first await. gui_create_world and gui_start_generation are
   // both awaited round-trips, so leaving the claim until after them lets a second click
   // through and starts a parallel run against the same process-global world floor.
-  generationButtonEnabled = false;
+  setGenerationButtonEnabled(false);
   let started = false;
 
   try {
@@ -2136,7 +2201,7 @@ async function startGeneration() {
         return;
       }
       try {
-        const requestedName = isCustomWorldNameEnabled() && customWorldName ? customWorldName : null;
+        const requestedName = isCustomWorldNameFeatureEnabled() && customWorldName ? customWorldName : null;
         const worldName = await invoke('gui_create_world', { savePath: savePath, worldName: requestedName });
         if (worldName) {
           worldPath = worldName;
@@ -2254,7 +2319,7 @@ async function startGeneration() {
     // Hand the guard back unless a run actually started; once it has, the Done!/Error!
     // progress message releases it instead.
     if (!started) {
-      generationButtonEnabled = true;
+      setGenerationButtonEnabled(true);
       window.arnisPreview3D?.setGenerationRunning(false);
     }
   }

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -157,6 +157,7 @@ async function applyLocalization(localization) {
     "button[data-localize='gamemode_spectator']": "gamemode_spectator",
     "span[data-localize='world_time']": "world_time",
     "span[data-localize='map_item']": "map_item",
+    "span[data-localize='custom_world_name']": "custom_world_name",
     "span[data-localize='signage']": "signage",
     "button[data-localize='signage_none']": "signage_none",
     "button[data-localize='signage_basic']": "signage_basic",
@@ -1019,6 +1020,9 @@ function initSettings() {
   // World format toggle (Java/Bedrock/Luanti)
   initWorldFormatToggle();
 
+  // Custom world name editor (Java only), gated by its Settings toggle
+  initCustomWorldNameToggle();
+
   // Save path setting
   initSavePathSetting();
 
@@ -1312,6 +1316,10 @@ function updateFormatToggleUI(format) {
     if (luantiBtn) luantiBtn.classList.add('format-active');
     worldPath = "";
   }
+
+  // Custom names are Java-only; hide/show the pencil and re-derive the
+  // label preview whenever the active format changes.
+  refreshWorldNameEditUI();
 }
 
 // Expose to window for onclick handlers
@@ -1934,6 +1942,145 @@ function basenameFromPath(p) {
   return p.replace(/[\\/]+$/, "").split(/[\\/]/).pop() || "";
 }
 
+/* Custom world name (Java only, opt-in via Settings > Custom World Name) */
+
+// Holds the user's typed name across edits/generations. Only ever sent to
+// the backend while the setting is enabled; the backend sanitizes and
+// de-duplicates it, so this is just what the pencil editor shows/pre-fills.
+let customWorldName = "";
+
+// True from the moment the user commits an edit until the next world is
+// actually created. Lets the label preview the pending name even when
+// `worldPath` still points at a previously generated world (otherwise that
+// stale real name would keep showing instead of what was just typed).
+let worldNameEditedSinceLastCreate = false;
+
+function isCustomWorldNameEnabled() {
+  const toggle = document.getElementById('custom-world-name-toggle');
+  // Custom names are Java-only: creating a Bedrock/Luanti world never calls
+  // gui_create_world, so offering the editor there would silently do nothing.
+  return !!(toggle && toggle.checked) && selectedWorldFormat === 'java';
+}
+
+// Shows the pending custom name (if any) unless a world already exists for
+// the current pending state, in which case its real (possibly
+// de-duplicated) name from the backend is authoritative.
+function updateWorldNamePreviewLabel() {
+  if (worldPath && !worldNameEditedSinceLastCreate) return;
+  setWorldNameLabel(isCustomWorldNameEnabled() ? customWorldName : "");
+}
+
+// Cancels any in-progress edit and shows/hides the pencil to match the
+// current setting + world format. Safe to call anytime state that affects
+// availability changes (toggle flipped, format switched, language changed).
+function refreshWorldNameEditUI() {
+  endWorldNameEdit();
+  const editButton = document.getElementById('world-name-edit-button');
+  if (editButton) {
+    editButton.style.display = isCustomWorldNameEnabled() ? '' : 'none';
+  }
+  updateWorldNamePreviewLabel();
+}
+
+function startWorldNameEdit(event) {
+  if (event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+  if (!isCustomWorldNameEnabled()) return;
+
+  const label = document.getElementById('world-name-label');
+  const input = document.getElementById('world-name-input');
+  const editButton = document.getElementById('world-name-edit-button');
+  if (!label || !input) return;
+
+  input.value = customWorldName;
+  label.style.display = 'none';
+  if (editButton) editButton.style.display = 'none';
+  input.style.display = '';
+  input.focus();
+  input.select();
+}
+
+function commitWorldNameEdit() {
+  const input = document.getElementById('world-name-input');
+  if (input) customWorldName = input.value.trim();
+  worldNameEditedSinceLastCreate = true;
+  endWorldNameEdit();
+}
+
+// Hiding the (still-focused) input fires a native blur, which would
+// otherwise re-enter the blur handler below and commit the very edit
+// Escape just discarded. Suppress that one follow-up blur.
+let suppressNextWorldNameBlur = false;
+
+function cancelWorldNameEdit() {
+  suppressNextWorldNameBlur = true;
+  endWorldNameEdit();
+}
+
+// Shared teardown for both commit and cancel: hides the input, restores the
+// label (and the pencil, if the feature is still enabled), and refreshes
+// what the label shows.
+function endWorldNameEdit() {
+  const label = document.getElementById('world-name-label');
+  const input = document.getElementById('world-name-input');
+  const editButton = document.getElementById('world-name-edit-button');
+  if (!input || input.style.display === 'none') return;
+  input.style.display = 'none';
+  if (label) label.style.display = '';
+  if (editButton && isCustomWorldNameEnabled()) editButton.style.display = '';
+  updateWorldNamePreviewLabel();
+}
+
+function initCustomWorldNameToggle() {
+  const toggle = document.getElementById('custom-world-name-toggle');
+  const editButton = document.getElementById('world-name-edit-button');
+  const input = document.getElementById('world-name-input');
+  if (!toggle) return;
+
+  // Covers manual clicks and settings-store restoring/reverting the value
+  // (both dispatch a real "change" event), as long as this listener is
+  // attached before initSettingsStore() runs its restore().
+  toggle.addEventListener('change', refreshWorldNameEditUI);
+
+  if (editButton) {
+    editButton.addEventListener('click', startWorldNameEdit);
+    editButton.addEventListener('mousedown', (event) => event.stopPropagation());
+    editButton.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        startWorldNameEdit(event);
+      }
+    });
+  }
+
+  if (input) {
+    // The input lives inside #start-button; without this, any click to
+    // place the caret bubbles up and triggers startGeneration().
+    input.addEventListener('click', (event) => event.stopPropagation());
+    input.addEventListener('mousedown', (event) => event.stopPropagation());
+    input.addEventListener('keydown', (event) => {
+      event.stopPropagation();
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        commitWorldNameEdit();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        cancelWorldNameEdit();
+      }
+    });
+    input.addEventListener('blur', () => {
+      if (suppressNextWorldNameBlur) {
+        suppressNextWorldNameBlur = false;
+        return;
+      }
+      commitWorldNameEdit();
+    });
+  }
+
+  refreshWorldNameEditUI();
+}
+
 /**
  * Handles world selection errors and displays appropriate messages
  * @param {number} errorCode - Error code from the backend
@@ -1986,10 +2133,16 @@ async function startGeneration() {
         return;
       }
       try {
-        const worldName = await invoke('gui_create_world', { savePath: savePath });
+        const requestedName = isCustomWorldNameEnabled() && customWorldName ? customWorldName : null;
+        const worldName = await invoke('gui_create_world', { savePath: savePath, worldName: requestedName });
         if (worldName) {
           worldPath = worldName;
-          setWorldNameLabel(basenameFromPath(worldName));
+          worldNameEditedSinceLastCreate = false;
+          const createdName = basenameFromPath(worldName);
+          setWorldNameLabel(createdName);
+          // Pre-fill the editor with the real (possibly de-duplicated) name,
+          // so editing again starts from what was actually created.
+          if (requestedName) customWorldName = createdName;
         }
       } catch (error) {
         handleWorldSelectionError(error);

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -1994,7 +1994,10 @@ function startWorldNameEdit(event) {
   const editButton = document.getElementById('world-name-edit-button');
   if (!label || !input) return;
 
-  input.value = customWorldName;
+  // Prefer an in-progress edit; otherwise pre-fill with the currently
+  // generated world's real name (if any) so re-opening the editor lets the
+  // user rename an already-created world instead of starting from blank.
+  input.value = customWorldName || basenameFromPath(worldPath);
   label.style.display = 'none';
   if (editButton) editButton.style.display = 'none';
   input.style.display = '';

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -2059,8 +2059,17 @@ async function commitWorldNameEdit() {
       }
     } catch (error) {
       console.error("Failed to rename world:", error);
-      // Nothing changed on disk; make sure the label still reflects that.
+      // Nothing changed on disk; make sure the label still reflects that,
+      // and say why. A rename fails for reasons the user can act on - the
+      // world is open in Minecraft holding a lock on the directory, or the
+      // name was left with nothing usable after sanitization - and silently
+      // snapping the old name back just reads as a dead pencil.
       setWorldNameLabel(currentName);
+      const progressInfo = document.getElementById('progress-info');
+      if (progressInfo) {
+        localizeElement(window.localization, { element: progressInfo }, "failed_to_rename_world");
+        progressInfo.style.color = "#fa7878";
+      }
     } finally {
       setGenerationButtonEnabled(true);
     }
@@ -2072,15 +2081,13 @@ async function commitWorldNameEdit() {
   endWorldNameEdit();
 }
 
-// Hiding the (still-focused) input fires a native blur, which would
-// otherwise re-enter the blur handler below and commit the very edit
-// Escape just discarded. Suppress that one follow-up blur.
+// Hiding the still-focused input fires a native blur (asynchronously, after
+// the handler that hid it has returned), which would otherwise re-enter the
+// blur handler below and re-run the edit we are already finishing: Escape
+// would re-commit what it just discarded, and Enter would fire a second
+// gui_rename_world against the path the first one is still renaming.
+// endWorldNameEdit() sets this whenever it hides a focused input.
 let suppressNextWorldNameBlur = false;
-
-function cancelWorldNameEdit() {
-  suppressNextWorldNameBlur = true;
-  endWorldNameEdit();
-}
 
 // Shared teardown for both commit and cancel: hides the input, restores the
 // label (and the pencil, if the feature is still enabled), and refreshes
@@ -2090,6 +2097,9 @@ function endWorldNameEdit() {
   const input = document.getElementById('world-name-input');
   const editButton = document.getElementById('world-name-edit-button');
   if (!input || input.style.display === 'none') return;
+  // Only when the input still holds focus: a teardown reached *from* the blur
+  // handler must not arm this, or it would swallow the next real blur.
+  if (document.activeElement === input) suppressNextWorldNameBlur = true;
   input.style.display = 'none';
   if (label) label.style.display = '';
   if (editButton && canEditCustomWorldName()) editButton.style.display = '';
@@ -2125,8 +2135,9 @@ function initCustomWorldNameToggle() {
         event.preventDefault();
         commitWorldNameEdit();
       } else if (event.key === 'Escape') {
+        // Discard: tear the editor down without committing.
         event.preventDefault();
-        cancelWorldNameEdit();
+        endWorldNameEdit();
       }
     });
     input.addEventListener('blur', () => {

--- a/src/gui/js/main.js
+++ b/src/gui/js/main.js
@@ -1999,6 +1999,21 @@ function refreshWorldNameEditUI() {
   updateWorldNamePreviewLabel();
 }
 
+// Marks the editor red once it is full. The input's own maxlength is what
+// actually refuses further characters; this only makes that visible. The
+// limit is read off that same attribute rather than duplicating the number
+// here, so the colour can never disagree with what the field accepts.
+function updateWorldNameLimitState() {
+  const input = document.getElementById('world-name-input');
+  if (!input) return;
+  const limit = input.maxLength;
+  if (limit > 0 && input.value.length >= limit) {
+    input.setAttribute('data-at-limit', 'true');
+  } else {
+    input.removeAttribute('data-at-limit');
+  }
+}
+
 function startWorldNameEdit(event) {
   if (event) {
     event.preventDefault();
@@ -2022,6 +2037,7 @@ function startWorldNameEdit(event) {
   label.style.display = 'none';
   if (editButton) editButton.style.display = 'none';
   input.style.display = '';
+  updateWorldNameLimitState();
   input.focus();
   input.select();
 }
@@ -2129,6 +2145,9 @@ function initCustomWorldNameToggle() {
     // would bubble up and trigger that too.
     input.addEventListener('click', (event) => event.stopPropagation());
     input.addEventListener('mousedown', (event) => event.stopPropagation());
+    // "input" rather than "keydown": it also covers pasting, cutting and
+    // undo, and fires after the value has actually changed.
+    input.addEventListener('input', updateWorldNameLimitState);
     input.addEventListener('keydown', (event) => {
       event.stopPropagation();
       if (event.key === 'Enter') {

--- a/src/gui/js/settings-store.js
+++ b/src/gui/js/settings-store.js
@@ -33,6 +33,7 @@ const SETTINGS = [
   { id: 'gamemode-group', kind: 'segmented', store: OWN, valueAttr: 'data-gamemode' },
   { id: 'world-time-slider', kind: 'number', store: OWN },
   { id: 'map-item-toggle', kind: 'checkbox', store: OWN },
+  { id: 'custom-world-name-toggle', kind: 'checkbox', store: OWN },
   { id: 'signage-group', kind: 'segmented', store: OWN, valueAttr: 'data-signage' },
   { id: 'disable-height-limit-toggle', kind: 'checkbox', store: OWN },
   { id: 'aws-only-elevation-toggle', kind: 'checkbox', store: OWN },

--- a/src/gui/locales/ar.json
+++ b/src/gui/locales/ar.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "المتفرج",
   "world_time": "وقت العالم",
   "map_item": "عنصر خريطة العالم",
+  "custom_world_name": "اسم عالم مخصص",
   "signage": "اللافتات",
   "signage_none": "بدون",
   "signage_basic": "أساسي",

--- a/src/gui/locales/ar.json
+++ b/src/gui/locales/ar.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "لم يتم العثور على مجلد ماين كرافت",
   "world_in_use": "العالم المحدد قيد الاستخدام حاليًا",
   "failed_to_create_world": "حدث خطأ عند محاولة إنشاء عالم جديد",
+  "failed_to_rename_world": "فشل في إعادة تسمية العالم",
   "no_world_selected_error": "لم يتم تحديد عالم",
   "create_world_first": "أنشئ عالمًا أولاً!",
   "select_location_first": "يرجى اختيار موقع أولاً!",

--- a/src/gui/locales/de.json
+++ b/src/gui/locales/de.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Minecraft Verzeichnis nicht gefunden",
   "world_in_use": "Die ausgewählte Welt ist gerade in Benutzung",
   "failed_to_create_world": "Neue Welt konnte nicht erstellt werden",
+  "failed_to_rename_world": "Welt konnte nicht umbenannt werden",
   "no_world_selected_error": "Keine Welt ausgewählt",
   "create_world_first": "Erstelle zuerst eine Welt!",
   "select_location_first": "Wähle zuerst einen Standort aus!",

--- a/src/gui/locales/de.json
+++ b/src/gui/locales/de.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Zuschauer",
   "world_time": "Weltzeit",
   "map_item": "Weltkarte im Inventar",
+  "custom_world_name": "Eigener Weltname",
   "signage": "Beschilderung",
   "signage_none": "Keine",
   "signage_basic": "Standard",

--- a/src/gui/locales/en-US.json
+++ b/src/gui/locales/en-US.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Spectator",
   "world_time": "World Time",
   "map_item": "World Map Item",
+  "custom_world_name": "Custom World Name",
   "signage": "Signage",
   "signage_none": "None",
   "signage_basic": "Basic",

--- a/src/gui/locales/en-US.json
+++ b/src/gui/locales/en-US.json
@@ -26,6 +26,7 @@
   "minecraft_directory_not_found": "Minecraft directory not found",
   "world_in_use": "The selected world is currently in use",
   "failed_to_create_world": "Failed to create new world",
+  "failed_to_rename_world": "Failed to rename world",
   "no_world_selected_error": "No world selected",
   "create_world_first": "Create a world first!",
   "select_location_first": "Select a location first!",

--- a/src/gui/locales/es.json
+++ b/src/gui/locales/es.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Espectador",
   "world_time": "Hora del mundo",
   "map_item": "Objeto de mapa del mundo",
+  "custom_world_name": "Nombre de mundo personalizado",
   "signage": "Señalización",
   "signage_none": "Ninguna",
   "signage_basic": "Básica",

--- a/src/gui/locales/es.json
+++ b/src/gui/locales/es.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Directorio de Minecraft no encontrado",
   "world_in_use": "El mundo seleccionado está en uso",
   "failed_to_create_world": "No se pudo crear un nuevo mundo",
+  "failed_to_rename_world": "No se pudo renombrar el mundo",
   "no_world_selected_error": "Ningún mundo seleccionado",
   "create_world_first": "¡Crea un mundo primero!",
   "select_location_first": "¡Seleccione una ubicación primero!",

--- a/src/gui/locales/fi.json
+++ b/src/gui/locales/fi.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Minecraft-hakemistoa ei löytynyt",
   "world_in_use": "Valittu maailma käytössä.",
   "failed_to_create_world": "Uuden maailman luonti epäonnistui",
+  "failed_to_rename_world": "Maailman uudelleennimeäminen epäonnistui",
   "no_world_selected_error": "Maailmaa ei valittu",
   "create_world_first": "Luo ensin maailma!",
   "select_location_first": "Valitse paikka ensin!",

--- a/src/gui/locales/fi.json
+++ b/src/gui/locales/fi.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Katselija",
   "world_time": "Maailman aika",
   "map_item": "Maailmankarttaesine",
+  "custom_world_name": "Mukautettu maailman nimi",
   "signage": "Kyltit",
   "signage_none": "Ei mitään",
   "signage_basic": "Perus",

--- a/src/gui/locales/fr-FR.json
+++ b/src/gui/locales/fr-FR.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Spectateur",
   "world_time": "Heure du monde",
   "map_item": "Objet carte du monde",
+  "custom_world_name": "Nom du monde personnalisé",
   "signage": "Signalétique",
   "signage_none": "Aucune",
   "signage_basic": "Basique",

--- a/src/gui/locales/fr-FR.json
+++ b/src/gui/locales/fr-FR.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Répertoire Minecraft introuvable",
   "world_in_use": "Le monde sélectionné est en cours d'utilisation",
   "failed_to_create_world": "Échec de la création du nouveau monde",
+  "failed_to_rename_world": "Échec du renommage du monde",
   "no_world_selected_error": "Aucun monde sélectionné",
   "create_world_first": "Créez d'abord un monde !",
   "select_location_first": "Sélectionnez d'abord une localisation !",

--- a/src/gui/locales/hu.json
+++ b/src/gui/locales/hu.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Minecraft mappa nem található",
   "world_in_use": "A kiválasztott világ már használatban van",
   "failed_to_create_world": "Nem sikerült új világot létrehozni",
+  "failed_to_rename_world": "Nem sikerült átnevezni a világot",
   "no_world_selected_error": "Nincs kiválasztott világ",
   "create_world_first": "Először hozz létre egy világot!",
   "select_location_first": "Válassz egy helyet először!",

--- a/src/gui/locales/hu.json
+++ b/src/gui/locales/hu.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Néző",
   "world_time": "Világidő",
   "map_item": "Világtérkép-tárgy",
+  "custom_world_name": "Egyéni világnév",
   "signage": "Táblák",
   "signage_none": "Nincs",
   "signage_basic": "Alap",

--- a/src/gui/locales/ja.json
+++ b/src/gui/locales/ja.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Minecraft ディレクトリが見つかりません",
   "world_in_use": "選択したワールドは現在使用中です",
   "failed_to_create_world": "新しいワールドの作成に失敗しました",
+  "failed_to_rename_world": "ワールドの名前の変更に失敗しました",
   "no_world_selected_error": "ワールドが選択されていません",
   "create_world_first": "先にワールドを作成してください！",
   "select_location_first": "先に場所を選択してください！",

--- a/src/gui/locales/ja.json
+++ b/src/gui/locales/ja.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "スペクテイター",
   "world_time": "ワールド時間",
   "map_item": "ワールド地図アイテム",
+  "custom_world_name": "カスタムワールド名",
   "signage": "看板",
   "signage_none": "なし",
   "signage_basic": "基本",

--- a/src/gui/locales/ka-GE.json
+++ b/src/gui/locales/ka-GE.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "მაყურებელი",
   "world_time": "სამყაროს დრო",
   "map_item": "სამყაროს რუკის ნივთი",
+  "custom_world_name": "მორგებული სამყაროს სახელი",
   "signage": "აბრები",
   "signage_none": "არცერთი",
   "signage_basic": "ძირითადი",

--- a/src/gui/locales/ka-GE.json
+++ b/src/gui/locales/ka-GE.json
@@ -26,6 +26,7 @@
   "minecraft_directory_not_found": "Minecraft-ის დირექტორია ვერ მოიძებნა",
   "world_in_use": "არჩეული სამყარო ამჟამად გამოიყენება",
   "failed_to_create_world": "ახალი სამყაროს შექმნა ვერ მოხერხდა",
+  "failed_to_rename_world": "სამყაროს გადარქმევა ვერ მოხერხდა",
   "no_world_selected_error": "სამყარო არ არის არჩეული",
   "create_world_first": "ჯერ შექმენით სამყარო!",
   "select_location_first": "ჯერ აირჩიეთ ადგილმდებარეობა!",

--- a/src/gui/locales/ko.json
+++ b/src/gui/locales/ko.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "관전자",
   "world_time": "월드 시간",
   "map_item": "월드 지도 아이템",
+  "custom_world_name": "사용자 지정 월드 이름",
   "signage": "표지판",
   "signage_none": "없음",
   "signage_basic": "기본",

--- a/src/gui/locales/ko.json
+++ b/src/gui/locales/ko.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "마인크래프트 디렉토리가 발견되지 않았습니다",
   "world_in_use": "선택한 세계가 현재 사용 중입니다",
   "failed_to_create_world": "새 세계 생성에 실패했습니다",
+  "failed_to_rename_world": "세계 이름 변경에 실패했습니다",
   "no_world_selected_error": "선택된 세계 없음 오류",
   "create_world_first": "먼저 월드를 만드세요!",
   "select_location_first": "먼저 위치를 선택하세요!",

--- a/src/gui/locales/lt.json
+++ b/src/gui/locales/lt.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Nerastas „Minecraft“ aplankas",
   "world_in_use": "Pasirinktas pasaulis dabar užimtas",
   "failed_to_create_world": "Klaida sukuriant naują pasaulį",
+  "failed_to_rename_world": "Klaida pervadinant pasaulį",
   "no_world_selected_error": "Nėra pasirinktas pasaulis",
   "create_world_first": "Pirmiausia sukurkite pasaulį!",
   "select_location_first": "Pirma pasirinkite vietą!",

--- a/src/gui/locales/lt.json
+++ b/src/gui/locales/lt.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Stebėtojas",
   "world_time": "Pasaulio laikas",
   "map_item": "Pasaulio žemėlapio daiktas",
+  "custom_world_name": "Pasirinktinis pasaulio pavadinimas",
   "signage": "Ženklai",
   "signage_none": "Nėra",
   "signage_basic": "Pagrindiniai",

--- a/src/gui/locales/lv.json
+++ b/src/gui/locales/lv.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Skatītājs",
   "world_time": "Pasaules laiks",
   "map_item": "Pasaules kartes priekšmets",
+  "custom_world_name": "Pielāgots pasaules nosaukums",
   "signage": "Zīmes",
   "signage_none": "Nav",
   "signage_basic": "Pamata",

--- a/src/gui/locales/lv.json
+++ b/src/gui/locales/lv.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Minecraft direktorijs nav atrasts",
   "world_in_use": "Izvēlētā pasaule jau tiek izmantota",
   "failed_to_create_world": "Neizdevās izveidot jaunu pasauli",
+  "failed_to_rename_world": "Neizdevās pārdēvēt pasauli",
   "no_world_selected_error": "Pasaulē nav izvēlēta",
   "create_world_first": "Vispirms izveidojiet pasauli!",
   "select_location_first": "Vispirms izvēlieties atrašanās vietu!",

--- a/src/gui/locales/pl.json
+++ b/src/gui/locales/pl.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Obserwator",
   "world_time": "Czas świata",
   "map_item": "Przedmiot mapy świata",
+  "custom_world_name": "Własna nazwa świata",
   "signage": "Oznakowanie",
   "signage_none": "Brak",
   "signage_basic": "Podstawowe",

--- a/src/gui/locales/pl.json
+++ b/src/gui/locales/pl.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Nie znaleziono katalogu Minecrafta",
   "world_in_use": "Wybrany świat jest obecnie używany",
   "failed_to_create_world": "Nie udało się utworzyć świata",
+  "failed_to_rename_world": "Nie udało się zmienić nazwy świata",
   "no_world_selected_error": "Nie wybrano świata",
   "create_world_first": "Najpierw utwórz świat!",
   "select_location_first": "Najpierw wybierz lokalizację!",

--- a/src/gui/locales/pt-BR.json
+++ b/src/gui/locales/pt-BR.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Diretório do Minecraft não encontrado",
   "world_in_use": "O mundo selecionado está em uso no momento",
   "failed_to_create_world": "Falha ao criar novo mundo",
+  "failed_to_rename_world": "Falha ao renomear o mundo",
   "no_world_selected_error": "Nenhum mundo selecionado",
   "create_world_first": "Crie um mundo primeiro!",
   "select_location_first": "Selecione um local primeiro!",

--- a/src/gui/locales/pt-BR.json
+++ b/src/gui/locales/pt-BR.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Espectador",
   "world_time": "Hora do mundo",
   "map_item": "Item do mapa do mundo",
+  "custom_world_name": "Nome de mundo personalizado",
   "signage": "Sinalização",
   "signage_none": "Nenhuma",
   "signage_basic": "Básica",

--- a/src/gui/locales/ru.json
+++ b/src/gui/locales/ru.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Наблюдатель",
   "world_time": "Время мира",
   "map_item": "Предмет карты мира",
+  "custom_world_name": "Собственное имя мира",
   "signage": "Указатели",
   "signage_none": "Нет",
   "signage_basic": "Базовые",

--- a/src/gui/locales/ru.json
+++ b/src/gui/locales/ru.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Каталог Minecraft не найден",
   "world_in_use": "Выбранный мир уже используется",
   "failed_to_create_world": "Не удалось создать новый мир",
+  "failed_to_rename_world": "Не удалось переименовать мир",
   "no_world_selected_error": "Мир не выбран",
   "create_world_first": "Сначала создайте мир!",
   "select_location_first": "Сначала выберите местоположение!",

--- a/src/gui/locales/sl.json
+++ b/src/gui/locales/sl.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Mapa Minecrafta ni bila najdena",
   "world_in_use": "Izbrani svet je trenutno v uporabi",
   "failed_to_create_world": "Ustvarjanje novega sveta je spodletelo",
+  "failed_to_rename_world": "Preimenovanje sveta je spodletelo",
   "no_world_selected_error": "Ni izbranega sveta",
   "create_world_first": "Najprej ustvarite svet!",
   "select_location_first": "Najprej izberite lokacijo!",

--- a/src/gui/locales/sl.json
+++ b/src/gui/locales/sl.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Gledalec",
   "world_time": "Čas sveta",
   "map_item": "Predmet zemljevida sveta",
+  "custom_world_name": "Lastno ime sveta",
   "signage": "Oznake",
   "signage_none": "Brez",
   "signage_basic": "Osnovne",

--- a/src/gui/locales/sv.json
+++ b/src/gui/locales/sv.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Åskådare",
   "world_time": "Världstid",
   "map_item": "Världskartsföremål",
+  "custom_world_name": "Anpassat världsnamn",
   "signage": "Skyltar",
   "signage_none": "Inga",
   "signage_basic": "Grundläggande",

--- a/src/gui/locales/sv.json
+++ b/src/gui/locales/sv.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Minecraft-katalogen hittades inte",
   "world_in_use": "Den valda världen används just nu",
   "failed_to_create_world": "Misslyckades att skapa ny värld",
+  "failed_to_rename_world": "Misslyckades att byta namn på världen",
   "no_world_selected_error": "Ingen värld vald fel",
   "create_world_first": "Skapa en värld först!",
   "select_location_first": "Välj plats först!",

--- a/src/gui/locales/ua.json
+++ b/src/gui/locales/ua.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "Каталог Minecraft не знайдено",
   "world_in_use": "Вибраний світ зараз використовується",
   "failed_to_create_world": "Не вдалося створити новий світ",
+  "failed_to_rename_world": "Не вдалося перейменувати світ",
   "no_world_selected_error": "Світ не обрано",
   "create_world_first": "Спочатку створіть світ!",
   "select_location_first": "Спочатку виберіть місцезнаходження!",

--- a/src/gui/locales/ua.json
+++ b/src/gui/locales/ua.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "Спостерігач",
   "world_time": "Час світу",
   "map_item": "Предмет карти світу",
+  "custom_world_name": "Власна назва світу",
   "signage": "Вказівники",
   "signage_none": "Немає",
   "signage_basic": "Базові",

--- a/src/gui/locales/zh-CN.json
+++ b/src/gui/locales/zh-CN.json
@@ -85,6 +85,7 @@
   "gamemode_spectator": "旁观",
   "world_time": "世界时间",
   "map_item": "世界地图物品",
+  "custom_world_name": "自定义世界名称",
   "signage": "标牌",
   "signage_none": "无",
   "signage_basic": "基础",

--- a/src/gui/locales/zh-CN.json
+++ b/src/gui/locales/zh-CN.json
@@ -19,6 +19,7 @@
   "minecraft_directory_not_found": "未找到 Minecraft 目录",
   "world_in_use": "所选世界正在使用中",
   "failed_to_create_world": "无法创建新世界",
+  "failed_to_rename_world": "重命名世界失败",
   "no_world_selected_error": "未选择世界",
   "create_world_first": "请先创建一个世界！",
   "select_location_first": "请先选择一个位置！",

--- a/src/world_utils.rs
+++ b/src/world_utils.rs
@@ -280,10 +280,21 @@ fn generate_unique_custom_world_name(base_path: &Path, raw_name: &str) -> String
     generate_unique_custom_world_name_excluding(base_path, raw_name, None)
 }
 
-/// Same as [`generate_unique_custom_world_name`], but a candidate path equal
-/// to `exclude` is treated as available. Used when renaming a world in place
-/// so keeping (or case-tweaking) its current name doesn't get bumped to
-/// " (2)" just because its own directory already "collides" with itself.
+/// True when both paths exist and resolve to the same directory entry.
+/// Canonicalizing normalises the case on case-insensitive filesystems, which
+/// a textual `Path` comparison would not. Returns false if either side can't
+/// be resolved, so an unreadable path is never mistaken for a match.
+fn is_same_existing_path(a: &Path, b: &Path) -> bool {
+    match (fs::canonicalize(a), fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
+}
+
+/// Same as [`generate_unique_custom_world_name`], but a candidate path that
+/// resolves to `exclude` is treated as available. Used when renaming a world
+/// in place so keeping (or case-tweaking) its current name doesn't get bumped
+/// to " (2)" just because its own directory already "collides" with itself.
 fn generate_unique_custom_world_name_excluding(
     base_path: &Path,
     raw_name: &str,
@@ -299,7 +310,17 @@ fn generate_unique_custom_world_name_excluding(
     }
 
     let is_available = |candidate: &Path| -> bool {
-        !candidate.exists() || Some(candidate) == exclude
+        if !candidate.exists() {
+            return true;
+        }
+        // The candidate is taken - unless it *is* the excluded world's own
+        // directory. Compared canonically rather than by path equality: on
+        // Windows and macOS the filesystem matches case-insensitively, so
+        // re-capitalising a world ("My World" -> "my world") finds an
+        // existing directory whose path text differs from `exclude`, and a
+        // plain `==` would read the world's own directory as a collision and
+        // bump it to " (2)".
+        exclude.is_some_and(|excluded| is_same_existing_path(candidate, excluded))
     };
 
     let candidate_path = base_path.join(&sanitized);
@@ -321,8 +342,7 @@ fn generate_unique_custom_world_name_excluding(
 /// Overwrites the `LevelName` field in an existing world's `level.dat`.
 fn update_level_name(world_path: &Path, new_name: &str) -> Result<(), String> {
     let level_path = world_path.join("level.dat");
-    let level_data =
-        fs::read(&level_path).map_err(|e| format!("Failed to read level.dat: {e}"))?;
+    let level_data = fs::read(&level_path).map_err(|e| format!("Failed to read level.dat: {e}"))?;
 
     let mut decoder = GzDecoder::new(level_data.as_slice());
     let mut decompressed_data = Vec::new();
@@ -354,8 +374,7 @@ fn update_level_name(world_path: &Path, new_name: &str) -> Result<(), String> {
         .finish()
         .map_err(|e| format!("Failed to finalize level.dat compression: {e}"))?;
 
-    fs::write(&level_path, compressed_data)
-        .map_err(|e| format!("Failed to write level.dat: {e}"))
+    fs::write(&level_path, compressed_data).map_err(|e| format!("Failed to write level.dat: {e}"))
 }
 
 /// Renames an already-created Java world in place: moves its directory to a
@@ -365,7 +384,10 @@ fn update_level_name(world_path: &Path, new_name: &str) -> Result<(), String> {
 ///
 /// Fails (without touching anything) if `world_path` isn't an existing
 /// directory or doesn't look like a world (no `level.dat`), so callers can't
-/// accidentally rename an arbitrary/unrelated folder.
+/// accidentally rename an arbitrary/unrelated folder. A failure to rewrite
+/// `level.dat` also moves the directory back, so an `Err` means the world is
+/// still where and what the caller last saw it - unless the rollback itself
+/// fails, which the error message then spells out.
 pub fn rename_world(world_path: &Path, new_name: &str) -> Result<String, String> {
     if !world_path.is_dir() {
         return Err("World directory does not exist".to_string());
@@ -389,12 +411,27 @@ pub fn rename_world(world_path: &Path, new_name: &str) -> Result<String, String>
         generate_unique_custom_world_name_excluding(base_path, trimmed, Some(world_path));
     let new_world_path = base_path.join(&unique_name);
 
-    if new_world_path != world_path {
+    let moved = new_world_path != world_path;
+    if moved {
         fs::rename(world_path, &new_world_path)
             .map_err(|e| format!("Failed to rename world directory: {e}"))?;
     }
 
-    update_level_name(&new_world_path, &unique_name)?;
+    if let Err(update_error) = update_level_name(&new_world_path, &unique_name) {
+        // Put the directory back. Without this, a reported failure would still
+        // have moved the world, leaving the caller holding a `world_path` that
+        // no longer exists while it believes nothing changed.
+        if moved {
+            if let Err(rollback_error) = fs::rename(&new_world_path, world_path) {
+                return Err(format!(
+                    "{update_error}. The world was also left renamed to \
+                     \"{unique_name}\" because it could not be moved back: \
+                     {rollback_error}"
+                ));
+            }
+        }
+        return Err(update_error);
+    }
 
     Ok(new_world_path.display().to_string())
 }
@@ -788,8 +825,9 @@ mod tests {
         // Regression guard: must not be confused with sanitize_for_filename's
         // internal fallback label for a genuinely empty/invalid name.
         let tmp = tempfile::tempdir().unwrap();
-        let world =
-            PathBuf::from(create_new_world_with_name(tmp.path(), Some("Unknown Location")).unwrap());
+        let world = PathBuf::from(
+            create_new_world_with_name(tmp.path(), Some("Unknown Location")).unwrap(),
+        );
         assert_eq!(world.file_name().unwrap(), "Unknown Location");
     }
 
@@ -813,7 +851,8 @@ mod tests {
     #[test]
     fn rename_world_moves_directory_and_updates_level_name() {
         let tmp = tempfile::tempdir().unwrap();
-        let world = PathBuf::from(create_new_world_with_name(tmp.path(), Some("Old Name")).unwrap());
+        let world =
+            PathBuf::from(create_new_world_with_name(tmp.path(), Some("Old Name")).unwrap());
         let renamed = PathBuf::from(rename_world(&world, "New Name").unwrap());
 
         assert_eq!(renamed.file_name().unwrap(), "New Name");
@@ -837,11 +876,38 @@ mod tests {
     #[test]
     fn rename_world_to_its_own_name_is_a_no_op() {
         let tmp = tempfile::tempdir().unwrap();
-        let world = PathBuf::from(create_new_world_with_name(tmp.path(), Some("Same Name")).unwrap());
+        let world =
+            PathBuf::from(create_new_world_with_name(tmp.path(), Some("Same Name")).unwrap());
         let renamed = PathBuf::from(rename_world(&world, "Same Name").unwrap());
         assert_eq!(renamed, world);
         assert!(renamed.exists());
         assert_eq!(level_name(&renamed), "Same Name");
+    }
+
+    #[test]
+    fn rename_world_allows_case_only_change() {
+        // On Windows/macOS the new directory "exists" (the filesystem matches
+        // case-insensitively) *and* is the world's own directory, so a plain
+        // path comparison against `exclude` misses it and the world gets
+        // bumped to "... (2)" for merely re-capitalising its own name.
+        let tmp = tempfile::tempdir().unwrap();
+        let world =
+            PathBuf::from(create_new_world_with_name(tmp.path(), Some("My World")).unwrap());
+        let renamed = PathBuf::from(rename_world(&world, "my world").unwrap());
+
+        assert_eq!(renamed.file_name().unwrap(), "my world");
+        assert_eq!(level_name(&renamed), "my world");
+        // Exactly one world directory, not an extra "my world (2)".
+        let dirs: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert_eq!(
+            dirs.len(),
+            1,
+            "case-only rename must not create a second world"
+        );
     }
 
     #[test]
@@ -860,6 +926,21 @@ mod tests {
         assert!(rename_world(&world, "...  ").is_err());
         assert!(world.exists());
         assert_eq!(level_name(&world), "Keep Me");
+    }
+
+    #[test]
+    fn rename_world_rolls_back_the_move_when_level_dat_cannot_be_updated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world =
+            PathBuf::from(create_new_world_with_name(tmp.path(), Some("Old Name")).unwrap());
+        // Unreadable as NBT, but still a file, so the up-front validation
+        // passes and the failure lands after the directory has been moved.
+        fs::write(world.join("level.dat"), b"not gzipped nbt").unwrap();
+
+        assert!(rename_world(&world, "New Name").is_err());
+        // An Err must mean nothing moved.
+        assert!(world.exists(), "world should have been moved back");
+        assert!(!tmp.path().join("New Name").exists());
     }
 
     #[test]

--- a/src/world_utils.rs
+++ b/src/world_utils.rs
@@ -53,6 +53,37 @@ pub fn get_area_name_for_bedrock(bbox: &LLBBox) -> String {
 /// that need to distinguish "nothing usable survived" from a real sanitized
 /// value (e.g. a custom world name) can do so unambiguously.
 fn sanitize_chars_and_trim(name: &str) -> String {
+    sanitize_chars_and_trim_capped(name, MAX_FILENAME_BYTES)
+}
+
+/// Byte budget for a name derived from an area/place lookup. Kept well under
+/// the 255-byte limit filesystems put on a single path component, because
+/// these names get wrapped in longer strings (`Arnis {name}.mcworld`).
+const MAX_FILENAME_BYTES: usize = 64;
+
+/// Longest custom world name a user may set, counted in characters (not
+/// bytes) so the limit means the same thing in every script. Mirrored by the
+/// world-name editor's `maxlength` and character counter in the GUI, so what
+/// the user is allowed to type is exactly what lands on disk.
+pub const MAX_CUSTOM_WORLD_NAME_CHARS: usize = 48;
+
+/// Byte budget for a custom world name. Sized so the character cap above is
+/// always the binding limit - even at UTF-8's 4 bytes per character, plus
+/// room for a `" (99)"` de-duplication suffix - while still leaving the
+/// directory name inside the filesystem's 255-byte component limit.
+const MAX_CUSTOM_WORLD_NAME_BYTES: usize = MAX_CUSTOM_WORLD_NAME_CHARS * 4 + 5;
+
+/// Sanitizes a user-supplied world name, capping it by characters so a
+/// non-Latin name isn't silently cut to a fraction of what was typed the way
+/// a byte cap would (48 Japanese characters are 144 bytes).
+fn sanitize_custom_world_name(name: &str) -> String {
+    let capped: String = name.chars().take(MAX_CUSTOM_WORLD_NAME_CHARS).collect();
+    sanitize_chars_and_trim_capped(&capped, MAX_CUSTOM_WORLD_NAME_BYTES)
+}
+
+/// Shared body of [`sanitize_chars_and_trim`], with the byte budget supplied
+/// by the caller.
+fn sanitize_chars_and_trim_capped(name: &str, max_bytes: usize) -> String {
     // Windows forbids directory/file names ending in '.' or ' ' (trailing
     // dots/spaces are silently stripped by the OS, which would make our
     // sanitized name mismatch the actual created directory). Strip any
@@ -77,12 +108,11 @@ fn sanitize_chars_and_trim(name: &str) -> String {
     sanitized = strip_trailing_unsafe(sanitized.trim());
 
     // Limit length to avoid excessively long filenames
-    const MAX_LEN: usize = 64;
-    if sanitized.len() > MAX_LEN {
-        // Find a valid UTF-8 char boundary at or before MAX_LEN bytes
+    if sanitized.len() > max_bytes {
+        // Find a valid UTF-8 char boundary at or before max_bytes
         let cutoff = sanitized
             .char_indices()
-            .take_while(|(idx, _)| *idx < MAX_LEN)
+            .take_while(|(idx, _)| *idx < max_bytes)
             .last()
             .map(|(idx, ch)| idx + ch.len_utf8())
             .unwrap_or(0);
@@ -300,7 +330,7 @@ fn generate_unique_custom_world_name_excluding(
     raw_name: &str,
     exclude: Option<&Path>,
 ) -> String {
-    let sanitized = sanitize_chars_and_trim(raw_name);
+    let sanitized = sanitize_custom_world_name(raw_name);
 
     // Nothing usable survived sanitization (e.g. the input was only invalid
     // characters), so fall back to the default naming scheme instead of
@@ -403,7 +433,9 @@ pub fn rename_world(world_path: &Path, new_name: &str) -> Result<String, String>
     if trimmed.is_empty() {
         return Err("World name cannot be blank".to_string());
     }
-    if sanitize_chars_and_trim(trimmed).is_empty() {
+    // Same sanitizer the new name is actually built with, so this check can't
+    // pass a name that later resolves to nothing.
+    if sanitize_custom_world_name(trimmed).is_empty() {
         return Err("World name is invalid after sanitization".to_string());
     }
 
@@ -846,6 +878,60 @@ mod tests {
         assert_eq!(sanitize_for_filename("My World..."), "My World");
         assert_eq!(sanitize_for_filename("My World. "), "My World");
         assert_eq!(sanitize_for_filename("Trailing.dot."), "Trailing.dot");
+    }
+
+    #[test]
+    fn a_full_length_custom_name_survives_in_any_script() {
+        // The editor caps input at MAX_CUSTOM_WORLD_NAME_CHARS characters, so
+        // a name of exactly that many characters must come back untouched -
+        // in every script, not just Latin-1. A byte-based cap would quietly
+        // cut a Japanese or Cyrillic name to a third of what was typed.
+        let tmp = tempfile::tempdir().unwrap();
+        for name in [
+            "a".repeat(MAX_CUSTOM_WORLD_NAME_CHARS),
+            "あ".repeat(MAX_CUSTOM_WORLD_NAME_CHARS),
+            "Мир"
+                .chars()
+                .cycle()
+                .take(MAX_CUSTOM_WORLD_NAME_CHARS)
+                .collect(),
+        ] {
+            let world = PathBuf::from(create_new_world_with_name(tmp.path(), Some(&name)).unwrap());
+            assert_eq!(
+                world.file_name().unwrap().to_str().unwrap().chars().count(),
+                MAX_CUSTOM_WORLD_NAME_CHARS,
+                "{name} was truncated"
+            );
+            assert_eq!(world.file_name().unwrap(), name.as_str());
+        }
+    }
+
+    #[test]
+    fn area_names_keep_the_tighter_byte_budget() {
+        // Area names are wrapped in longer strings ("Arnis {name}.mcworld"),
+        // so they stay on the 64-byte budget, while a custom world name the
+        // user typed is capped by characters. Same input, deliberately
+        // different results - roughly 22 characters is all a 64-byte budget
+        // buys in a 3-bytes-per-character script (the cut keeps the character
+        // that starts inside the budget, so it can spill a couple of bytes
+        // past it), and that is what custom names used to be cut down to.
+        let long = "あ".repeat(MAX_CUSTOM_WORLD_NAME_CHARS);
+        assert_eq!(sanitize_for_filename(&long).chars().count(), 22);
+        assert_eq!(
+            sanitize_custom_world_name(&long).chars().count(),
+            MAX_CUSTOM_WORLD_NAME_CHARS
+        );
+    }
+
+    #[test]
+    fn an_over_length_custom_name_is_capped_by_characters() {
+        let tmp = tempfile::tempdir().unwrap();
+        let long = "あ".repeat(MAX_CUSTOM_WORLD_NAME_CHARS + 20);
+        let world = PathBuf::from(create_new_world_with_name(tmp.path(), Some(&long)).unwrap());
+        assert_eq!(
+            world.file_name().unwrap(),
+            "あ".repeat(MAX_CUSTOM_WORLD_NAME_CHARS).as_str()
+        );
     }
 
     #[test]

--- a/src/world_utils.rs
+++ b/src/world_utils.rs
@@ -53,6 +53,16 @@ pub fn get_area_name_for_bedrock(bbox: &LLBBox) -> String {
 /// that need to distinguish "nothing usable survived" from a real sanitized
 /// value (e.g. a custom world name) can do so unambiguously.
 fn sanitize_chars_and_trim(name: &str) -> String {
+    // Windows forbids directory/file names ending in '.' or ' ' (trailing
+    // dots/spaces are silently stripped by the OS, which would make our
+    // sanitized name mismatch the actual created directory). Strip any
+    // trailing run of either so what we return is what actually lands on
+    // disk on every platform.
+    let strip_trailing_unsafe = |s: &str| -> String {
+        s.trim_end_matches(|c: char| c == '.' || c.is_whitespace())
+            .to_string()
+    };
+
     let invalid_chars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
     let mut sanitized: String = name
         .chars()
@@ -64,7 +74,7 @@ fn sanitize_chars_and_trim(name: &str) -> String {
             }
         })
         .collect();
-    sanitized = sanitized.trim().to_string();
+    sanitized = strip_trailing_unsafe(sanitized.trim());
 
     // Limit length to avoid excessively long filenames
     const MAX_LEN: usize = 64;
@@ -77,7 +87,8 @@ fn sanitize_chars_and_trim(name: &str) -> String {
             .map(|(idx, ch)| idx + ch.len_utf8())
             .unwrap_or(0);
         sanitized.truncate(cutoff);
-        sanitized = sanitized.trim_end().to_string();
+        // Truncation can newly expose a trailing dot/space/whitespace run.
+        sanitized = strip_trailing_unsafe(&sanitized);
     }
 
     sanitized
@@ -266,6 +277,18 @@ fn generate_unique_default_world_name(base_path: &Path) -> String {
 /// "Arnis World N" scheme if nothing usable survives sanitization (e.g. the
 /// input was only invalid characters).
 fn generate_unique_custom_world_name(base_path: &Path, raw_name: &str) -> String {
+    generate_unique_custom_world_name_excluding(base_path, raw_name, None)
+}
+
+/// Same as [`generate_unique_custom_world_name`], but a candidate path equal
+/// to `exclude` is treated as available. Used when renaming a world in place
+/// so keeping (or case-tweaking) its current name doesn't get bumped to
+/// " (2)" just because its own directory already "collides" with itself.
+fn generate_unique_custom_world_name_excluding(
+    base_path: &Path,
+    raw_name: &str,
+    exclude: Option<&Path>,
+) -> String {
     let sanitized = sanitize_chars_and_trim(raw_name);
 
     // Nothing usable survived sanitization (e.g. the input was only invalid
@@ -275,18 +298,105 @@ fn generate_unique_custom_world_name(base_path: &Path, raw_name: &str) -> String
         return generate_unique_default_world_name(base_path);
     }
 
-    if !base_path.join(&sanitized).exists() {
+    let is_available = |candidate: &Path| -> bool {
+        !candidate.exists() || Some(candidate) == exclude
+    };
+
+    let candidate_path = base_path.join(&sanitized);
+    if is_available(&candidate_path) {
         return sanitized;
     }
 
     let mut counter: i32 = 2;
     loop {
         let candidate = format!("{sanitized} ({counter})");
-        if !base_path.join(&candidate).exists() {
+        let candidate_path = base_path.join(&candidate);
+        if is_available(&candidate_path) {
             return candidate;
         }
         counter += 1;
     }
+}
+
+/// Overwrites the `LevelName` field in an existing world's `level.dat`.
+fn update_level_name(world_path: &Path, new_name: &str) -> Result<(), String> {
+    let level_path = world_path.join("level.dat");
+    let level_data =
+        fs::read(&level_path).map_err(|e| format!("Failed to read level.dat: {e}"))?;
+
+    let mut decoder = GzDecoder::new(level_data.as_slice());
+    let mut decompressed_data = Vec::new();
+    decoder
+        .read_to_end(&mut decompressed_data)
+        .map_err(|e| format!("Failed to decompress level.dat: {e}"))?;
+
+    let mut nbt_data: Value = fastnbt::from_bytes(&decompressed_data)
+        .map_err(|e| format!("Failed to parse level.dat: {e}"))?;
+
+    match nbt_data {
+        Value::Compound(ref mut root) => match root.get_mut("Data") {
+            Some(Value::Compound(ref mut data)) => {
+                data.insert("LevelName".to_string(), Value::String(new_name.to_string()));
+            }
+            _ => return Err("level.dat is missing its Data compound".to_string()),
+        },
+        _ => return Err("level.dat root is not a compound".to_string()),
+    }
+
+    let serialized_data =
+        fastnbt::to_bytes(&nbt_data).map_err(|e| format!("Failed to serialize level.dat: {e}"))?;
+
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder
+        .write_all(&serialized_data)
+        .map_err(|e| format!("Failed to compress level.dat: {e}"))?;
+    let compressed_data = encoder
+        .finish()
+        .map_err(|e| format!("Failed to finalize level.dat compression: {e}"))?;
+
+    fs::write(&level_path, compressed_data)
+        .map_err(|e| format!("Failed to write level.dat: {e}"))
+}
+
+/// Renames an already-created Java world in place: moves its directory to a
+/// sanitized, de-duplicated version of `new_name` (excluding the world's own
+/// current directory from collision checks) and updates `LevelName` in its
+/// `level.dat` to match. Returns the world's new full path.
+///
+/// Fails (without touching anything) if `world_path` isn't an existing
+/// directory or doesn't look like a world (no `level.dat`), so callers can't
+/// accidentally rename an arbitrary/unrelated folder.
+pub fn rename_world(world_path: &Path, new_name: &str) -> Result<String, String> {
+    if !world_path.is_dir() {
+        return Err("World directory does not exist".to_string());
+    }
+    if !world_path.join("level.dat").is_file() {
+        return Err("Not a valid world directory (missing level.dat)".to_string());
+    }
+    let base_path = world_path
+        .parent()
+        .ok_or_else(|| "World path has no parent directory".to_string())?;
+
+    let trimmed = new_name.trim();
+    if trimmed.is_empty() {
+        return Err("World name cannot be blank".to_string());
+    }
+    if sanitize_chars_and_trim(trimmed).is_empty() {
+        return Err("World name is invalid after sanitization".to_string());
+    }
+
+    let unique_name =
+        generate_unique_custom_world_name_excluding(base_path, trimmed, Some(world_path));
+    let new_world_path = base_path.join(&unique_name);
+
+    if new_world_path != world_path {
+        fs::rename(world_path, &new_world_path)
+            .map_err(|e| format!("Failed to rename world directory: {e}"))?;
+    }
+
+    update_level_name(&new_world_path, &unique_name)?;
+
+    Ok(new_world_path.display().to_string())
 }
 
 /// Name of the bundled Java datapack that extends the Overworld build height.
@@ -688,6 +798,75 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let world = PathBuf::from(create_new_world_with_name(tmp.path(), None).unwrap());
         assert_eq!(world.file_name().unwrap(), "Arnis World 1");
+    }
+
+    #[test]
+    fn sanitize_for_filename_strips_trailing_dots() {
+        // Windows silently drops trailing dots/spaces from directory names,
+        // so a sanitized name must not end in one or the created directory
+        // would end up named differently than what we return.
+        assert_eq!(sanitize_for_filename("My World..."), "My World");
+        assert_eq!(sanitize_for_filename("My World. "), "My World");
+        assert_eq!(sanitize_for_filename("Trailing.dot."), "Trailing.dot");
+    }
+
+    #[test]
+    fn rename_world_moves_directory_and_updates_level_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world = PathBuf::from(create_new_world_with_name(tmp.path(), Some("Old Name")).unwrap());
+        let renamed = PathBuf::from(rename_world(&world, "New Name").unwrap());
+
+        assert_eq!(renamed.file_name().unwrap(), "New Name");
+        assert!(!world.exists());
+        assert!(renamed.exists());
+        assert_eq!(level_name(&renamed), "New Name");
+    }
+
+    #[test]
+    fn rename_world_dedupes_against_other_worlds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world_a = PathBuf::from(create_new_world_with_name(tmp.path(), Some("Alpha")).unwrap());
+        let _world_b = create_new_world_with_name(tmp.path(), Some("Beta")).unwrap();
+
+        // Renaming "Alpha" to the already-taken "Beta" must not clobber it.
+        let renamed = PathBuf::from(rename_world(&world_a, "Beta").unwrap());
+        assert_eq!(renamed.file_name().unwrap(), "Beta (2)");
+        assert_eq!(level_name(&renamed), "Beta (2)");
+    }
+
+    #[test]
+    fn rename_world_to_its_own_name_is_a_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world = PathBuf::from(create_new_world_with_name(tmp.path(), Some("Same Name")).unwrap());
+        let renamed = PathBuf::from(rename_world(&world, "Same Name").unwrap());
+        assert_eq!(renamed, world);
+        assert!(renamed.exists());
+        assert_eq!(level_name(&renamed), "Same Name");
+    }
+
+    #[test]
+    fn rename_world_rejects_blank_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world = PathBuf::from(create_new_world_with_name(tmp.path(), Some("Keep Me")).unwrap());
+        assert!(rename_world(&world, "   ").is_err());
+        // Nothing should have moved on failure.
+        assert!(world.exists());
+    }
+
+    #[test]
+    fn rename_world_rejects_name_that_becomes_empty_after_sanitization() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world = PathBuf::from(create_new_world_with_name(tmp.path(), Some("Keep Me")).unwrap());
+        assert!(rename_world(&world, "...  ").is_err());
+        assert!(world.exists());
+        assert_eq!(level_name(&world), "Keep Me");
+    }
+
+    #[test]
+    fn rename_world_rejects_nonexistent_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("Does Not Exist");
+        assert!(rename_world(&missing, "New Name").is_err());
     }
 
     #[test]

--- a/src/world_utils.rs
+++ b/src/world_utils.rs
@@ -46,10 +46,13 @@ pub fn get_area_name_for_bedrock(bbox: &LLBBox) -> String {
     }
 }
 
-/// Sanitizes an area name for safe use in filesystem paths.
-/// Replaces characters that are invalid on Windows/macOS/Linux, trims whitespace,
-/// and limits length to prevent excessively long filenames.
-pub fn sanitize_for_filename(name: &str) -> String {
+/// Replaces characters that are invalid on Windows/macOS/Linux with `_`, trims
+/// whitespace, and limits length to prevent excessively long filenames.
+/// Unlike [`sanitize_for_filename`], an all-invalid/empty input is returned
+/// as an empty string rather than masked behind a fallback label, so callers
+/// that need to distinguish "nothing usable survived" from a real sanitized
+/// value (e.g. a custom world name) can do so unambiguously.
+fn sanitize_chars_and_trim(name: &str) -> String {
     let invalid_chars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
     let mut sanitized: String = name
         .chars()
@@ -77,6 +80,14 @@ pub fn sanitize_for_filename(name: &str) -> String {
         sanitized = sanitized.trim_end().to_string();
     }
 
+    sanitized
+}
+
+/// Sanitizes an area name for safe use in filesystem paths.
+/// Replaces characters that are invalid on Windows/macOS/Linux, trims whitespace,
+/// and limits length to prevent excessively long filenames.
+pub fn sanitize_for_filename(name: &str) -> String {
+    let sanitized = sanitize_chars_and_trim(name);
     if sanitized.is_empty() {
         "Unknown Location".to_string()
     } else {
@@ -102,31 +113,24 @@ pub fn build_bedrock_output(bbox: &LLBBox, output_dir: PathBuf) -> (PathBuf, Str
 ///
 /// Returns the full path to the newly created world directory.
 pub fn create_new_world(base_path: &Path) -> Result<String, String> {
-    // Generate a unique world name with proper counter
-    // Check for both "Arnis World X" and "Arnis World X: Location" patterns
-    let mut counter: i32 = 1;
-    let unique_name: String = loop {
-        let candidate_name: String = format!("Arnis World {counter}");
-        let candidate_path: PathBuf = base_path.join(&candidate_name);
+    create_new_world_with_name(base_path, None)
+}
 
-        // Check for exact match (no location suffix)
-        let exact_match_exists = candidate_path.exists();
-
-        // Check for worlds with location suffix (Arnis World X: Location)
-        let location_pattern = format!("Arnis World {counter}: ");
-        let location_match_exists = fs::read_dir(base_path)
-            .map(|entries| {
-                entries
-                    .filter_map(Result::ok)
-                    .filter_map(|entry| entry.file_name().into_string().ok())
-                    .any(|name| name.starts_with(&location_pattern))
-            })
-            .unwrap_or(false);
-
-        if !exact_match_exists && !location_match_exists {
-            break candidate_name;
-        }
-        counter += 1;
+/// Same as [`create_new_world`], but lets the caller request a specific world
+/// name instead of the auto-generated "Arnis World N" scheme. `custom_name` is
+/// sanitized for filesystem safety and de-duplicated against existing worlds
+/// in `base_path` (appending " (2)", " (3)", ... on collision). A `None`,
+/// empty/whitespace-only, or entirely-invalid custom name falls back to the
+/// default "Arnis World N" scheme.
+///
+/// Returns the full path to the newly created world directory.
+pub fn create_new_world_with_name(
+    base_path: &Path,
+    custom_name: Option<&str>,
+) -> Result<String, String> {
+    let unique_name: String = match custom_name.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(raw_name) => generate_unique_custom_world_name(base_path, raw_name),
+        None => generate_unique_default_world_name(base_path),
     };
 
     let new_world_path: PathBuf = base_path.join(&unique_name);
@@ -225,6 +229,64 @@ pub fn create_new_world(base_path: &Path) -> Result<String, String> {
         .map_err(|e| format!("Failed to create icon.png file: {e}"))?;
 
     Ok(new_world_path.display().to_string())
+}
+
+/// Generates a unique "Arnis World N" name.
+/// Checks for both "Arnis World X" and "Arnis World X: Location" patterns.
+fn generate_unique_default_world_name(base_path: &Path) -> String {
+    let mut counter: i32 = 1;
+    loop {
+        let candidate_name: String = format!("Arnis World {counter}");
+        let candidate_path: PathBuf = base_path.join(&candidate_name);
+
+        // Check for exact match (no location suffix)
+        let exact_match_exists = candidate_path.exists();
+
+        // Check for worlds with location suffix (Arnis World X: Location)
+        let location_pattern = format!("Arnis World {counter}: ");
+        let location_match_exists = fs::read_dir(base_path)
+            .map(|entries| {
+                entries
+                    .filter_map(Result::ok)
+                    .filter_map(|entry| entry.file_name().into_string().ok())
+                    .any(|name| name.starts_with(&location_pattern))
+            })
+            .unwrap_or(false);
+
+        if !exact_match_exists && !location_match_exists {
+            return candidate_name;
+        }
+        counter += 1;
+    }
+}
+
+/// Builds a unique world name from a user-supplied custom name: sanitizes it
+/// for filesystem safety, then de-duplicates against existing worlds in
+/// `base_path` by appending " (2)", " (3)", etc. Falls back to the default
+/// "Arnis World N" scheme if nothing usable survives sanitization (e.g. the
+/// input was only invalid characters).
+fn generate_unique_custom_world_name(base_path: &Path, raw_name: &str) -> String {
+    let sanitized = sanitize_chars_and_trim(raw_name);
+
+    // Nothing usable survived sanitization (e.g. the input was only invalid
+    // characters), so fall back to the default naming scheme instead of
+    // creating a world named after an empty string.
+    if sanitized.is_empty() {
+        return generate_unique_default_world_name(base_path);
+    }
+
+    if !base_path.join(&sanitized).exists() {
+        return sanitized;
+    }
+
+    let mut counter: i32 = 2;
+    loop {
+        let candidate = format!("{sanitized} ({counter})");
+        if !base_path.join(&candidate).exists() {
+            return candidate;
+        }
+        counter += 1;
+    }
 }
 
 /// Name of the bundled Java datapack that extends the Overworld build height.
@@ -553,6 +615,80 @@ pub fn set_spawn_in_level_dat(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn level_name(world: &Path) -> String {
+        let raw = fs::read(world.join("level.dat")).unwrap();
+        let mut decompressed = Vec::new();
+        GzDecoder::new(raw.as_slice())
+            .read_to_end(&mut decompressed)
+            .unwrap();
+        let root: Value = fastnbt::from_bytes(&decompressed).unwrap();
+        let Value::Compound(root) = root else {
+            panic!("root not a compound");
+        };
+        let Some(Value::Compound(data)) = root.get("Data") else {
+            panic!("missing Data");
+        };
+        let Some(Value::String(name)) = data.get("LevelName") else {
+            panic!("missing LevelName");
+        };
+        name.clone()
+    }
+
+    #[test]
+    fn create_new_world_with_name_uses_custom_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world =
+            PathBuf::from(create_new_world_with_name(tmp.path(), Some("My Cool World")).unwrap());
+        assert_eq!(world.file_name().unwrap(), "My Cool World");
+        assert_eq!(level_name(&world), "My Cool World");
+    }
+
+    #[test]
+    fn create_new_world_with_name_dedupes_on_collision() {
+        let tmp = tempfile::tempdir().unwrap();
+        let first =
+            PathBuf::from(create_new_world_with_name(tmp.path(), Some("Metropolis")).unwrap());
+        let second =
+            PathBuf::from(create_new_world_with_name(tmp.path(), Some("Metropolis")).unwrap());
+        let third =
+            PathBuf::from(create_new_world_with_name(tmp.path(), Some("Metropolis")).unwrap());
+        assert_eq!(first.file_name().unwrap(), "Metropolis");
+        assert_eq!(second.file_name().unwrap(), "Metropolis (2)");
+        assert_eq!(third.file_name().unwrap(), "Metropolis (3)");
+    }
+
+    #[test]
+    fn create_new_world_with_name_sanitizes_invalid_characters() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world =
+            PathBuf::from(create_new_world_with_name(tmp.path(), Some("My:World/Name?")).unwrap());
+        assert_eq!(world.file_name().unwrap(), "My_World_Name_");
+    }
+
+    #[test]
+    fn create_new_world_with_name_falls_back_when_blank() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world = PathBuf::from(create_new_world_with_name(tmp.path(), Some("   ")).unwrap());
+        assert_eq!(world.file_name().unwrap(), "Arnis World 1");
+    }
+
+    #[test]
+    fn create_new_world_with_name_accepts_literal_unknown_location() {
+        // Regression guard: must not be confused with sanitize_for_filename's
+        // internal fallback label for a genuinely empty/invalid name.
+        let tmp = tempfile::tempdir().unwrap();
+        let world =
+            PathBuf::from(create_new_world_with_name(tmp.path(), Some("Unknown Location")).unwrap());
+        assert_eq!(world.file_name().unwrap(), "Unknown Location");
+    }
+
+    #[test]
+    fn create_new_world_with_name_none_uses_default_scheme() {
+        let tmp = tempfile::tempdir().unwrap();
+        let world = PathBuf::from(create_new_world_with_name(tmp.path(), None).unwrap());
+        assert_eq!(world.file_name().unwrap(), "Arnis World 1");
+    }
 
     #[test]
     fn apply_java_world_settings_writes_gametype_and_daytime() {


### PR DESCRIPTION
## Summary
Adds an opt-in feature (Settings toggle, default **off**) letting users choose their own Minecraft world name for Java Edition generations, editable directly from the Start Generation button.

## What's included
- **Settings toggle** — "Custom World Name" row, default unchecked, persists via existing settings-store (revert/reset supported for free).
- **Pencil icon** — appears next to the world-name label on the Start button only when the toggle is on and format is Java. Styled to match the existing `.setting-revert` button (same golden color scheme).
- **Click-to-edit** — inline text input, commit on Enter/blur, cancel on Escape; click handling stops propagation so it never triggers generation.
- **Backend** (`world_utils.rs`, `gui.rs`) — `create_new_world_with_name` sanitizes and de-duplicates the custom name (`" (2)"`, `" (3)"`, …), falling back to the default `"Arnis World N"` scheme if the input is blank/unusable. All 14 existing call sites unchanged.
- **Localization** — `custom_world_name` key added to all 20 locale files.

## Testing
- `cargo check` — clean
- `cargo test` — 784 passed, 0 failed (11 new/updated tests in `world_utils`)
- All locale JSON files validated for syntax